### PR TITLE
Sdl3 window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,4 +14,5 @@ endif()
 
 add_subdirectory(engine)
 add_subdirectory(app)
+add_subdirectory(example)
 add_subdirectory(test)

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -1,33 +1,4 @@
-#include <batch/RefBatch.h>
-#include <batch/DataBatch.h>
-#include <raii/RefBatchHandle.h>
-#include <service/ServiceHost.h>
-#include <service/ServiceProvider.h>
-#include <system/SystemHost.h>
-#include <logging/ConsoleLogSink.h>
-#include <logging/FileLogSink.h>
-#include <iostream>
-
-class TestLogger{};
-
 int main()
 {
-    // Set up services
-    ServiceHost services;
-    auto& logging = services.GetLoggingProvider();
-    logging.AddSink<ConsoleLogSink>();
-    logging.AddSink<FileLogSink>("game.log");
-
-    // Create a service provider for systems to use during construction
-    ServiceProvider provider(services);
-
-    // Example usage: get a logger and log some messages
-    auto& logger = logging.GetLogger<TestLogger>();
-    logger.Debug("This is a debug message.");
-    logger.Info("This is an info message.");
-    logger.Warn("This is a warning message.");
-    logger.Error("This is an error message.");
-    logger.Critical("This is a critical message.");
-
     return 0;
 }

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -19,4 +19,5 @@ target_include_directories(engine PUBLIC
 )
 
 find_package(Vulkan REQUIRED)
-target_link_libraries(engine PUBLIC Vulkan::Vulkan)
+find_package(SDL3 REQUIRED CONFIG)
+target_link_libraries(engine PUBLIC Vulkan::Vulkan SDL3::SDL3)

--- a/engine/infuser/include/sdl/SdlVulkanSurfaceProvider.h
+++ b/engine/infuser/include/sdl/SdlVulkanSurfaceProvider.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <logging/Logger.h>
+#include <vulkan/IVulkanSurfaceProvider.h>
+
+class SdlWindow;
+
+class SdlVulkanSurfaceProvider final : public IVulkanSurfaceProvider
+{
+public:
+    SdlVulkanSurfaceProvider(Logger& logger, SdlWindow& window);
+
+    [[nodiscard]] std::vector<const char*> GetRequiredInstanceExtensions() const override;
+    [[nodiscard]] VulkanSurfaceResult CreateSurface(VkInstance instance) const override;
+
+private:
+    Logger& Log;
+    SdlWindow& Window;
+};

--- a/engine/infuser/include/sdl/SdlWindow.h
+++ b/engine/infuser/include/sdl/SdlWindow.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <service/IService.h>
+#include <logging/Logger.h>
+#include <window/IWindow.h>
+#include <window/WindowCreateInfo.h>
+#include <vulkan/IVulkanSurfaceProvider.h>
+
+struct SDL_Window;
+
+class SdlWindow : public IWindow, public IVulkanSurfaceProvider, public IService
+{
+public:
+    SdlWindow(Logger& logger, const WindowCreateInfo& createInfo);
+    ~SdlWindow() override;
+
+    SdlWindow(const SdlWindow&) = delete;
+    SdlWindow& operator=(const SdlWindow&) = delete;
+    SdlWindow(SdlWindow&&) = delete;
+    SdlWindow& operator=(SdlWindow&&) = delete;
+
+    [[nodiscard]] bool IsValid() const override;
+    void Close() override;
+
+    [[nodiscard]] std::string GetTitle() const override;
+    void SetTitle(std::string_view title) override;
+
+    [[nodiscard]] WindowExtent GetExtent() const override;
+    void SetSize(uint32_t width, uint32_t height) override;
+
+    [[nodiscard]] bool IsResizable() const override;
+    void SetResizable(bool resizable) override;
+
+    [[nodiscard]] WindowMode GetMode() const override;
+    void SetMode(WindowMode mode) override;
+
+    void Show() override;
+    void Hide() override;
+
+    [[nodiscard]] std::vector<const char*> GetRequiredInstanceExtensions() const override;
+    [[nodiscard]] VkSurfaceKHR CreateSurface(VkInstance instance) const override;
+
+private:
+    Logger& Log;
+    SDL_Window* Window = nullptr;
+};

--- a/engine/infuser/include/sdl/SdlWindow.h
+++ b/engine/infuser/include/sdl/SdlWindow.h
@@ -4,11 +4,10 @@
 #include <logging/Logger.h>
 #include <window/IWindow.h>
 #include <window/WindowCreateInfo.h>
