### PR TITLE
Add Vulkan support with device and instance services

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1,11 +1,13 @@
 file(GLOB_RECURSE ENGINE_SOURCES CONFIGURE_DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/kettle/src/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/teapot/src/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/infuser/src/*.cpp
 )
 
 file(GLOB_RECURSE ENGINE_HEADERS CONFIGURE_DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/kettle/include/*.h
     ${CMAKE_CURRENT_SOURCE_DIR}/teapot/include/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/infuser/include/*.h
 )
 
 add_library(engine STATIC ${ENGINE_SOURCES} ${ENGINE_HEADERS})
@@ -13,4 +15,8 @@ add_library(engine STATIC ${ENGINE_SOURCES} ${ENGINE_HEADERS})
 target_include_directories(engine PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/kettle/include
     ${CMAKE_CURRENT_SOURCE_DIR}/teapot/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/infuser/include
 )
+
+find_package(Vulkan REQUIRED)
+target_link_libraries(engine PUBLIC Vulkan::Vulkan)

--- a/engine/infuser/include/vulkan/IVulkanSurfaceProvider.h
+++ b/engine/infuser/include/vulkan/IVulkanSurfaceProvider.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vector>
+#include <string>
+
+//=============================================================================
+// IVulkanSurfaceProvider
+//
+// Narrow interface that decouples Vulkan from any specific windowing library.
+// A concrete implementation (SDL3, GLFW, Win32, headless, etc.) supplies:
+//   - The instance extensions it needs (e.g. VK_KHR_surface, VK_KHR_win32_surface)
+//   - A factory method to create a VkSurfaceKHR from a live VkInstance
+//
+// This is NOT a service. It is passed into VulkanDeviceService at construction
+// time as an optional dependency. If null, the device is created without
+// present capabilities.
+//=============================================================================
+class IVulkanSurfaceProvider
+{
+public:
+    virtual ~IVulkanSurfaceProvider() = default;
+
+    virtual std::vector<const char*> GetRequiredInstanceExtensions() const = 0;
+
+    virtual VkSurfaceKHR CreateSurface(VkInstance instance) const = 0;
+};

--- a/engine/infuser/include/vulkan/VulkanDeviceService.h
+++ b/engine/infuser/include/vulkan/VulkanDeviceService.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <service/IService.h>
+#include <logging/Logger.h>
+#include <vulkan/vulkan.h>
+#include <vulkan/VulkanQueueFamilies.h>
+#include <vector>
+#include <string>
+
+class VulkanInstanceService;
+class IVulkanSurfaceProvider;
+
+//=============================================================================
+// VulkanDeviceService
+//
+// Owns VkDevice and the selected VkPhysicalDevice. Optionally creates a
+// VkSurfaceKHR if an IVulkanSurfaceProvider is given.
+//
+// Construction:
+//   auto& dev = services.AddService<VulkanDeviceService>(
+//       logger, instanceService, surfaceProvider);
+//   if (!dev.IsValid()) { /* handle failure */ }
+//
+// Queue retrieval:
+//   VkQueue gfx = dev.GetGraphicsQueue();
+//=============================================================================
+class VulkanDeviceService : public IService
+{
+public:
+    struct CreateInfo
+    {
+        std::vector<const char*> RequiredDeviceExtensions;
+        bool                     PreferDiscreteGpu = true;
+    };
+
+    VulkanDeviceService(Logger& logger,
+                        VulkanInstanceService& instance,
+                        const CreateInfo& info,
+                        const IVulkanSurfaceProvider* surfaceProvider = nullptr);
+    ~VulkanDeviceService() override;
+
+    VulkanDeviceService(const VulkanDeviceService&) = delete;
+    VulkanDeviceService& operator=(const VulkanDeviceService&) = delete;
+    VulkanDeviceService(VulkanDeviceService&&) = delete;
+    VulkanDeviceService& operator=(VulkanDeviceService&&) = delete;
+
+    bool IsValid() const { return Device != VK_NULL_HANDLE; }
+
+    VkPhysicalDevice            GetPhysicalDevice() const { return PhysicalDevice; }
+    VkDevice                    GetDevice() const { return Device; }
+    const VulkanQueueFamilies&  GetQueueFamilies() const { return QueueFamilies; }
+    VkSurfaceKHR                GetSurface() const { return Surface; }
+
+    VkQueue GetGraphicsQueue() const { return GraphicsQueue; }
+    VkQueue GetPresentQueue() const { return PresentQueue; }
+    VkQueue GetComputeQueue() const { return ComputeQueue; }
+    VkQueue GetTransferQueue() const { return TransferQueue; }
+
+private:
+    Logger& Log;
+    VkInstance Instance = VK_NULL_HANDLE;
+
+    VkPhysicalDevice   PhysicalDevice = VK_NULL_HANDLE;
+    VkDevice           Device         = VK_NULL_HANDLE;
+    VkSurfaceKHR       Surface        = VK_NULL_HANDLE;
+    VulkanQueueFamilies QueueFamilies;
+
+    VkQueue GraphicsQueue = VK_NULL_HANDLE;
+    VkQueue PresentQueue  = VK_NULL_HANDLE;
+    VkQueue ComputeQueue  = VK_NULL_HANDLE;
+    VkQueue TransferQueue = VK_NULL_HANDLE;
+
+    bool PickPhysicalDevice(const CreateInfo& info);
+    int  RateDevice(VkPhysicalDevice device, const CreateInfo& info) const;
+    bool CheckDeviceExtensionSupport(VkPhysicalDevice device, const CreateInfo& info) const;
+    VulkanQueueFamilies FindQueueFamilies(VkPhysicalDevice device) const;
+    bool CreateLogicalDevice(const CreateInfo& info);
+    void RetrieveQueues();
+    void LogDeviceProperties(VkPhysicalDevice device) const;
+};

