### PR TITLE
Add Grid2d and Tilemap rendering features

### DIFF
--- a/docs/grid.md
+++ b/docs/grid.md
@@ -1,0 +1,205 @@
+# Grid2d
+
+`Grid2d<T>` is a fixed-size, row-major 2D array.  It owns a contiguous
+`std::vector<T>` and contains all 2D-to-1D index arithmetic so that callers
+never reimplement it.  The type carries zero game logic and zero render logic.
+
+---
+
+## Location
+
+```
+engine/include/math/spatial/Grid2d.h
+```
+
+```cpp
+#include <math/spatial/Grid2d.h>
+```
+
+---
+
+## Storage model
+
+Cells are stored row-major: the full width of row 0 comes first, followed by
+the full width of row 1, and so on.  A cell at `(col, row)` lives at flat
+offset `row * width + col`.
+
+Grid dimensions are fixed at construction.  There is no resize or reallocation
+after the object is built.
+
+---
+
+## API
+
+```cpp
+// Construction
+Grid2d<uint32_t> grid;                         // empty (0x0)
+Grid2d<uint32_t> grid(width, height);          // zero-initialized
+Grid2d<uint32_t> grid(width, height, fillId);  // filled with fillId
+
+// Dimensions
+uint32_t w   = grid.GetWidth();
+uint32_t h   = grid.GetHeight();
+size_t   n   = grid.Count();      // == w * h
+bool     e   = grid.IsEmpty();    // == Count() == 0
+bool     ok  = grid.InBounds(col, row);
+
+// Cell access
+uint32_t id  = grid.Get(col, row);
+uint32_t& id = grid.Get(col, row);   // mutable ref
+grid.Set(col, row, newId);
+grid.Set(col, row, std::move(val));
+
+// Flat span (for system sweeps — no index arithmetic in the loop)
+std::span<const uint32_t> cells = grid.GetCells();
+std::span<uint32_t>       cells = grid.GetCells();
+```
+
+Grid2d is copyable and movable.  Copy duplicates the cell vector.  Move leaves
+the source in a 0x0 empty state.
+
+---
+
+## Idiomatic setup
+
+### Standalone grid
+
+Any code that needs a fixed 2D array can own a `Grid2d<T>` directly.
+
+```cpp
+// A 256x256 float heightmap, initialised to sea level.
+Grid2d<float> heightmap(256, 256, 0.0f);
+heightmap.Set(64, 32, 12.5f);
+float h = heightmap.Get(64, 32);
+```
+
+### In a DataBatch
+
+`Grid2d<T>` is move-constructible, so it can live inside a `DataBatch<T>`.
+
+```cpp
+struct TerrainChunk
+{
+    Grid2d<uint8_t> Biomes;
+    Grid2d<float>   Heights;
+};
+
+DataBatch<TerrainChunk> chunks;
+chunks.Emplace(TerrainChunk{ Grid2d<uint8_t>(64, 64), Grid2d<float>(64, 64, 0.0f) });
+```
+
+### Via Tilemap2d
+
+`Tilemap2d` wraps a `Grid2d<uint32_t>` and is the primary consumer in the
+engine.  Tile cells are accessed through the wrapper methods, which delegate
+to `Grid2d`:
+
+```cpp
+DataBatch<Tilemap2d> maps;
+
+const Transform2f origin = Transform2f::Identity();
+DataBatchHandle<Tilemap2d> handle = maps.Emplace(
+    world.Domain, origin, /*width=*/32u, /*height=*/32u, /*tileSize=*/16.0f);
+
+Tilemap2d* map = maps.TryGet(handle.GetToken());
+map->SetTile(0, 0, 1);   // tile ID 1 at column 0, row 0
+map->SetTile(1, 0, 2);   // tile ID 2 at column 1, row 0
+
+uint32_t id = map->GetTile(0, 0); // 1
+```
+
+### System sweep
+
+Systems that need to process every cell iterate the flat span, not the 2D
+accessor.  This keeps the hot loop a straight memory walk with no branch.
+
+```cpp
+// Pathfinding: count walkable cells.
+std::span<const uint32_t> cells = grid.GetCells();
+size_t walkable = 0;
+for (uint32_t id : cells)
+    if (id != 0) ++walkable;
+
+// Serialisation: write all cells to a buffer in storage order.
+std::span<const uint32_t> cells = grid.GetCells();
+writer.WriteBytes(cells.data(), cells.size_bytes());
+```
+
+Reconstruction from a flat span is equally direct:
+
+```cpp
+Grid2d<uint32_t> grid(width, height);
+std::span<uint32_t> cells = grid.GetCells();
+reader.ReadBytes(cells.data(), cells.size_bytes());
+```
+
+---
+
+## Tile ID convention (Tilemap2d)
+
+When `Grid2d<uint32_t>` is used inside `Tilemap2d`, the engine treats cell
+value `0` as the empty sentinel — no quad is emitted for it.  Tile IDs `1..N`
+map to tileset index `N - 1`, laid out row-major in the spritesheet:
+
+```
+tileset index = tileId - 1
+tileset col   = index % TilesetColumns
+tileset row   = index / TilesetColumns
+```
+
+This convention is enforced by `TilemapRenderFeature`.  `Grid2d` itself has no
+knowledge of it.
+
+---
+
+## Constraints
+
+**Do not add render or visibility state to Grid2d.**  `Grid2d<T>` must remain a
+pure data container.  Dirty flags, GPU buffer handles, visibility booleans, and
+render-order hints belong in a separate struct (e.g. `TilemapRenderState`) that
+is stored in its own `DataBatch` and references the grid via a `DataBatchKey`.
+
+**Do not add game logic to Grid2d.**  Collision response, pathfinding graphs,
+and AI hint layers are the concern of systems that read the grid as input data.
+They must not be baked into the grid type itself.
+
+**Do not store world position in Grid2d.**  The grid has no coordinate frame.
+The position and orientation of the grid in the world is the concern of a
+transform (e.g. `Tilemap2d::Handle`) owned by whoever wraps the grid.
+
+**Column and row are unsigned.**  Attempting to call `Get` or `Set` with a
+`(col, row)` pair where either component exceeds the grid dimensions is
+undefined behaviour in release builds.  Call `InBounds(col, row)` first in any
+path where the coordinates come from runtime input.
+
+**Dimensions are fixed at construction.**  There is no `Resize`, `PushRow`, or
+`PushColumn`.  If the size must change, construct a new `Grid2d` and replace
+the old one.
+
+**T must be move-constructible or copy-constructible.**  The internal
+`std::vector<T>` requires one of these.  Most plain-data types satisfy both.
+
+---
+
+## Relationship to the tilemap pipeline
+
+`Grid2d<T>` is the lowest layer.  The full 2D tilemap stack composes on top of
+it without any of the layers reaching downward past their direct dependency:
+
+```
+Grid2d<uint32_t>          pure data: cells + dimensions
+       │
+Tilemap2d                 adds: transform slot, hierarchy registration, tile size
+       │                  lives in: DataBatch<Tilemap2d>
+       │
+TilemapRenderState        adds: tileset texture, tileset layout, layer order
+       │                  lives in: DataBatch<TilemapRenderState> (separate array)
+       │
+TilemapRenderFeature      sweeps DataBatch<TilemapRenderState>, resolves MapKey
+                          → Tilemap2d, reads world transform, emits GpuTile instances
+```
+
+Maps and render states are intentionally in separate batches.  A map can exist
+without a render state (purely logical, serialised, or off-screen).  A render
+state can be disabled by removing it from its batch without touching the map
+data.  Neither `Grid2d` nor `Tilemap2d` carries any render or visibility state.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -120,6 +120,13 @@ example/   Small executable examples.
 test/      GoogleTest-based engine tests.
 ```
 
+## Documentation
+
+| Document | Description |
+|---|---|
+| [docs/shaders.md](shaders.md) | Shader authoring, build pipeline, metadata format, hot-reload, and planned tiers. |
+| [docs/grid.md](grid.md) | `Grid2d<T>` setup, storage model, idiomatic usage, constraints, and its role in the tilemap pipeline. |
+
 ## Requirements
 
 - CMake 3.20 or newer.

--- a/engine/include/math/spatial/Grid2d.h
+++ b/engine/include/math/spatial/Grid2d.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+//=============================================================================
+// Grid2d<T>
+//
+// Contiguous 2D array owning a flat std::vector<T>. All 2D-to-1D index math
+// lives here so callers never reimplement it; the grid itself carries zero
+// game or render logic.
+//
+// Storage order: row-major (row 0 is the first Width elements). A cell at
+// (col, row) lives at offset row * Width + col.
+//
+// Bounds checking is enforced only in debug builds (InBounds / assertions).
+// Release builds perform a single unchecked array access for hot paths.
+//=============================================================================
+template <typename T>
+class Grid2d
+{
+public:
+    Grid2d() = default;
+
+    Grid2d(uint32_t width, uint32_t height, const T& fillValue = T{})
+        : Width(width)
+        , Height(height)
+        , Cells(static_cast<size_t>(width) * height, fillValue)
+    {
+    }
+
+    Grid2d(Grid2d&&) noexcept = default;
+    Grid2d& operator=(Grid2d&&) noexcept = default;
+    Grid2d(const Grid2d&) = default;
+    Grid2d& operator=(const Grid2d&) = default;
+
+    // -- Dimensions -----------------------------------------------------------
+
+    uint32_t GetWidth()  const { return Width; }
+    uint32_t GetHeight() const { return Height; }
+    size_t   Count()     const { return Cells.size(); }
+    bool     IsEmpty()   const { return Cells.empty(); }
+
+    bool InBounds(uint32_t col, uint32_t row) const
+    {
+        return col < Width && row < Height;
+    }
+
+    // -- Cell access ----------------------------------------------------------
+
+    const T& Get(uint32_t col, uint32_t row) const { return Cells[Index(col, row)]; }
+          T& Get(uint32_t col, uint32_t row)       { return Cells[Index(col, row)]; }
+
+    void Set(uint32_t col, uint32_t row, const T& value)
+    {
+        Cells[Index(col, row)] = value;
+    }
+
+    void Set(uint32_t col, uint32_t row, T&& value)
+    {
+        Cells[Index(col, row)] = std::move(value);
+    }
+
+    // -- Flat span access (for systems that sweep the whole grid) -------------
+
+    std::span<const T> GetCells() const { return std::span<const T>(Cells); }
+    std::span<T>       GetCells()       { return std::span<T>(Cells); }
+
+private:
+    size_t Index(uint32_t col, uint32_t row) const
+    {
+        return static_cast<size_t>(row) * Width + col;
+    }
+
+    uint32_t       Width  = 0;
+    uint32_t       Height = 0;
+    std::vector<T> Cells;
+};

--- a/engine/include/render/features/TilemapRenderFeature.h
+++ b/engine/include/render/features/TilemapRenderFeature.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <core/batch/DataBatch.h>
+#include <math/geometry/2d/Transform2d.h>
+#include <render/Renderer.h>
+#include <render/backend/vulkan/VulkanDescriptorCache.h>
+#include <render/backend/vulkan/VulkanPipelineCache.h>
+#include <render/backend/vulkan/VulkanShaderCache.h>
+#include <render/features/TilemapRenderState.h>
+#include <world/tilemap/Tilemap2d.h>
+#include <world/transform/TransformStore.h>
+#include <vulkan/vulkan.h>
+
+#include <cstdint>
+#include <vector>
+
+class VulkanBufferService;
+class VulkanFrameScratch;
+
+//=============================================================================
+// TilemapRenderFeature
+//
+// IRenderFeature that drives the tilemap draw pass each frame.
+//
+// DOD contract:
+//   - Maps and RenderStates live in separate DataBatch arrays owned by the
+//     caller (typically the game bootstrap). This feature holds non-owning
+//     references to both. Lifetimes must outlive the Renderer.
+//   - OnDraw() sweeps DataBatch<TilemapRenderState> in LayerZIndex order,
+//     resolves each state's MapKey and TransformKey, then emits one instanced
+//     draw call per tilemap layer into the per-frame scratch buffer.
+//   - No virtual dispatch, no inheritance, no heap allocation per tile.
+//
+// Tile encoding:
+//   - Tile ID 0 is the "empty" sentinel; no quad is emitted for it.
+//   - Tile IDs 1..N map to tileset index N-1, laid out row-major in the
+//     spritesheet: col = (id-1) % TilesetColumns, row = (id-1) / TilesetColumns.
+//
+// GPU program:
+//   - Reuses the sprite vertex/fragment SPIR-V (instanced quads, bindless
+//     texture array). GpuTile is layout-compatible with SpriteFeature::GpuInstance.
+//   - Tiles are axis-aligned at their natural size; SinRot=0, CosRot=1.
+//   - Tilemap world transforms (translation, rotation, non-uniform scale) are
+//     applied to each tile center via Transform2d::TransformPoint before upload.
+//=============================================================================
+class TilemapRenderFeature : public IRenderFeature
+{
+public:
+    // Maps        — game-owned DataBatch<Tilemap2d>; feature reads, never writes.
+    // RenderStates — game-owned DataBatch<TilemapRenderState>; feature reads, never writes.
+    // Transforms  — world transform store; TryGetWorld(TransformKey) is called per-map per-frame.
+    TilemapRenderFeature(
+        DataBatch<Tilemap2d>&          maps,
+        DataBatch<TilemapRenderState>& renderStates,
+        TransformStore<Transform2f>&   transforms);
+
+    ~TilemapRenderFeature() override = default;
+
+    // -- IRenderFeature -------------------------------------------------------
+
+    [[nodiscard]] RenderPhase GetPhase() const override { return RenderPhase::MainColor; }
+    void Setup(const RendererServices& services) override;
+    void OnDraw(const FrameContext& frame) override;
+    void Teardown() override;
+
+private:
+    // 48-byte per-tile instance record — layout-compatible with
+    // SpriteFeature::GpuInstance so the sprite SPIR-V can be reused directly.
+    struct GpuTile
+    {
+        float    Center[2];       // World-space centre, screen pixels
+        float    HalfExtents[2];  // Half tile dimensions in pixels
+        float    UvMin[2];        // UV rect bottom-left on the tileset
+        float    UvMax[2];        // UV rect top-right on the tileset
+        uint32_t Color;           // Packed rgba8 tint (0xFFFFFFFF = opaque white)
+        uint32_t TextureIndex;    // Bindless tileset slot
+        float    SinRot;          // 0.0f — tiles are drawn axis-aligned
+        float    CosRot;          // 1.0f — tiles are drawn axis-aligned
+    };
+    static_assert(sizeof(GpuTile) == 48, "GpuTile must remain 48 bytes to match sprite layout");
+
+    // Per-draw UBO written into the frame scratch ring.
+    // std140-padded to 16 bytes; must match frame_ubo.glsli.
+    struct FrameUbo
+    {
+        float InvViewport[2];
+        float _pad[2];
+    };
+
+    [[nodiscard]] bool BuildPipeline(VkFormat colorFormat);
+
+    // Non-owning references to game-side DataBatch instances.
+    DataBatch<Tilemap2d>*          Maps         = nullptr;
+    DataBatch<TilemapRenderState>* RenderStates = nullptr;
+    TransformStore<Transform2f>*   Transforms   = nullptr;
+
+    // Cached service pointers (populated in Setup; never re-queried on hot path).
+    LoggingProvider*       Logging      = nullptr;
+    VulkanDeviceService*   DeviceService = nullptr;
+    VulkanBufferService*   Buffers      = nullptr;
+    VulkanShaderCache*     Shaders      = nullptr;
+    VulkanPipelineCache*   Pipelines    = nullptr;
+    VulkanDescriptorCache* Descriptors  = nullptr;
+    VulkanFrameScratch*    Scratch      = nullptr;
+
+    ShaderHandle     VertexShader;
+    ShaderHandle     FragmentShader;
+    VkPipelineLayout PipelineLayout    = VK_NULL_HANDLE;
+    VkPipeline       CachedPipeline    = VK_NULL_HANDLE;
+    VkFormat         CachedColorFormat = VK_FORMAT_UNDEFINED;
+
+    // Per-frame tile instance accumulator. Cleared at the end of every OnDraw.
+    std::vector<GpuTile>   Pending;
+    // Scratch index array for sorting render states by LayerZIndex without
+    // mutating the DataBatch. Retained across frames to avoid reallocation.
+    std::vector<uint32_t>  SortedIndices;
+
+    bool Valid = false;
+};

--- a/engine/include/render/features/TilemapRenderState.h
+++ b/engine/include/render/features/TilemapRenderState.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <core/batch/DataBatchKey.h>
+#include <render/backend/vulkan/VulkanDescriptorCache.h>
+#include <cstdint>
+
+//=============================================================================
+// TilemapRenderState
+//
+// Pure data descriptor that binds a Tilemap2d map to a rendered layer. Lives
+// in a DataBatch<TilemapRenderState> that is entirely separate from the
+// DataBatch<Tilemap2d> holding tile data — render state and game state are
+// never co-located in the same array.
+//
+// MapKey       — key into DataBatch<Tilemap2d>; provides grid dimensions,
+//                tile size, and per-cell tile IDs.
+// TransformKey — key into the world Transform batch (from TransformStore);
+//                TilemapRenderFeature reads the world matrix from here each
+//                frame without reaching into the Tilemap2d.
+// TilesetTexture  — bindless slot registered with VulkanDescriptorCache.
+// TilesetColumns / TilesetRows — grid layout of the tileset spritesheet;
+//                used to compute per-tileId UV rects at draw time.
+// LayerZIndex  — ascending sort order; lower values draw first (behind).
+//=============================================================================
+struct TilemapRenderState
+{
+    DataBatchKey       MapKey;
+    DataBatchKey       TransformKey;
+    BindlessImageIndex TilesetTexture;
+    uint32_t           TilesetColumns = 1;
+    uint32_t           TilesetRows    = 1;
+    int32_t            LayerZIndex    = 0;
+};

--- a/engine/include/world/tilemap/Tilemap2d.h
+++ b/engine/include/world/tilemap/Tilemap2d.h
@@ -3,89 +3,71 @@
 #include <core/batch/DataBatchKey.h>
 #include <core/raii/DataBatchHandle.h>
 #include <math/geometry/2d/Transform2d.h>
+#include <math/spatial/Grid2d.h>
 #include <world/transform/TransformDomain.h>
 #include <world/transform/TransformHierarchyRegistration.h>
 #include <cstdint>
-#include <vector>
 
 //=============================================================================
 // Tilemap2d
 //
-// A gameplay object that owns a transform in a 2D TransformDomain and
-// participates in the transform hierarchy WITHOUT going through TransformNode.
-// Proof that hierarchy participation is a flat capability any type can opt
-// into by holding a DataBatchHandle + TransformHierarchyRegistration against
-// the domain — composing TransformNode is convenient, not required.
+// Thin struct that owns a transform slot in a 2D TransformDomain and wraps
+// a Grid2d<uint32_t> for tile data. No render or visibility state lives here;
+// rendering decisions belong to TilemapRenderState (a separate DataBatch).
 //
-// The tilemap owns exactly one transform (the grid origin). Individual tiles
-// are not transforms; they are cells in the grid addressed by (col, row) and
-// resolved against the tilemap's world transform at draw/query time. Putting
-// a transform per tile would blow up the propagation set for no benefit — all
-// tiles move rigidly with the tilemap.
+// Transform participation is opt-in composition: holding a DataBatchHandle
+// and a TransformHierarchyRegistration is sufficient — no base class required.
+//
+// Individual tiles are NOT transforms. All cells move rigidly with the map's
+// single world transform, resolved at draw time via TransformKey().
 //=============================================================================
-class Tilemap2d
+struct Tilemap2d
 {
-public:
-	Tilemap2d(
-		TransformDomain<Transform2f>& domain,
-		const Transform2f& origin,
-		uint32_t gridWidth,
-		uint32_t gridHeight,
-		float tileSize)
-		: Handle(domain.Transforms.Emplace(origin))
-		, Registration(domain.Hierarchy, Handle.GetToken())
-		, GridWidth(gridWidth)
-		, GridHeight(gridHeight)
-		, TileSize(tileSize)
-		, Tiles(static_cast<size_t>(gridWidth) * gridHeight, 0)
-	{
-	}
+    Tilemap2d(
+        TransformDomain<Transform2f>& domain,
+        const Transform2f& origin,
+        uint32_t gridWidth,
+        uint32_t gridHeight,
+        float tileSize)
+        : Handle(domain.Transforms.Emplace(origin))
+        , Registration(domain.Hierarchy, Handle.GetToken())
+        , TileSize(tileSize)
+        , Grid(gridWidth, gridHeight, 0u)
+    {
+    }
 
-	Tilemap2d(Tilemap2d&&) noexcept = default;
-	Tilemap2d& operator=(Tilemap2d&&) noexcept = default;
-	Tilemap2d(const Tilemap2d&) = delete;
-	Tilemap2d& operator=(const Tilemap2d&) = delete;
+    Tilemap2d(Tilemap2d&&) noexcept = default;
+    Tilemap2d& operator=(Tilemap2d&&) noexcept = default;
+    Tilemap2d(const Tilemap2d&) = delete;
+    Tilemap2d& operator=(const Tilemap2d&) = delete;
 
-	// -- Transform participation -------------------------------------------
+    // -- Transform participation ----------------------------------------------
 
-	DataBatchKey TransformKey() const { return Handle.GetToken(); }
+    DataBatchKey TransformKey() const { return Handle.GetToken(); }
 
-	void SetTransformParent(DataBatchKey parentKey)
-	{
-		Registration.GetService()->SetParent(Handle.GetToken(), parentKey);
-	}
+    void SetTransformParent(DataBatchKey parentKey)
+    {
+        Registration.GetService()->SetParent(Handle.GetToken(), parentKey);
+    }
 
-	void ClearTransformParent()
-	{
-		Registration.GetService()->ClearParent(Handle.GetToken());
-	}
+    void ClearTransformParent()
+    {
+        Registration.GetService()->ClearParent(Handle.GetToken());
+    }
 
-	// -- Grid data ---------------------------------------------------------
+    // -- Grid access ----------------------------------------------------------
 
-	uint32_t Width() const { return GridWidth; }
-	uint32_t Height() const { return GridHeight; }
-	float GetTileSize() const { return TileSize; }
+    uint32_t Width()        const { return Grid.GetWidth(); }
+    uint32_t Height()       const { return Grid.GetHeight(); }
+    float    GetTileSize()  const { return TileSize; }
 
-	uint32_t GetTile(uint32_t col, uint32_t row) const
-	{
-		return Tiles[Index(col, row)];
-	}
+    uint32_t GetTile(uint32_t col, uint32_t row) const { return Grid.Get(col, row); }
+    void     SetTile(uint32_t col, uint32_t row, uint32_t tileId) { Grid.Set(col, row, tileId); }
 
-	void SetTile(uint32_t col, uint32_t row, uint32_t tileId)
-	{
-		Tiles[Index(col, row)] = tileId;
-	}
+    // -- Data members (public for DataBatch move-construction) ----------------
 
-private:
-	size_t Index(uint32_t col, uint32_t row) const
-	{
-		return static_cast<size_t>(row) * GridWidth + col;
-	}
-
-	DataBatchHandle<Transform2f> Handle;
-	TransformHierarchyRegistration Registration;
-	uint32_t GridWidth = 0;
-	uint32_t GridHeight = 0;
-	float TileSize = 0.0f;
-	std::vector<uint32_t> Tiles;
+    DataBatchHandle<Transform2f>   Handle;
+    TransformHierarchyRegistration Registration;
+    float                          TileSize = 1.0f;
+    Grid2d<uint32_t>               Grid;
 };

--- a/engine/src/render/backend/vulkan/features/TilemapRenderFeature.cpp
+++ b/engine/src/render/backend/vulkan/features/TilemapRenderFeature.cpp
@@ -1,0 +1,342 @@
+#include <render/features/TilemapRenderFeature.h>
+
+// Reuse the sprite SPIR-V blobs: tiles are instanced quads with bindless
+// texture sampling — the same GPU program as SpriteFeature. GpuTile is
+// layout-compatible with SpriteFeature::GpuInstance (both 48 bytes).
+#include <shaders/kSpriteVertSpv.h>
+#include <shaders/kSpriteFragSpv.h>
+
+#include <render/backend/vulkan/VulkanBufferService.h>
+#include <render/backend/vulkan/VulkanDescriptorCache.h>
+#include <render/backend/vulkan/VulkanDeviceService.h>
+#include <render/backend/vulkan/VulkanFrameScratch.h>
+#include <render/backend/vulkan/VulkanPipelineCache.h>
+#include <render/backend/vulkan/VulkanShaderCache.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+// ── Construction ─────────────────────────────────────────────────────────────
+
+TilemapRenderFeature::TilemapRenderFeature(
+    DataBatch<Tilemap2d>&          maps,
+    DataBatch<TilemapRenderState>& renderStates,
+    TransformStore<Transform2f>&   transforms)
+    : Maps(&maps)
+    , RenderStates(&renderStates)
+    , Transforms(&transforms)
+{
+}
+
+// ── IRenderFeature: Setup ─────────────────────────────────────────────────────
+
+void TilemapRenderFeature::Setup(const RendererServices& services)
+{
+    Logging       = services.Logging;
+    DeviceService = services.Device;
+    Buffers       = services.Buffers;
+    Shaders       = services.Shaders;
+    Pipelines     = services.Pipelines;
+    Descriptors   = services.Descriptors;
+    Scratch       = services.Scratch;
+
+    if (!Logging || !DeviceService || !Buffers || !Shaders
+        || !Pipelines || !Descriptors || !Scratch)
+    {
+        return;
+    }
+
+    Logger& log = Logging->GetLogger<TilemapRenderFeature>();
+
+    // Load pre-compiled SPIR-V blobs (embedded by the build pipeline; no I/O).
+    VertexShader = Shaders->CreateModuleFromSpirv(
+        kSpriteVertSpv, kSpriteVertSpvWordCount, "tilemap.vert");
+    FragmentShader = Shaders->CreateModuleFromSpirv(
+        kSpriteFragSpv, kSpriteFragSpvWordCount, "tilemap.frag");
+
+    if (!VertexShader.IsValid() || !FragmentShader.IsValid())
+    {
+        log.Error("TilemapRenderFeature: shader module creation failed");
+        return;
+    }
+
+    PipelineLayout = Descriptors->GetDefaultPipelineLayout();
+    if (PipelineLayout == VK_NULL_HANDLE)
+    {
+        log.Error("TilemapRenderFeature: failed to acquire pipeline layout");
+        return;
+    }
+
+    // Point set-0 binding-0 at the frame scratch ring (same as SpriteFeature).
+    Descriptors->SetFrameUniformBuffer(Scratch->GetBuffer(), 256);
+
+    Valid = true;
+}
+
+// ── IRenderFeature: Teardown ──────────────────────────────────────────────────
+
+void TilemapRenderFeature::Teardown()
+{
+    if (Shaders)
+    {
+        if (VertexShader.IsValid())   Shaders->Destroy(VertexShader);
+        if (FragmentShader.IsValid()) Shaders->Destroy(FragmentShader);
+    }
+    VertexShader       = {};
+    FragmentShader     = {};
+    CachedPipeline     = VK_NULL_HANDLE;
+    CachedColorFormat  = VK_FORMAT_UNDEFINED;
+    PipelineLayout     = VK_NULL_HANDLE;
+    Pending.clear();
+    Pending.shrink_to_fit();
+    Valid = false;
+}
+
+// ── Pipeline ──────────────────────────────────────────────────────────────────
+
+bool TilemapRenderFeature::BuildPipeline(VkFormat colorFormat)
+{
+    if (CachedPipeline != VK_NULL_HANDLE && CachedColorFormat == colorFormat)
+        return true;
+
+    GraphicsPipelineDesc desc;
+    desc.VertexShader   = VertexShader;
+    desc.FragmentShader = FragmentShader;
+    desc.Layout         = PipelineLayout;
+    desc.ColorFormats   = { colorFormat };
+
+    // One instance-rate binding at binding 0, stride = sizeof(GpuTile) = 48.
+    {
+        VertexInputBindingDesc vb{};
+        vb.Binding   = 0;
+        vb.Stride    = sizeof(GpuTile);
+        vb.InputRate = VK_VERTEX_INPUT_RATE_INSTANCE;
+        desc.VertexBindings.push_back(vb);
+    }
+
+    // Vertex attributes — must match GpuTile and sprite.vert.glsl locations.
+    auto addAttr = [&](uint32_t loc, VkFormat fmt, uint32_t off)
+    {
+        VertexInputAttributeDesc a{};
+        a.Location = loc;
+        a.Binding  = 0;
+        a.Format   = fmt;
+        a.Offset   = off;
+        desc.VertexAttributes.push_back(a);
+    };
+    addAttr(0, VK_FORMAT_R32G32_SFLOAT, offsetof(GpuTile, Center));
+    addAttr(1, VK_FORMAT_R32G32_SFLOAT, offsetof(GpuTile, HalfExtents));
+    addAttr(2, VK_FORMAT_R32G32_SFLOAT, offsetof(GpuTile, UvMin));
+    addAttr(3, VK_FORMAT_R32G32_SFLOAT, offsetof(GpuTile, UvMax));
+    addAttr(4, VK_FORMAT_R32_UINT,      offsetof(GpuTile, Color));
+    addAttr(5, VK_FORMAT_R32_UINT,      offsetof(GpuTile, TextureIndex));
+    addAttr(6, VK_FORMAT_R32G32_SFLOAT, offsetof(GpuTile, SinRot));
+
+    desc.Topology    = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    desc.CullMode    = VK_CULL_MODE_NONE;
+    desc.FrontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    desc.PolygonMode = VK_POLYGON_MODE_FILL;
+    desc.DepthTest   = false;
+    desc.DepthWrite  = false;
+    desc.DepthCompare = VK_COMPARE_OP_LESS_OR_EQUAL;
+
+    // Straight-alpha blending (same as sprites).
+    {
+        ColorBlendAttachmentDesc blend{};
+        blend.BlendEnable = true;
+        blend.SrcColor    = VK_BLEND_FACTOR_SRC_ALPHA;
+        blend.DstColor    = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+        blend.ColorOp     = VK_BLEND_OP_ADD;
+        blend.SrcAlpha    = VK_BLEND_FACTOR_ONE;
+        blend.DstAlpha    = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+        blend.AlphaOp     = VK_BLEND_OP_ADD;
+        desc.ColorBlend.push_back(blend);
+    }
+
+    VkPipeline pipeline = Pipelines->GetGraphicsPipeline(desc);
+    if (pipeline == VK_NULL_HANDLE)
+        return false;
+
+    CachedPipeline    = pipeline;
+    CachedColorFormat = colorFormat;
+    return true;
+}
+
+// ── IRenderFeature: OnDraw ────────────────────────────────────────────────────
+
+void TilemapRenderFeature::OnDraw(const FrameContext& frame)
+{
+    if (!Valid) return;
+
+    // ── Sweep render states ───────────────────────────────────────────────────
+    //
+    // Build a sorted view of active render states (ascending LayerZIndex).
+    // We sort indices rather than the batch itself so the DataBatch is not
+    // mutated and its generational keys stay stable.
+
+    std::span<const TilemapRenderState> states = RenderStates->GetItems();
+    if (states.empty()) return;
+
+    // Collect indices sorted by LayerZIndex.
+    SortedIndices.clear();
+    SortedIndices.resize(states.size());
+    for (size_t i = 0; i < states.size(); ++i)
+        SortedIndices[i] = static_cast<uint32_t>(i);
+
+    std::stable_sort(SortedIndices.begin(), SortedIndices.end(),
+        [&](uint32_t a, uint32_t b)
+        {
+            return states[a].LayerZIndex < states[b].LayerZIndex;
+        });
+
+    // ── Generate tile instances ───────────────────────────────────────────────
+
+    Pending.clear();
+
+    for (uint32_t stateIdx : SortedIndices)
+    {
+        const TilemapRenderState& rs = states[stateIdx];
+        if (!rs.TilesetTexture.IsValid()) continue;
+
+        const Tilemap2d* map = Maps->TryGet(rs.MapKey);
+        if (!map) continue;
+
+        const Transform2f* worldXf = Transforms->TryGetWorld(rs.TransformKey);
+        if (!worldXf) continue;
+
+        const uint32_t cols     = map->Width();
+        const uint32_t rows     = map->Height();
+        const float    tileSize = map->GetTileSize();
+        const float    half     = tileSize * 0.5f;
+
+        // Derive per-tile scale from the world transform's Scale.
+        // If scale is non-uniform, tiles are stretched; this is intentional.
+        const float halfW = half * worldXf->Scale.X;
+        const float halfH = half * worldXf->Scale.Y;
+
+        const float sinRot = std::sin(worldXf->Rotation);
+        const float cosRot = std::cos(worldXf->Rotation);
+
+        const float invCols = rs.TilesetColumns > 0
+            ? 1.0f / static_cast<float>(rs.TilesetColumns) : 1.0f;
+        const float invRows = rs.TilesetRows > 0
+            ? 1.0f / static_cast<float>(rs.TilesetRows) : 1.0f;
+
+        for (uint32_t row = 0; row < rows; ++row)
+        {
+            for (uint32_t col = 0; col < cols; ++col)
+            {
+                const uint32_t tileId = map->GetTile(col, row);
+                if (tileId == 0) continue; // 0 == empty cell
+
+                // Tile IDs are 1-based; tileset index = tileId - 1.
+                const uint32_t tsIndex = tileId - 1u;
+                const uint32_t tsCol   = tsIndex % rs.TilesetColumns;
+                const uint32_t tsRow   = tsIndex / rs.TilesetColumns;
+
+                // Local centre of this tile in the tilemap's local space.
+                const float localX = (static_cast<float>(col) + 0.5f) * tileSize;
+                const float localY = (static_cast<float>(row) + 0.5f) * tileSize;
+
+                // World centre via full TRS (TransformPoint applies scale then rotate then translate).
+                const Vec<2, float> worldCentre =
+                    worldXf->TransformPoint(Vec<2, float>(localX, localY));
+
+                GpuTile& t        = Pending.emplace_back();
+                t.Center[0]       = worldCentre.X;
+                t.Center[1]       = worldCentre.Y;
+                t.HalfExtents[0]  = halfW;
+                t.HalfExtents[1]  = halfH;
+                t.UvMin[0]        = static_cast<float>(tsCol)     * invCols;
+                t.UvMin[1]        = static_cast<float>(tsRow)     * invRows;
+                t.UvMax[0]        = static_cast<float>(tsCol + 1) * invCols;
+                t.UvMax[1]        = static_cast<float>(tsRow + 1) * invRows;
+                t.Color           = 0xFFFFFFFFu; // opaque white
+                t.TextureIndex    = rs.TilesetTexture.Value;
+                t.SinRot          = sinRot;
+                t.CosRot          = cosRot;
+            }
+        }
+    }
+
+    if (Pending.empty()) return;
+
+    if (!BuildPipeline(frame.TargetFormat))
+    {
+        Pending.clear();
+        return;
+    }
+
+    // ── Upload frame UBO ──────────────────────────────────────────────────────
+
+    const VulkanFrameScratch::Allocation uboAlloc =
+        Scratch->AllocateUniform(sizeof(FrameUbo));
+    if (!uboAlloc.IsValid())
+    {
+        Pending.clear();
+        return;
+    }
+
+    FrameUbo ubo{};
+    if (frame.TargetExtent.width  > 0)
+        ubo.InvViewport[0] = 1.0f / static_cast<float>(frame.TargetExtent.width);
+    if (frame.TargetExtent.height > 0)
+        ubo.InvViewport[1] = 1.0f / static_cast<float>(frame.TargetExtent.height);
+    std::memcpy(uboAlloc.Mapped, &ubo, sizeof(ubo));
+
+    // ── Upload tile instance buffer ───────────────────────────────────────────
+
+    const VkDeviceSize instanceBytes =
+        sizeof(GpuTile) * static_cast<VkDeviceSize>(Pending.size());
+    const VulkanFrameScratch::Allocation vboAlloc =
+        Scratch->AllocateVertex(instanceBytes);
+    if (!vboAlloc.IsValid())
+    {
+        Pending.clear();
+        return;
+    }
+
+    std::memcpy(vboAlloc.Mapped, Pending.data(), instanceBytes);
+
+    const VkBuffer ringBuffer = Buffers->GetBuffer(vboAlloc.Buffer);
+    if (ringBuffer == VK_NULL_HANDLE)
+    {
+        Pending.clear();
+        return;
+    }
+
+    // ── Record draw commands ──────────────────────────────────────────────────
+
+    vkCmdBindPipeline(frame.Cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, CachedPipeline);
+
+    VkViewport viewport{};
+    viewport.x        = 0.0f;
+    viewport.y        = 0.0f;
+    viewport.width    = static_cast<float>(frame.TargetExtent.width);
+    viewport.height   = static_cast<float>(frame.TargetExtent.height);
+    viewport.minDepth = 0.0f;
+    viewport.maxDepth = 1.0f;
+    vkCmdSetViewport(frame.Cmd, 0, 1, &viewport);
+
+    VkRect2D scissor{};
+    scissor.offset = { 0, 0 };
+    scissor.extent = frame.TargetExtent;
+    vkCmdSetScissor(frame.Cmd, 0, 1, &scissor);
+
+    const VkDescriptorSet sets[2] = {
+        Descriptors->GetFrameSet(),
+        Descriptors->GetBindlessSet(),
+    };
+    const uint32_t dynamicOffset = static_cast<uint32_t>(uboAlloc.Offset);
+    vkCmdBindDescriptorSets(frame.Cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                            PipelineLayout, 0, 2, sets, 1, &dynamicOffset);
+
+    const VkDeviceSize vboOffset = vboAlloc.Offset;
+    vkCmdBindVertexBuffers(frame.Cmd, 0, 1, &ringBuffer, &vboOffset);
+
+    // 6 vertices per tile (two triangles, no index buffer), N instances.
+    vkCmdDraw(frame.Cmd, 6, static_cast<uint32_t>(Pending.size()), 0, 0);
+
+    Pending.clear();
+}


### PR DESCRIPTION
- Introduced Grid2d class for fixed-size 2D array management.
- Added TilemapRenderFeature for handling tilemap draw passes.
- Created TilemapRenderState to bind Tilemap2d maps to rendered layers.
- Updated Tilemap2d to utilize Grid2d for tile data storage.
- Enhanced documentation for Grid2d and tilemap features.