-#include <vulkan/IVulkanSurfaceProvider.h>
 
 struct SDL_Window;
 
-class SdlWindow : public IWindow, public IVulkanSurfaceProvider, public IService
+class SdlWindow : public IWindow, public IService
 {
 public:
     SdlWindow(Logger& logger, const WindowCreateInfo& createInfo);
@@ -37,8 +36,7 @@ public:
     void Show() override;
     void Hide() override;
 
-    [[nodiscard]] std::vector<const char*> GetRequiredInstanceExtensions() const override;
-    [[nodiscard]] VkSurfaceKHR CreateSurface(VkInstance instance) const override;
+    [[nodiscard]] SDL_Window* GetHandle() const { return Window; }
 
 private:
     Logger& Log;

--- a/engine/infuser/include/vulkan/IVulkanSurfaceProvider.h
+++ b/engine/infuser/include/vulkan/IVulkanSurfaceProvider.h
@@ -4,24 +4,19 @@
 #include <vector>
 #include <string>
 
-//=============================================================================
-// IVulkanSurfaceProvider
-//
-// Narrow interface that decouples Vulkan from any specific windowing library.
-// A concrete implementation (SDL3, GLFW, Win32, headless, etc.) supplies:
-//   - The instance extensions it needs (e.g. VK_KHR_surface, VK_KHR_win32_surface)
-//   - A factory method to create a VkSurfaceKHR from a live VkInstance
-//
-// This is NOT a service. It is passed into VulkanDeviceService at construction
-// time as an optional dependency. If null, the device is created without
-// present capabilities.
-//=============================================================================
+struct VulkanSurfaceResult
+{
+    VkSurfaceKHR Surface = VK_NULL_HANDLE;
+    std::string  Error;
+
+    [[nodiscard]] bool Succeeded() const noexcept { return Surface != VK_NULL_HANDLE; }
+};
+
 class IVulkanSurfaceProvider
 {
 public:
     virtual ~IVulkanSurfaceProvider() = default;
 
-    virtual std::vector<const char*> GetRequiredInstanceExtensions() const = 0;
-
-    virtual VkSurfaceKHR CreateSurface(VkInstance instance) const = 0;
+    [[nodiscard]] virtual std::vector<const char*> GetRequiredInstanceExtensions() const = 0;
+    [[nodiscard]] virtual VulkanSurfaceResult CreateSurface(VkInstance instance) const = 0;
 };

--- a/engine/infuser/src/sdl/SdlVulkanSurfaceProvider.cpp
+++ b/engine/infuser/src/sdl/SdlVulkanSurfaceProvider.cpp
@@ -1,0 +1,34 @@
+#include <sdl/SdlVulkanSurfaceProvider.h>
+#include <sdl/SdlWindow.h>
+
+#include <SDL3/SDL_vulkan.h>
+
+SdlVulkanSurfaceProvider::SdlVulkanSurfaceProvider(Logger& logger, SdlWindow& window)
+    : Log(logger), Window(window)
+{
+}
+
+std::vector<const char*> SdlVulkanSurfaceProvider::GetRequiredInstanceExtensions() const
+{
+    Uint32 count = 0;
+    const char* const* names = SDL_Vulkan_GetInstanceExtensions(&count);
+    if (!names || count == 0)
+    {
+        Log.Error("Failed to query SDL Vulkan extensions: {}", SDL_GetError());
+        return {};
+    }
+    return { names, names + count };
+}
+
+VulkanSurfaceResult SdlVulkanSurfaceProvider::CreateSurface(VkInstance instance) const
+{
+    if (!Window.IsValid())
+        return { VK_NULL_HANDLE, "Window is not valid" };
+
+    VkSurfaceKHR surface = VK_NULL_HANDLE;
+    if (!SDL_Vulkan_CreateSurface(Window.GetHandle(), instance, nullptr, &surface))
+        return { VK_NULL_HANDLE, SDL_GetError() };
+
+    Log.Info("Vulkan surface created");
+    return { surface, {} };
+}

--- a/engine/infuser/src/sdl/SdlWindow.cpp
+++ b/engine/infuser/src/sdl/SdlWindow.cpp
@@ -1,7 +1,6 @@
 #include <sdl/SdlWindow.h>
 
 #include <SDL3/SDL.h>
-#include <SDL3/SDL_vulkan.h>
 #include <stdexcept>
 
 namespace
@@ -161,27 +160,3 @@ void SdlWindow::Hide()
         SDL_HideWindow(Window);
 }
 