--- a/engine/infuser/include/vulkan/VulkanInstanceService.h
+++ b/engine/infuser/include/vulkan/VulkanInstanceService.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <service/IService.h>
+#include <logging/Logger.h>
+#include <vulkan/vulkan.h>
+#include <vector>
+#include <string>
+
+class IVulkanSurfaceProvider;
+
+//=============================================================================
+// VulkanInstanceService
+//
+// Owns VkInstance and the optional debug messenger. Created early in the
+// engine lifetime and destroyed after all other Vulkan services.
+//
+// Construction:
+//   auto& inst = services.AddService<VulkanInstanceService>(logger, provider);
+//   if (!inst.IsValid()) { /* handle failure */ }
+//
+// The optional IVulkanSurfaceProvider* is used ONLY to query additional
+// required instance extensions. It does not create a surface — that
+// responsibility belongs to VulkanDeviceService.
+//=============================================================================
+class VulkanInstanceService : public IService
+{
+public:
+    struct CreateInfo
+    {
+        std::string AppName       = "Sencha";
+        uint32_t    AppVersion    = VK_MAKE_API_VERSION(0, 1, 0, 0);
+        uint32_t    ApiVersion    = VK_API_VERSION_1_3;
+        bool        EnableValidation = true;
+        std::vector<const char*> ExtraExtensions;
+    };
+
+    VulkanInstanceService(Logger& logger,
+                          const CreateInfo& info,
+                          const IVulkanSurfaceProvider* surfaceProvider = nullptr);
+    ~VulkanInstanceService() override;
+
+    VulkanInstanceService(const VulkanInstanceService&) = delete;
+    VulkanInstanceService& operator=(const VulkanInstanceService&) = delete;
+    VulkanInstanceService(VulkanInstanceService&&) = delete;
+    VulkanInstanceService& operator=(VulkanInstanceService&&) = delete;
+
+    bool        IsValid() const { return Instance != VK_NULL_HANDLE; }
+    VkInstance  GetInstance() const { return Instance; }
+    bool        IsValidationEnabled() const { return ValidationEnabled; }
+
+private:
+    Logger& Log;
+
+    VkInstance               Instance       = VK_NULL_HANDLE;
+    VkDebugUtilsMessengerEXT DebugMessenger = VK_NULL_HANDLE;
+    bool                     ValidationEnabled = false;
+
+    bool CheckValidationLayerSupport() const;
+    std::vector<const char*> BuildExtensionList(const CreateInfo& info,
+                                                const IVulkanSurfaceProvider* surfaceProvider) const;
+    void SetupDebugMessenger();
+    void DestroyDebugMessenger();
+
+    static VKAPI_ATTR VkBool32 VKAPI_CALL DebugCallback(
+        VkDebugUtilsMessageSeverityFlagBitsEXT severity,
+        VkDebugUtilsMessageTypeFlagsEXT type,
+        const VkDebugUtilsMessengerCallbackDataEXT* callbackData,
+        void* userData);
+
+    static VkDebugUtilsMessengerCreateInfoEXT MakeDebugCreateInfo(void* userData);
+};