-std::vector<const char*> SdlWindow::GetRequiredInstanceExtensions() const
-{
-    Uint32 count = 0;
-    const char* const* names = SDL_Vulkan_GetInstanceExtensions(&count);
-    if (!names || count == 0)
-    {
-        Log.Error("Failed to query SDL Vulkan extensions: {}", SDL_GetError());
-        return {};
-    }
-    return { names, names + count };
-}
-
-VkSurfaceKHR SdlWindow::CreateSurface(VkInstance instance) const
-{
-    if (!Window)
-        throw std::runtime_error("Cannot create Vulkan surface: window is not valid");
-
-    VkSurfaceKHR surface = VK_NULL_HANDLE;
-    if (!SDL_Vulkan_CreateSurface(Window, instance, nullptr, &surface))
-        throw std::runtime_error(std::string("SDL Vulkan surface creation failed: ") + SDL_GetError());
-
-    Log.Info("Vulkan surface created");
-    return surface;
-}

--- a/engine/infuser/src/sdl/SdlWindow.cpp
+++ b/engine/infuser/src/sdl/SdlWindow.cpp
@@ -1,0 +1,187 @@
+#include <sdl/SdlWindow.h>
+
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_vulkan.h>
+#include <stdexcept>
+
+namespace
+{
+    SDL_WindowFlags TranslateFlags(const WindowCreateInfo& info)
+    {
+        SDL_WindowFlags flags = SDL_WINDOW_VULKAN;
+
+        if (info.Resizable)
+            flags |= SDL_WINDOW_RESIZABLE;
+
+        if (!info.Visible)
+            flags |= SDL_WINDOW_HIDDEN;
+
+        switch (info.Mode)
+        {
+        case WindowMode::Fullscreen:
+            flags |= SDL_WINDOW_FULLSCREEN;
+            break;
+        case WindowMode::BorderlessFullscreen:
+            flags |= SDL_WINDOW_BORDERLESS | SDL_WINDOW_FULLSCREEN;
+            break;
+        case WindowMode::Windowed:
+            break;
+        }
+
+        return flags;
+    }
+}
+
+SdlWindow::SdlWindow(Logger& logger, const WindowCreateInfo& createInfo)
+    : Log(logger)
+{
+    if (!SDL_InitSubSystem(SDL_INIT_VIDEO))
+    {
+        Log.Error("SDL video init failed: {}", SDL_GetError());
+        return;
+    }
+
+    Window = SDL_CreateWindow(
+        createInfo.Title.c_str(),
+        static_cast<int>(createInfo.Width),
+        static_cast<int>(createInfo.Height),
+        TranslateFlags(createInfo));
+
+    if (!Window)
+    {
+        Log.Error("SDL window creation failed: {}", SDL_GetError());
+        return;
+    }
+
+    Log.Info("Window created: {}x{} \"{}\"", createInfo.Width, createInfo.Height, createInfo.Title);
+}
+
+SdlWindow::~SdlWindow()
+{
+    Close();
+    SDL_QuitSubSystem(SDL_INIT_VIDEO);
+}
+
+bool SdlWindow::IsValid() const
+{
+    return Window != nullptr;
+}
+
+void SdlWindow::Close()
+{
+    if (Window)
+    {
+        SDL_DestroyWindow(Window);
+        Window = nullptr;
+        Log.Info("Window closed");
+    }
+}
+
+std::string SdlWindow::GetTitle() const
+{
+    if (!Window) return {};
+    return SDL_GetWindowTitle(Window);
+}
+
+void SdlWindow::SetTitle(std::string_view title)
+{
+    if (Window)
+        SDL_SetWindowTitle(Window, std::string(title).c_str());
+}
+
+WindowExtent SdlWindow::GetExtent() const
+{
+    if (!Window) return {};
+    int w = 0, h = 0;
+    SDL_GetWindowSize(Window, &w, &h);
+    return { static_cast<uint32_t>(w), static_cast<uint32_t>(h) };
+}
+
+void SdlWindow::SetSize(uint32_t width, uint32_t height)
+{
+    if (Window)
+        SDL_SetWindowSize(Window, static_cast<int>(width), static_cast<int>(height));
+}
+
+bool SdlWindow::IsResizable() const
+{
+    if (!Window) return false;
+    return (SDL_GetWindowFlags(Window) & SDL_WINDOW_RESIZABLE) != 0;
+}
+
+void SdlWindow::SetResizable(bool resizable)
+{
+    if (Window)
+        SDL_SetWindowResizable(Window, resizable);
+}
+
+WindowMode SdlWindow::GetMode() const
+{
+    if (!Window) return WindowMode::Windowed;
+    auto flags = SDL_GetWindowFlags(Window);
+    if (flags & SDL_WINDOW_FULLSCREEN)
+    {
+        if (flags & SDL_WINDOW_BORDERLESS)
+            return WindowMode::BorderlessFullscreen;
+        return WindowMode::Fullscreen;
+    }
+    return WindowMode::Windowed;
+}
+
+void SdlWindow::SetMode(WindowMode mode)
+{
+    if (!Window) return;
+
+    switch (mode)
+    {
+    case WindowMode::Windowed:
+        SDL_SetWindowFullscreen(Window, false);
+        SDL_SetWindowBordered(Window, true);
+        break;
+    case WindowMode::Fullscreen:
+        SDL_SetWindowBordered(Window, true);
+        SDL_SetWindowFullscreen(Window, true);
+        break;
+    case WindowMode::BorderlessFullscreen:
+        SDL_SetWindowBordered(Window, false);
+        SDL_SetWindowFullscreen(Window, true);
+        break;
+    }
+}
+
+void SdlWindow::Show()
+{
+    if (Window)
+        SDL_ShowWindow(Window);
+}
+
+void SdlWindow::Hide()
+{
+    if (Window)
+        SDL_HideWindow(Window);
+}
+
+std::vector<const char*> SdlWindow::GetRequiredInstanceExtensions() const
+{
+    Uint32 count = 0;
+    const char* const* names = SDL_Vulkan_GetInstanceExtensions(&count);
+    if (!names || count == 0)
+    {
+        Log.Error("Failed to query SDL Vulkan extensions: {}", SDL_GetError());
+        return {};
+    }
+    return { names, names + count };
+}
+
+VkSurfaceKHR SdlWindow::CreateSurface(VkInstance instance) const
+{
+    if (!Window)
+        throw std::runtime_error("Cannot create Vulkan surface: window is not valid");
+
+    VkSurfaceKHR surface = VK_NULL_HANDLE;
+    if (!SDL_Vulkan_CreateSurface(Window, instance, nullptr, &surface))
+        throw std::runtime_error(std::string("SDL Vulkan surface creation failed: ") + SDL_GetError());
+
+    Log.Info("Vulkan surface created");
+    return surface;
+}

--- a/engine/infuser/src/vulkan/VulkanDeviceService.cpp
+++ b/engine/infuser/src/vulkan/VulkanDeviceService.cpp
@@ -21,12 +21,13 @@ VulkanDeviceService::VulkanDeviceService(Logger& logger,
 
     if (surfaceProvider)
     {
-        Surface = surfaceProvider->CreateSurface(Instance);
-        if (Surface == VK_NULL_HANDLE)
+        auto result = surfaceProvider->CreateSurface(Instance);
+        if (!result.Succeeded())
         {
-            Log.Error("Surface provider returned a null surface");
+            Log.Error("Surface creation failed: {}", result.Error);
             return;
         }
+        Surface = result.Surface;
         Log.Info("Surface created via provider");
     }
 

--- a/engine/teapot/include/window/IWindow.h
+++ b/engine/teapot/include/window/IWindow.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <window/WindowTypes.h>
+
+class IWindow
+{
+public:
+    virtual ~IWindow() = default;
+
+    [[nodiscard]] virtual bool IsValid() const = 0;
+    virtual void Close() = 0;
+
+    [[nodiscard]] virtual std::string GetTitle() const = 0;
+    virtual void SetTitle(std::string_view title) = 0;
+
+    [[nodiscard]] virtual WindowExtent GetExtent() const = 0;
+    virtual void SetSize(uint32_t width, uint32_t height) = 0;
+
+    [[nodiscard]] virtual bool IsResizable() const = 0;
+    virtual void SetResizable(bool resizable) = 0;
+
+    [[nodiscard]] virtual WindowMode GetMode() const = 0;
+    virtual void SetMode(WindowMode mode) = 0;
+
+    virtual void Show() = 0;
+    virtual void Hide() = 0;
+};

--- a/engine/teapot/include/window/WindowCreateInfo.h
+++ b/engine/teapot/include/window/WindowCreateInfo.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <window/WindowTypes.h>
+
+struct WindowCreateInfo
+{
+    std::string Title    = "Sencha";
+    uint32_t    Width    = 1280;
+    uint32_t    Height   = 720;
+    WindowMode  Mode     = WindowMode::Windowed;
+    bool        Resizable = true;
+    bool        Visible   = true;
+};

--- a/engine/teapot/include/window/WindowTypes.h
+++ b/engine/teapot/include/window/WindowTypes.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+
+enum class WindowMode : uint8_t
+{
+    Windowed,
+    Fullscreen,
+    BorderlessFullscreen
+};
+
+struct WindowExtent
+{
+    uint32_t Width  = 0;
+    uint32_t Height = 0;
+};

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(SdlVulkanWindow)

--- a/example/SdlVulkanWindow/CMakeLists.txt
+++ b/example/SdlVulkanWindow/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(SdlVulkanWindow
+    SdlVulkanWindow.cpp
+)
+
+target_link_libraries(SdlVulkanWindow PRIVATE engine)

--- a/example/SdlVulkanWindow/SdlVulkanWindow.cpp
+++ b/example/SdlVulkanWindow/SdlVulkanWindow.cpp
@@ -1,0 +1,75 @@
+#include <logging/ConsoleLogSink.h>
+#include <sdl/SdlVulkanSurfaceProvider.h>
+#include <sdl/SdlWindow.h>
+#include <service/ServiceHost.h>
+#include <vulkan/VulkanInstanceService.h>
+
+#include <SDL3/SDL.h>
+#include <vulkan/vulkan.h>
+
+class SdlVulkanWindowExample
+{
+};
+
+int main()
+{
+    ServiceHost services;
+    auto& logging = services.GetLoggingProvider();
+    logging.AddSink<ConsoleLogSink>();
+
+    auto& logger = logging.GetLogger<SdlVulkanWindowExample>();
+
+    WindowCreateInfo windowInfo;
+    windowInfo.Title = "Sencha SDL3 Vulkan Window";
+    windowInfo.Width = 1280;
+    windowInfo.Height = 720;
+    windowInfo.Resizable = true;
+    windowInfo.Visible = true;
+
+    SdlWindow window(logger, windowInfo);
+    if (!window.IsValid())
+    {
+        return 1;
+    }
+
+    SdlVulkanSurfaceProvider surfaceProvider(logger, window);
+
+    VulkanInstanceService::CreateInfo instanceInfo;
+    instanceInfo.AppName = "SdlVulkanWindow";
+
+    VulkanInstanceService instance(logger, instanceInfo, &surfaceProvider);
+    if (!instance.IsValid())
+    {
+        return 1;
+    }
+
+    auto surfaceResult = surfaceProvider.CreateSurface(instance.GetInstance());
+    if (!surfaceResult.Succeeded())
+    {
+        logger.Error("Failed to create Vulkan surface: {}", surfaceResult.Error);
+        return 1;
+    }
+
+    logger.Info("SDL3 Vulkan window is running. Close the window to exit.");
+
+    bool running = true;
+    while (running)
+    {
+        SDL_Event event;
+        while (SDL_PollEvent(&event))
+        {
+            if (event.type == SDL_EVENT_QUIT ||
+                event.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED)
+            {
+                running = false;
+            }
+        }
+
+        SDL_Delay(16);
+    }
+
+    vkDestroySurfaceKHR(instance.GetInstance(), surfaceResult.Surface, nullptr);
+    logger.Info("Vulkan surface destroyed");
+
+    return 0;
+}


### PR DESCRIPTION
I've made a slight compromise to my vision, but I think it's worth keeping the code sane and legible than introducing abstraction that will actually just push tight coupling in an ugly closet. I think that's closer to Sencha's vision of total transparency than being "modular" for the sake of "modularity".

SDL3 is an infuser level core assumption for window providers. My original vision was closer to allowing people to pick and choose any component of the engine like lego bricks, 

```
AddService<SDLWindowProvider>()
AddService<GLFWWindowProvider>()
AddService<MyOwnDamnWin32Wrapper>()
```

But in practice, it leads to layers of indirection that makes the code difficult to reason about, and that's worse for Sencha's integrity than forcing people to use a library that resolves windows/input/audio. 

At the end of the day, an engine needs a spine. Sencha's real strength comes from how people are going to author gameplay systems and opt out of certain render pipelines.