--- a/engine/infuser/include/vulkan/VulkanQueueFamilies.h
+++ b/engine/infuser/include/vulkan/VulkanQueueFamilies.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+//=============================================================================
+// VulkanQueueFamilies
+//
+// Plain data: discovered queue family indices for a physical device.
+// Present is only populated when a surface is available.
+//=============================================================================
+struct VulkanQueueFamilies
+{
+    std::optional<uint32_t> Graphics;
+    std::optional<uint32_t> Present;
+    std::optional<uint32_t> Compute;
+    std::optional<uint32_t> Transfer;
+
+    bool HasGraphics() const { return Graphics.has_value(); }
+    bool HasPresent() const { return Present.has_value(); }
+    bool HasCompute() const { return Compute.has_value(); }
+    bool HasTransfer() const { return Transfer.has_value(); }
+
+    bool IsComplete(bool requirePresent) const
+    {
+        if (!HasGraphics()) return false;
+        if (requirePresent && !HasPresent()) return false;
+        return true;
+    }
+};

--- a/engine/infuser/src/vulkan/VulkanDeviceService.cpp
+++ b/engine/infuser/src/vulkan/VulkanDeviceService.cpp
@@ -1,0 +1,305 @@
+#include <vulkan/VulkanDeviceService.h>
+#include <vulkan/VulkanInstanceService.h>
+#include <vulkan/IVulkanSurfaceProvider.h>
+#include <algorithm>
+#include <cstring>
+#include <set>
+#include <format>
+
+VulkanDeviceService::VulkanDeviceService(Logger& logger,
+                                         VulkanInstanceService& instance,
+                                         const CreateInfo& info,
+                                         const IVulkanSurfaceProvider* surfaceProvider)
+    : Log(logger)
+    , Instance(instance.GetInstance())
+{
+    if (!instance.IsValid())
+    {
+        Log.Error("Cannot create device: VulkanInstanceService is not valid");
+        return;
+    }
+
+    if (surfaceProvider)
+    {
+        Surface = surfaceProvider->CreateSurface(Instance);
+        if (Surface == VK_NULL_HANDLE)
+        {
+            Log.Error("Surface provider returned a null surface");
+            return;
+        }
+        Log.Info("Surface created via provider");
+    }
+
+    if (!PickPhysicalDevice(info))
+    {
+        Log.Error("Failed to find a suitable physical device");
+        return;
+    }
+
+    if (!CreateLogicalDevice(info))
+    {
+        Log.Error("Failed to create logical device");
+        return;
+    }
+
+    RetrieveQueues();
+}
+
+VulkanDeviceService::~VulkanDeviceService()
+{
+    if (Device != VK_NULL_HANDLE)
+    {
+        vkDeviceWaitIdle(Device);
+        vkDestroyDevice(Device, nullptr);
+        Log.Info("Vulkan logical device destroyed");
+    }
+
+    if (Surface != VK_NULL_HANDLE)
+    {
+        vkDestroySurfaceKHR(Instance, Surface, nullptr);
+        Log.Info("Vulkan surface destroyed");
+    }
+}
+
+bool VulkanDeviceService::PickPhysicalDevice(const CreateInfo& info)
+{
+    uint32_t deviceCount = 0;
+    vkEnumeratePhysicalDevices(Instance, &deviceCount, nullptr);
+
+    if (deviceCount == 0)
+    {
+        Log.Error("No Vulkan-capable physical devices found");
+        return false;
+    }
+
+    std::vector<VkPhysicalDevice> devices(deviceCount);
+    vkEnumeratePhysicalDevices(Instance, &deviceCount, devices.data());
+
+    Log.Info("Found {} physical device(s):", deviceCount);
+    for (auto d : devices)
+        LogDeviceProperties(d);
+
+    int bestScore = -1;
+    VkPhysicalDevice bestDevice = VK_NULL_HANDLE;
+
+    for (auto d : devices)
+    {
+        int score = RateDevice(d, info);
+        if (score > bestScore)
+        {
+            bestScore = score;
+            bestDevice = d;
+        }
+    }
+
+    if (bestDevice == VK_NULL_HANDLE || bestScore < 0)
+        return false;
+
+    PhysicalDevice = bestDevice;
+    QueueFamilies = FindQueueFamilies(PhysicalDevice);
+
+    VkPhysicalDeviceProperties props;
+    vkGetPhysicalDeviceProperties(PhysicalDevice, &props);
+    Log.Info("Selected device: {} (score {})", props.deviceName, bestScore);
+
+    return true;
+}
+
+int VulkanDeviceService::RateDevice(VkPhysicalDevice device, const CreateInfo& info) const
+{
+    if (!CheckDeviceExtensionSupport(device, info))
+        return -1;
+
+    auto families = FindQueueFamilies(device);
+    bool requirePresent = Surface != VK_NULL_HANDLE;
+    if (!families.IsComplete(requirePresent))
+        return -1;
+
+    VkPhysicalDeviceProperties props;
+    vkGetPhysicalDeviceProperties(device, &props);
+
+    VkPhysicalDeviceFeatures features;
+    vkGetPhysicalDeviceFeatures(device, &features);
+
+    int score = 0;
+
+    if (props.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU && info.PreferDiscreteGpu)
+        score += 1000;
+    else if (props.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)
+        score += 100;
+
+    score += static_cast<int>(props.limits.maxImageDimension2D / 1024);
+
+    if (families.HasCompute() && families.Graphics != families.Compute)
+        score += 50;
+
+    if (families.HasTransfer()
+        && families.Graphics != families.Transfer
+        && (!families.HasCompute() || families.Compute != families.Transfer))
+        score += 50;
+
+    return score;
+}
+
+bool VulkanDeviceService::CheckDeviceExtensionSupport(VkPhysicalDevice device,
+                                                      const CreateInfo& info) const
+{
+    uint32_t extensionCount = 0;
+    vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, nullptr);
+
+    std::vector<VkExtensionProperties> available(extensionCount);
+    vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, available.data());
+
+    for (const auto* required : info.RequiredDeviceExtensions)
+    {
+        bool found = false;
+        for (const auto& ext : available)
+        {
+            if (std::strcmp(ext.extensionName, required) == 0)
+            {
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+            return false;
+    }
+
+    return true;
+}
+
+VulkanQueueFamilies VulkanDeviceService::FindQueueFamilies(VkPhysicalDevice device) const
+{
+    uint32_t familyCount = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(device, &familyCount, nullptr);
+
+    std::vector<VkQueueFamilyProperties> families(familyCount);
+    vkGetPhysicalDeviceQueueFamilyProperties(device, &familyCount, families.data());
+
+    VulkanQueueFamilies result;
+
+    for (uint32_t i = 0; i < familyCount; ++i)
+    {
+        const auto& family = families[i];
+
+        if ((family.queueFlags & VK_QUEUE_GRAPHICS_BIT) && !result.HasGraphics())
+            result.Graphics = i;
+
+        if ((family.queueFlags & VK_QUEUE_COMPUTE_BIT) && !result.HasCompute())
+        {
+            if (!(family.queueFlags & VK_QUEUE_GRAPHICS_BIT) || !result.HasCompute())
+                result.Compute = i;
+        }
+
+        if ((family.queueFlags & VK_QUEUE_TRANSFER_BIT)
+            && !(family.queueFlags & VK_QUEUE_GRAPHICS_BIT)
+            && !(family.queueFlags & VK_QUEUE_COMPUTE_BIT))
+        {
+            result.Transfer = i;
+        }
+
+        if (Surface != VK_NULL_HANDLE && !result.HasPresent())
+        {
+            VkBool32 presentSupport = VK_FALSE;
+            vkGetPhysicalDeviceSurfaceSupportKHR(device, i, Surface, &presentSupport);
+            if (presentSupport)
+                result.Present = i;
+        }
+    }
+
+    if (!result.HasCompute() && result.HasGraphics())
+        result.Compute = result.Graphics;
+
+    if (!result.HasTransfer() && result.HasGraphics())
+        result.Transfer = result.Graphics;
+
+    return result;
+}
+
+bool VulkanDeviceService::CreateLogicalDevice(const CreateInfo& info)
+{
+    std::set<uint32_t> uniqueFamilies;
+    if (QueueFamilies.HasGraphics()) uniqueFamilies.insert(*QueueFamilies.Graphics);
+    if (QueueFamilies.HasPresent())  uniqueFamilies.insert(*QueueFamilies.Present);
+    if (QueueFamilies.HasCompute())  uniqueFamilies.insert(*QueueFamilies.Compute);
+    if (QueueFamilies.HasTransfer()) uniqueFamilies.insert(*QueueFamilies.Transfer);
+
+    float queuePriority = 1.0f;
+    std::vector<VkDeviceQueueCreateInfo> queueCreateInfos;
+    queueCreateInfos.reserve(uniqueFamilies.size());
+
+    for (uint32_t family : uniqueFamilies)
+    {
+        VkDeviceQueueCreateInfo queueInfo{};
+        queueInfo.sType            = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+        queueInfo.queueFamilyIndex = family;
+        queueInfo.queueCount       = 1;
+        queueInfo.pQueuePriorities = &queuePriority;
+        queueCreateInfos.push_back(queueInfo);
+    }
+
+    VkPhysicalDeviceFeatures deviceFeatures{};
+
+    VkDeviceCreateInfo createInfo{};
+    createInfo.sType                   = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    createInfo.queueCreateInfoCount    = static_cast<uint32_t>(queueCreateInfos.size());
+    createInfo.pQueueCreateInfos       = queueCreateInfos.data();
+    createInfo.pEnabledFeatures        = &deviceFeatures;
+    createInfo.enabledExtensionCount   = static_cast<uint32_t>(info.RequiredDeviceExtensions.size());
+    createInfo.ppEnabledExtensionNames = info.RequiredDeviceExtensions.data();
+
+    VkResult result = vkCreateDevice(PhysicalDevice, &createInfo, nullptr, &Device);
+    if (result != VK_SUCCESS)
+    {
+        Log.Error("vkCreateDevice failed with code {}", static_cast<int>(result));
+        Device = VK_NULL_HANDLE;
+        return false;
+    }
+
+    Log.Info("Vulkan logical device created");
+    return true;
+}
+
+void VulkanDeviceService::RetrieveQueues()
+{
+    if (QueueFamilies.HasGraphics())
+        vkGetDeviceQueue(Device, *QueueFamilies.Graphics, 0, &GraphicsQueue);
+
+    if (QueueFamilies.HasPresent())
+        vkGetDeviceQueue(Device, *QueueFamilies.Present, 0, &PresentQueue);
+
+    if (QueueFamilies.HasCompute())
+        vkGetDeviceQueue(Device, *QueueFamilies.Compute, 0, &ComputeQueue);
+
+    if (QueueFamilies.HasTransfer())
+        vkGetDeviceQueue(Device, *QueueFamilies.Transfer, 0, &TransferQueue);
+
+    Log.Info("Queues retrieved — Graphics:{} Present:{} Compute:{} Transfer:{}",
+             QueueFamilies.HasGraphics() ? std::to_string(*QueueFamilies.Graphics) : "none",
+             QueueFamilies.HasPresent()  ? std::to_string(*QueueFamilies.Present)  : "none",
+             QueueFamilies.HasCompute()  ? std::to_string(*QueueFamilies.Compute)  : "none",
+             QueueFamilies.HasTransfer() ? std::to_string(*QueueFamilies.Transfer) : "none");
+}
+
+void VulkanDeviceService::LogDeviceProperties(VkPhysicalDevice device) const
+{
+    VkPhysicalDeviceProperties props;
+    vkGetPhysicalDeviceProperties(device, &props);
+
+    const char* typeStr = "Unknown";
+    switch (props.deviceType)
+    {
+        case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:   typeStr = "Discrete GPU";   break;
+        case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU: typeStr = "Integrated GPU"; break;
+        case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:    typeStr = "Virtual GPU";    break;
+        case VK_PHYSICAL_DEVICE_TYPE_CPU:            typeStr = "CPU";            break;
+        default: break;
+    }
+
+    Log.Info("  {} [{}] (API {}.{}.{})",
+             props.deviceName,
+             typeStr,
+             VK_API_VERSION_MAJOR(props.apiVersion),
+             VK_API_VERSION_MINOR(props.apiVersion),
+             VK_API_VERSION_PATCH(props.apiVersion));
+}

--- a/engine/infuser/src/vulkan/VulkanInstanceService.cpp
+++ b/engine/infuser/src/vulkan/VulkanInstanceService.cpp
@@ -1,0 +1,196 @@
+#include <vulkan/VulkanInstanceService.h>
+#include <vulkan/IVulkanSurfaceProvider.h>
+#include <algorithm>
+#include <cstring>
+
+static constexpr const char* ValidationLayerName = "VK_LAYER_KHRONOS_validation";
+
+VulkanInstanceService::VulkanInstanceService(Logger& logger,
+                                             const CreateInfo& info,
+                                             const IVulkanSurfaceProvider* surfaceProvider)
+    : Log(logger)
+{
+    if (info.EnableValidation && !CheckValidationLayerSupport())
+    {
+        Log.Warn("Validation layers requested but not available. Continuing without them.");
+    }
+    else
+    {
+        ValidationEnabled = info.EnableValidation;
+    }
+
+    VkApplicationInfo appInfo{};
+    appInfo.sType              = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    appInfo.pApplicationName   = info.AppName.c_str();
+    appInfo.applicationVersion = info.AppVersion;
+    appInfo.pEngineName        = "Sencha";
+    appInfo.engineVersion      = VK_MAKE_API_VERSION(0, 1, 0, 0);
+    appInfo.apiVersion         = info.ApiVersion;
+
+    auto extensions = BuildExtensionList(info, surfaceProvider);
+
+    VkInstanceCreateInfo createInfo{};
+    createInfo.sType                   = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    createInfo.pApplicationInfo        = &appInfo;
+    createInfo.enabledExtensionCount   = static_cast<uint32_t>(extensions.size());
+    createInfo.ppEnabledExtensionNames = extensions.data();
+
+    VkDebugUtilsMessengerCreateInfoEXT debugCreateInfo{};
+    if (ValidationEnabled)
+    {
+        createInfo.enabledLayerCount   = 1;
+        createInfo.ppEnabledLayerNames = &ValidationLayerName;
+
+        debugCreateInfo = MakeDebugCreateInfo(this);
+        createInfo.pNext = &debugCreateInfo;
+    }
+
+    VkResult result = vkCreateInstance(&createInfo, nullptr, &Instance);
+    if (result != VK_SUCCESS)
+    {
+        Log.Error("vkCreateInstance failed with code {}", static_cast<int>(result));
+        Instance = VK_NULL_HANDLE;
+        return;
+    }
+
+    Log.Info("Vulkan instance created successfully");
+
+    if (ValidationEnabled)
+    {
+        SetupDebugMessenger();
+    }
+}
+
+VulkanInstanceService::~VulkanInstanceService()
+{
+    if (DebugMessenger != VK_NULL_HANDLE)
+    {
+        DestroyDebugMessenger();
+    }
+
+    if (Instance != VK_NULL_HANDLE)
+    {
+        vkDestroyInstance(Instance, nullptr);
+        Log.Info("Vulkan instance destroyed");
+    }
+}
+
+bool VulkanInstanceService::CheckValidationLayerSupport() const
+{
+    uint32_t layerCount = 0;
+    vkEnumerateInstanceLayerProperties(&layerCount, nullptr);
+
+    std::vector<VkLayerProperties> available(layerCount);
+    vkEnumerateInstanceLayerProperties(&layerCount, available.data());
+
+    for (const auto& layer : available)
+    {
+        if (std::strcmp(layer.layerName, ValidationLayerName) == 0)
+            return true;
+    }
+
+    return false;
+}
+
+std::vector<const char*> VulkanInstanceService::BuildExtensionList(
+    const CreateInfo& info,
+    const IVulkanSurfaceProvider* surfaceProvider) const
+{
+    std::vector<const char*> extensions;
+
+    if (surfaceProvider)
+    {
+        auto surfaceExts = surfaceProvider->GetRequiredInstanceExtensions();
+        extensions.insert(extensions.end(), surfaceExts.begin(), surfaceExts.end());
+    }
+
+    if (ValidationEnabled)
+    {
+        extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    }
+
+    extensions.insert(extensions.end(), info.ExtraExtensions.begin(), info.ExtraExtensions.end());
+
+    Log.Info("Requesting {} instance extension(s):", extensions.size());
+    for (const auto* ext : extensions)
+    {
+        Log.Info("  {}", ext);
+    }
+
+    return extensions;
+}
+
+void VulkanInstanceService::SetupDebugMessenger()
+{
+    auto createInfo = MakeDebugCreateInfo(this);
+
+    auto func = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(
+        vkGetInstanceProcAddr(Instance, "vkCreateDebugUtilsMessengerEXT"));
+
+    if (!func)
+    {
+        Log.Warn("vkCreateDebugUtilsMessengerEXT not available");
+        return;
+    }
+
+    VkResult result = func(Instance, &createInfo, nullptr, &DebugMessenger);
+    if (result != VK_SUCCESS)
+    {
+        Log.Warn("Failed to set up debug messenger (code {})", static_cast<int>(result));
+        DebugMessenger = VK_NULL_HANDLE;
+    }
+    else
+    {
+        Log.Info("Vulkan debug messenger created");
+    }
+}
+
+void VulkanInstanceService::DestroyDebugMessenger()
+{
+    auto func = reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(
+        vkGetInstanceProcAddr(Instance, "vkDestroyDebugUtilsMessengerEXT"));
+
+    if (func)
+    {
+        func(Instance, DebugMessenger, nullptr);
+        Log.Info("Vulkan debug messenger destroyed");
+    }
+
+    DebugMessenger = VK_NULL_HANDLE;
+}
+
+VKAPI_ATTR VkBool32 VKAPI_CALL VulkanInstanceService::DebugCallback(
+    VkDebugUtilsMessageSeverityFlagBitsEXT severity,
+    VkDebugUtilsMessageTypeFlagsEXT /*type*/,
+    const VkDebugUtilsMessengerCallbackDataEXT* callbackData,
+    void* userData)
+{
+    auto* self = static_cast<VulkanInstanceService*>(userData);
+
+    if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
+        self->Log.Error("[Vulkan] {}", callbackData->pMessage);
+    else if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
+        self->Log.Warn("[Vulkan] {}", callbackData->pMessage);
+    else if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT)
+        self->Log.Info("[Vulkan] {}", callbackData->pMessage);
+    else
+        self->Log.Debug("[Vulkan] {}", callbackData->pMessage);
+
+    return VK_FALSE;
+}
+
+VkDebugUtilsMessengerCreateInfoEXT VulkanInstanceService::MakeDebugCreateInfo(void* userData)
+{
+    VkDebugUtilsMessengerCreateInfoEXT info{};
+    info.sType           = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+    info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT
+                         | VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT
+                         | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT
+                         | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+    info.messageType     = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT
+                         | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT
+                         | VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+    info.pfnUserCallback = DebugCallback;
+    info.pUserData       = userData;
+    return info;
+}


### PR DESCRIPTION
- Implement VulkanDeviceService for managing VkDevice and VkPhysicalDevice.
- Create VulkanInstanceService for handling VkInstance and validation layers.
- Introduce IVulkanSurfaceProvider interface for surface creation.
- Add VulkanQueueFamilies struct to manage queue family indices.
- Update CMakeLists.txt to include Vulkan headers and link Vulkan library.