### PR TITLE
Add documentation for various systems

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -1,0 +1,295 @@
+# Audio
+
+The audio system is a three-layer stack: `AudioClip` holds raw PCM data,
+`AudioBus` is a named pool of concurrent voices with shared volume controls,
+and `AudioService` owns the SDL backend, allocates voices from buses, and
+drives per-frame retirement of finished sounds.  Asset loading lives in
+`AudioClipCache` alongside the other asset caches and is independent of the
+playback service.
+
+---
+
+## Location
+
+```
+engine/include/audio/AudioService.h
+engine/include/audio/AudioBus.h
+engine/include/audio/AudioVoice.h
+engine/include/audio/AudioConfig.h
+engine/include/assets/audio/AudioClip.h
+engine/include/assets/audio/AudioClipCache.h
+engine/include/assets/audio/AudioClipLoader.h
+```
+
+```cpp
+#include <audio/AudioService.h>
+#include <assets/audio/AudioClipCache.h>
+```
+
+---
+
+## System model
+
+**Clips** are backend-agnostic CPU buffers.  `AudioClip` stores interleaved
+`int16_t` samples, a sample rate, and a channel count.  The clip knows nothing
+about streams, buses, or voices; it is a plain data struct.  Clips are loaded
+from WAV files by `AudioClipCache` and resampled at play time to the device
+spec (44100 Hz, stereo, Sint16).
+
+**Buses** are named voice pools configured at startup.  Each bus has a maximum
+voice count (1–255), a master volume, a mute flag, and a steal policy.  The
+built-in `"Engine"` bus (MaxVoices=1, Reject) is always present and cannot be
+configured or removed.  All other buses are declared in `EngineAudioConfig`
+before `AudioService` is constructed.
+
+**Voices** are individual playback streams.  Callers receive a `VoiceId` —
+an opaque generational handle — and use it to stop, pause, or query a sound.
+Stale handles from a recycled slot are silently rejected.
+
+---
+
+## API
+
+```cpp
+// -- Construction -----------------------------------------------------------
+
+EngineAudioConfig audioConfig;
+// (populate audioConfig.Buses — see Idiomatic setup below)
+AudioService audio(logging, audioConfig);
+
+if (!audio.IsValid())
+    return; // SDL device failed to open
+
+// -- Clip loading -----------------------------------------------------------
+
+AudioClipCache clipCache(logging);
+
+AudioClipHandle handle = clipCache.Acquire("sounds/explosion.wav");
+// or RAII:
+AudioClipCacheHandle handle = clipCache.AcquireOwned("sounds/explosion.wav");
+
+const AudioClip* clip = clipCache.Get(handle); // nullptr if invalid/released
+clipCache.Release(handle);                      // manual release
+
+// -- Playback ---------------------------------------------------------------
+
+PlayParams params;
+params.Bus     = "Sfx";    // bus name (default: "Engine")
+params.Gain    = 0.8f;     // [0, 1]   (default: 1.0)
+params.Pan     = -0.5f;    // [-1, +1] (default: 0.0)
+params.Looping = false;    //           (default: false)
+
+VoiceId voice = audio.Play(AssetId{handle.Id}, *clip, params);
+// Returns invalid VoiceId if: bus full + Reject policy, clip invalid, bus not found.
+if (!voice.IsValid()) { /* bus was full */ }
+
+audio.Stop(voice);   // immediate retire; no-op on invalid/stopped VoiceId
+audio.Pause(voice);  // no-op if not Playing
+audio.Resume(voice); // no-op if not Paused
+
+// -- Bus controls -----------------------------------------------------------
+
+audio.SetBusVolume("Sfx", 0.5f);   // returns false if bus name unknown
+audio.SetBusMuted("Music", true);
+float vol  = audio.GetBusVolume("Sfx");
+bool muted = audio.IsBusMuted("Music");
+
+// -- Voice state queries ----------------------------------------------------
+
+bool        playing = audio.IsPlaying(voice);
+bool        paused  = audio.IsPaused(voice);
+VoiceState  state   = audio.GetState(voice);
+// VoiceState: Idle | Playing | Paused | Stopped
+
+// -- Per-frame update -------------------------------------------------------
+
+audio.Tick(); // call once per frame; retires drained non-looping voices
+```
+
+`AudioService` is non-copyable and non-movable.
+
+---
+
+## Idiomatic setup
+
+### SFX bus with voice stealing
+
+Use `StealOldest` when only one instance of a sound should play at a time
+and a new trigger should always succeed (e.g. a footstep or UI click).
+
+```cpp
+EngineAudioConfig audioConfig;
+
+EngineAudioBusConfig sfx;
+sfx.Name        = "Sfx";
+sfx.MaxVoices   = 8;
+sfx.Volume      = 1.0f;
+sfx.StealPolicy = VoiceStealPolicy::StealOldest;
+audioConfig.Buses.push_back(std::move(sfx));
+
+AudioService audio(logging, audioConfig);
+```
+
+### Music bus with rejection
+
+Use `Reject` for music so that a second `Play` call does not silently cut the
+currently playing track.  Check the returned `VoiceId` before assuming
+playback started.
+
+```cpp
+EngineAudioBusConfig music;
+music.Name        = "Music";
+music.MaxVoices   = 1;
+music.Volume      = 0.7f;
+music.StealPolicy = VoiceStealPolicy::Reject;
+audioConfig.Buses.push_back(std::move(music));
+
+// At runtime:
+if (musicVoice.IsValid() && audio.IsPlaying(musicVoice))
+    audio.Stop(musicVoice);
+
+const AudioClip* track = clipCache.Get(trackHandle);
+musicVoice = audio.Play(AssetId{trackHandle.Id}, *track,
+                        PlayParams{ .Bus = "Music", .Looping = true });
+```
+
+### RAII clip lifetime
+
+`AcquireOwned` wraps the handle in an `AudioClipCacheHandle` that releases
+the clip automatically on destruction.  Use this when the clip should live
+exactly as long as the owning object.
+
+```cpp
+struct Weapon
+{
+    AudioClipCacheHandle FireSound;
+};
+
+Weapon weapon;
+weapon.FireSound = clipCache.AcquireOwned("sounds/gunshot.wav");
+
+// In fire logic:
+const AudioClip* clip = clipCache.Get(weapon.FireSound.Get());
+if (clip)
+    audio.Play(AssetId{weapon.FireSound.Get().Id}, *clip,
+               PlayParams{ .Bus = "Sfx" });
+
+// weapon destructor: FireSound calls clipCache.Release() automatically.
+```
+
+### Per-frame tick placement
+
+`Tick()` retires voices whose SDL streams have drained.  Call it once per
+frame, after processing all `Play` / `Stop` calls for that frame.
+
+```cpp
+// Main loop:
+while (running)
+{
+    ProcessEvents();
+    Update();
+    Render();
+    audio.Tick(); // last; retires finished voices
+}
+```
+
+---
+
+## JSON configuration
+
+When `AudioService` is constructed from an engine config file, the `"audio"`
+section is deserialized by `DeserializeAudioConfig`.  Do not list the built-in
+`"Engine"` bus here.
+
+```json
+{
+  "audio": {
+    "buses": [
+      {
+        "name":        "Sfx",
+        "maxVoices":   8,
+        "volume":      1.0,
+        "muted":       false,
+        "stealPolicy": "StealOldest"
+      },
+      {
+        "name":        "Music",
+        "maxVoices":   1,
+        "volume":      0.7,
+        "muted":       false,
+        "stealPolicy": "Reject"
+      }
+    ]
+  }
+}
+```
+
+Valid `stealPolicy` values: `"Reject"`, `"StealOldest"`.
+
+---
+
+## Constraints
+
+**The built-in `"Engine"` bus must not appear in `EngineAudioConfig`.**  It is
+hardcoded to MaxVoices=1 with Reject policy and is always constructed first.
+Declaring a bus with the same name is undefined behaviour.
+
+**Buses are fixed at construction.**  There is no API to add, remove, or
+resize a bus after `AudioService` is constructed.  All buses must be declared
+in `EngineAudioConfig` before calling the constructor.
+
+**`MaxVoices` must be in the range [1, 255].**  Zero is invalid.  The field is
+a `uint8_t`; values above 255 cannot be represented.
+
+**The device spec is fixed at 44100 Hz, stereo, Sint16.**  Clips are resampled
+to this spec via an SDL audio stream at play time.  There is no API to change
+the output spec.
+
+**`AudioClip` must remain alive for the duration of playback.**  `AudioService`
+holds a const reference to the clip's samples for the life of the voice.  For
+non-looping clips the samples are pushed into the SDL stream in `Play()`, so
+the clip can be released once the call returns.  For looping clips the stream
+is kept open and re-fed from the same buffer; the clip must not be freed until
+after `Stop()` is called on the voice.
+
+**`Tick()` must be called once per frame.**  Without it, non-looping voices
+are never retired and their slots are not returned to the free pool.  Missing
+`Tick()` calls will exhaust bus voice capacity over time.
+
+**A zero or invalid `VoiceId` is always safe to pass to any control method.**
+`Stop`, `Pause`, `Resume`, `IsPlaying`, `IsPaused`, and `GetState` silently
+no-op on invalid handles.  There is no need to guard call sites with
+`IsValid()` checks on the hot path.
+
+**`AudioService` is non-copyable and non-movable.**  It owns the SDL audio
+device handle for its entire lifetime.  Construct it once and pass it by
+reference.
+
+---
+
+## Relationship to the engine
+
+`AudioService` is a standalone service with no dependency on the ECS, render
+pipeline, or game loop.  The full audio stack composes as:
+
+```
+AudioClip                 raw PCM data: samples + rate + channel count
+      │
+AudioClipCache            path-keyed ref-counted loader; returns AudioClipHandle
+      │                   owns clip memory until refcount reaches zero
+      │
+AudioService              SDL backend, bus table, voice slots
+      │                   Play() → VoiceId (opaque generational handle)
+      │                   Tick() → retires drained non-looping voices
+      │
+Bus (AudioBus)            named voice pool: MaxVoices, Volume, Muted, StealPolicy
+      │                   built-in "Engine" bus always present
+      │
+Voice (VoiceId)           per-play SDL_AudioStream bound to device
+                          gain = params.Gain × bus.Volume (0 if muted)
+```
+
+`AudioClip` and `AudioClipCache` are independent of `AudioService`.  A clip
+can be loaded, inspected, or serialized without an audio device.  A service
+can be constructed against an empty config and clips loaded later.  Neither
+layer reaches upward into the other.

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,314 @@
+# Data
+
+The data layer is built around `DataBatch<T>` and `LifetimeHandle`.  `DataBatch<T>`
+owns a dense contiguous array of T values; each item receives a stable
+`DataBatchKey` so swap-and-pop removal never invalidates other handles.  Keys
+pack a recyclable 20-bit index and a 12-bit generation — a stale key stops
+resolving the moment its slot is removed and reused.  `LifetimeHandle` is the
+RAII wrapper that calls `Detach` on the owning batch when the handle goes out
+of scope, automatically removing the item without any manual bookkeeping.
+
+---
+
+## Location
+
+```
+engine/include/core/batch/DataBatch.h
+engine/include/core/batch/DataBatchKey.h
+engine/include/core/raii/LifetimeHandle.h
+engine/include/core/raii/ILifetimeOwner.h
+engine/include/core/raii/DataBatchHandle.h
+```
+
+```cpp
+#include <core/batch/DataBatch.h>
+#include <core/batch/DataBatchKey.h>
+#include <core/raii/LifetimeHandle.h>
+#include <core/raii/DataBatchHandle.h>
+```
+
+---
+
+## Core types
+
+**`DataBatch<T>`** is the primary container.  It owns a `std::vector<T>` and a
+parallel `IndexToKey` table; items are addressed by `DataBatchKey`, not by
+pointer or integer index.  Removal swaps the target with the last element and
+pops — O(1) and cache-dense.  `DataBatch<T>` implements `ILifetimeOwner` so
+`DataBatchHandle<T>` can drive automatic removal through the RAII protocol.
+
+**`DataBatchKey`** is a strongly-typed 32-bit value packing a 20-bit slot index
+and a 12-bit generation.  The default-constructed value (`Value == 0`) is the
+null sentinel.  A key becomes stale when its slot is deactivated; `TryGet` with
+a stale key returns `nullptr` instead of a dangling pointer.
+
+**`DataBatchBlock`** is lightweight metadata for a contiguous key range returned
+by one `EmplaceBlock` call.  It carries `FirstKey` and `Count` and exposes
+`KeyAt(i)` and `Contains(key)`.  It does **not** own any handles or keep items
+alive.
+
+**`ILifetimeOwner`** is the type-erased interface that connects handles to their
+container.  Any class that manages resource lifetimes — batches, registries,
+asset caches — implements `Attach(uint64_t)` and `Detach(uint64_t)`.
+
+**`LifetimeHandle<T, KeyT>`** is the generic RAII handle.  `T` names the value
+type; `KeyT` names the token shape (pointer for `InstanceRegistry`, value type
+for `DataBatch`).  Construction calls `Attach`; destruction and `Reset()` call
+`Detach`.  Move transfers ownership; copy is deleted.
+
+**`DataBatchHandle<T>`** is the alias `LifetimeHandle<T, DataBatchKey>`.  It is
+what `DataBatch<T>::Emplace` returns and what game code holds.
+
+---
+
+## API
+
+```cpp
+// ---- Single-item emplacement ---------------------------------------------
+
+// Emplace constructs T in-place and returns an owning RAII handle.
+DataBatch<Particle> particles;
+DataBatchHandle<Particle> handle = particles.Emplace(x, y, z);
+
+// EmplaceUnowned emplace without creating a handle. Caller is responsible
+// for removal. Useful inside TransformStore or similar dual-batch wrappers.
+DataBatchKey key = particles.EmplaceUnowned(x, y, z);
+
+// ---- Block emplacement ---------------------------------------------------
+
+// Allocate count items in one operation; factory(index) returns each T.
+DataBatchBlock block = particles.EmplaceBlock(4, [](size_t i) {
+    return Particle{ float(i), 0.0f, 0.0f };
+});
+// block.FirstKey, block.Count, block.KeyAt(i), block.Contains(key)
+
+// ---- Random access -------------------------------------------------------
+
+T*       ptr = particles.TryGet(handle);  // nullptr if stale
+T*       ptr = particles.TryGet(key);
+const T* ptr = particles.TryGet(key);     // const overload
+
+bool exists = particles.Contains(key);
+uint32_t i  = particles.IndexOf(key);     // UINT32_MAX if absent
+
+// ---- Removal -------------------------------------------------------------
+
+// Implicit: handle destructs → Detach → swap-and-pop.
+{
+    auto h = particles.Emplace(1.0f, 0.0f, 0.0f);
+}  // item removed here
+
+// Explicit early release:
+handle.Reset();         // Detach + nullify; handle.IsValid() == false
+
+// Bulk removal:
+particles.RemoveKey(key);
+particles.RemoveBlock(block);
+particles.RemoveKeys(std::span<const DataBatchKey>{ keys });
+particles.RemoveHandles(std::span<DataBatchHandle<T>>{ handles });
+
+// ---- Iteration -----------------------------------------------------------
+
+// The whole point of DOD: one contiguous span.
+for (Particle& p : particles.GetItems())  { /* ... */ }
+for (const Particle& p : particles)       { /* range-for */ }
+size_t n = particles.Count();
+
+// ---- Version and dirty tracking -----------------------------------------
+
+uint64_t v = particles.GetVersion();  // bumped on any structural change
+bool dirty = particles.CheckAndClearDirty();  // test-and-clear
+
+// Sort the dense array if dirty; updates internal key→index tables.
+particles.SortIfDirty([](const Particle& a, const Particle& b) {
+    return a.Z < b.Z;
+});
+
+// ---- RAII handle interface -----------------------------------------------
+
+bool valid      = handle.IsValid();
+DataBatchKey k  = handle.GetToken();
+if (handle) { /* ... */ }           // explicit bool conversion
+```
+
+---
+
+## Idiomatic setup
+
+### Single item with RAII
+
+```cpp
+DataBatch<Particle> particles;
+
+// Emplace returns a handle; the item lives exactly as long as the handle.
+auto handle = particles.Emplace(100.0f, 200.0f, 0.0f);
+
+// Access by handle without extracting the key.
+if (Particle* p = particles.TryGet(handle))
+    p->X += 10.0f;
+
+// Item is removed when handle goes out of scope or is reset explicitly.
+handle.Reset();
+```
+
+### Block allocation
+
+Use `EmplaceBlock` when adding a batch of items whose lifetimes are coupled and
+managed together (e.g. all tiles in a tilemap layer).  `DataBatchBlock` is a
+plain-old-data range descriptor — store it alongside whichever object owns the
+logical group, and call `RemoveBlock` when that object is torn down.
+
+```cpp
+DataBatch<GpuTile> tiles;
+
+DataBatchBlock block = tiles.EmplaceBlock(width * height, [&](size_t i) {
+    return GpuTile{ tileIds[i] };
+});
+
+// Address a specific tile by local offset:
+for (size_t i = 0; i < block.Count; ++i)
+{
+    DataBatchKey key = block.KeyAt(i);
+    if (GpuTile* tile = tiles.TryGet(key))
+        tile->Flags = 1;
+}
+
+// Remove the whole block at once:
+tiles.RemoveBlock(block);
+```
+
+### Move semantics
+
+```cpp
+DataBatchHandle<Particle> a = particles.Emplace(1.0f, 2.0f, 3.0f);
+
+// Transfer ownership — a becomes invalid, b owns the item.
+DataBatchHandle<Particle> b = std::move(a);
+assert(!a.IsValid());
+assert( b.IsValid());
+
+// Move-assign: b's current item is removed, then b takes ownership of c's.
+DataBatchHandle<Particle> c = particles.Emplace(4.0f, 5.0f, 6.0f);
+b = std::move(c);
+// The item b previously owned is gone; c is now invalid.
+```
+
+### Implementing ILifetimeOwner for multi-resource handles
+
+When a single logical entity spans two or more batches, implement
+`ILifetimeOwner` directly and return a single `DataBatchHandle` whose
+destruction removes from all batches at once.
+
+```cpp
+class EntityStore : public ILifetimeOwner, public IService
+{
+public:
+    DataBatchHandle<Position> Emplace(Position pos, Velocity vel)
+    {
+        const DataBatchKey key = Positions.EmplaceUnowned(pos);
+        try   { Velocities.EmplaceAtKey(key, vel); }
+        catch (...) { Positions.RemoveKey(key); throw; }
+        return DataBatchHandle<Position>(this, key);
+    }
+
+    void Attach(uint64_t) override {}
+
+    void Detach(uint64_t token) override
+    {
+        DataBatchKey key{};
+        std::memcpy(&key, &token, sizeof(key));
+        Velocities.RemoveKey(key);
+        Positions.RemoveKey(key);
+    }
+
+    DataBatch<Position> Positions;
+    DataBatch<Velocity> Velocities;
+};
+```
+
+### EmplaceUnowned and manual removal
+
+`EmplaceUnowned` returns a raw key with no handle.  Use it inside owner
+objects that manage their own lifetime accounting (like `EntityStore` above or
+`TransformStore`) and do not want an extra RAII level.
+
+```cpp
+DataBatchKey key = particles.EmplaceUnowned(x, y, z);
+// ... later, explicit removal required:
+particles.RemoveKey(key);
+```
+
+---
+
+## Constraints
+
+**Do not copy `DataBatchHandle`.**  Copy constructor and copy-assignment are
+deleted.  Two owners for the same item would double-free it on destruction.
+Transfer ownership with `std::move` or keep the handle in the object that
+logically owns the item.
+
+**Do not hold a raw `DataBatchKey` as a long-lived ownership token.**  A key
+does not keep the item alive; it is a look-up token only.  If you need
+ownership semantics, use a `DataBatchHandle`.  Raw keys are appropriate for
+non-owning references — render features reading transforms they did not create.
+
+**Do not assume a raw key is valid without calling `TryGet` or `Contains`.**
+Any `RemoveKey` or handle destruction can deactivate a slot.  The generation
+check in `TryGet` returns `nullptr` rather than a dangling pointer, but the
+check only fires if you actually call it.
+
+**`DataBatchBlock` does not own or keep items alive.**  It is metadata.  If you
+call `RemoveBlock` or destroy the handles that were not created for those keys,
+the block's `KeyAt` entries become stale silently.  Store blocks only alongside
+the code responsible for the matching `RemoveBlock` call.
+
+**`EmplaceUnowned` items must be removed explicitly.**  The batch has no record
+that these items are unmanaged; they will not be cleaned up when the batch is
+destroyed (they are destroyed with the batch, but the slot is never `Detach`-ed
+by a handle).  Use `EmplaceUnowned` only inside types that implement
+`ILifetimeOwner` and guarantee `RemoveKey` is called through `Detach`.
+
+**Do not pass `Value == 0` as a `DataBatchKey`.**  Zero is the null sentinel.
+`DataBatch` will silently ignore a remove-by-null-key and `TryGet` will return
+`nullptr`.
+
+**`EmplaceAtKey` requires the target slot to be free.**  It throws
+`std::invalid_argument` if the slot is occupied or the generation does not
+match.  It is intended for paired stores (like `TransformStore`) that must
+place world and local transforms at the same key index.
+
+**Do not rely on dense-array indices surviving a removal.**  Swap-and-pop moves
+the last element into the removed slot.  Any externally cached integer index is
+invalidated.  Use `DataBatchKey` or `DataBatchHandle` for stable addressing;
+use `GetItems()` for iteration-only passes where order does not matter.
+
+---
+
+## Relationship to the rest of the engine
+
+`DataBatch` is the shared data substrate.  Systems read `GetItems()` spans each
+tick; render features hold non-owning pointers to the game's batches.  The RAII
+chain ensures items are always removed when the logical owner is torn down,
+regardless of the order in which game objects are destroyed.
+
+```
+Game / scene code
+       │  holds DataBatchHandle<T>  (RAII owner)
+       │  handle destructs → Detach → swap-and-pop → item gone
+       │
+DataBatch<T>                implements ILifetimeOwner
+       │  dense Items[]  ←  iterated by systems and render features
+       │  generational KeySlots[]  ←  TryGet resolves stable handles
+       │
+Systems (ECS-style loops)
+       │  for (auto& item : batch.GetItems()) { … }
+       │
+TilemapRenderFeature / TransformStore / AssetCache
+       │  store non-owning DataBatch* pointers
+       │  read Items[] directly; never remove
+       │
+LifetimeHandle<T, KeyT>
+       │  generic base; DataBatchHandle<T> is the DataBatch alias
+       │  InstanceRegistryHandle<T> is the pointer-registry alias
+       │  AssetCache uses NoAttach tag to avoid double-counting refcount
+```

--- a/docs/render.md
+++ b/docs/render.md
@@ -1,0 +1,280 @@
+# Renderer
+
+The render system is built around `IRenderFeature` and `Renderer`.  `Renderer`
+owns an ordered list of features, drives them through a single `DrawFrame()`
+call each tick, and hands each feature a small `FrameContext` on the hot path —
+no `ServiceHost` lookups in the loop.  Features extend the renderer by
+implementing `IRenderFeature`; the engine ships two: `SpriteFeature` (immediate
+sprite batching) and `TilemapRenderFeature` (tilemap layer rendering).
+
+---
+
+## Location
+
+```
+engine/include/render/Renderer.h
+engine/include/render/features/SpriteFeature.h
+engine/include/render/features/TilemapRenderFeature.h
+engine/include/render/features/TilemapRenderState.h
+```
+
+```cpp
+#include <render/Renderer.h>
+#include <render/features/SpriteFeature.h>
+#include <render/features/TilemapRenderFeature.h>
+#include <render/features/TilemapRenderState.h>
+```
+
+---
+
+## Core types
+
+**`IRenderFeature`** is the extension point.  Implement it to add a new draw
+pass.  One feature belongs to exactly one `RenderPhase`.  The Renderer calls
+`Setup()` once at `AddFeature()` time (the device already exists), and
+`Teardown()` in `~Renderer` before any Vulkan service is torn down.  `OnDraw()`
+is called every frame inside the appropriate phase.
+
+**`Renderer`** owns all features, runs the frame loop, and is itself an
+`IService`.  It is neither copyable nor movable.
+
+**`RenderPhase`** is an enum that buckets features.  Only `MainColor` exists
+today; the renderer is designed so adding `Offscreen`, `Shadow`, `UI`, and
+`Post` phases later does not change the feature interface.
+
+**`RendererServices`** is a plain struct of non-owning service pointers handed
+to `Setup()`.  Features cache whichever pointers they need and never touch the
+`ServiceHost` again.
+
+**`FrameContext`** is the small, cache-dense payload passed to every `OnDraw()`
+call.  It contains the command buffer, frame-in-flight index, target extent,
+target format, and current phase — nothing else.
+
+---
+
+## API
+
+```cpp
+// ---- IRenderFeature (implement to add a draw pass) ----------------------
+
+class MyFeature : public IRenderFeature
+{
+public:
+    RenderPhase GetPhase() const override { return RenderPhase::MainColor; }
+
+    // Optional: fold device extensions / feature bits into the bootstrap
+    // policy before VkDevice creation. Renderer never calls this directly —
+    // game code calls it before standing up the Vulkan stack.
+    void Contribute(VulkanBootstrapPolicy& policy) override;
+
+    // Called once inside Renderer::AddFeature. Cache service pointers here.
+    void Setup(const RendererServices& services) override;
+
+    // Called every frame. Command buffer is already inside vkCmdBeginRendering
+    // for MainColor features.
+    void OnDraw(const FrameContext& frame) override;
+
+    // Called in ~Renderer before any Vulkan service tears down.
+    void Teardown() override;
+};
+
+// ---- Renderer -----------------------------------------------------------
+
+// Add a feature and run its Setup() immediately. Returns a raw pointer
+// whose lifetime is tied to the Renderer.
+T* raw = renderer.AddFeature(std::make_unique<MyFeature>());
+
+// Drive one frame: acquire → scratch rotate → phase iterate → present.
+Renderer::DrawStatus status = renderer.DrawFrame();
+// status == Ok | SwapchainOutOfDate | Skipped | Error
+
+// Call after VulkanSwapchainService::Recreate to reset per-image tracking.
+renderer.NotifySwapchainRecreated();
+
+// ---- SpriteFeature submission -------------------------------------------
+
+sprites->Submit({
+    .CenterX  = 100.0f, .CenterY  = 200.0f,  // screen pixels, origin top-left
+    .Width    = 32.0f,  .Height   = 32.0f,
+    .UvMinX   = 0.0f,   .UvMinY   = 0.0f,
+    .UvMaxX   = 1.0f,   .UvMaxY   = 1.0f,
+    .Color    = 0xFFFFFFFFu,                   // packed rgba8, opaque white
+    .Texture  = bindlessSlot,                  // BindlessImageIndex
+    .Rotation = 0.0f,                          // radians around Center
+    .SortKey  = 0,                             // ascending; smaller draws first
+});
+
+sprites->ClearPending();  // abort without drawing (rarely needed)
+```
+
+---
+
+## Idiomatic setup
+
+### Bootstrap sequence
+
+Features that need Vulkan extensions (e.g. for ray tracing or mesh shaders)
+must call `Contribute()` on the feature before the device is created.  All
+other wiring happens after the device exists.
+
+```cpp
+// 1. Collect contributions from features that need device extensions.
+SpriteFeature sprite;
+sprite.Contribute(vulkanPolicy);   // no-op for SpriteFeature today
+
+// 2. Bring up the Vulkan stack (Instance → Surface → PhysicalDevice →
+//    Device → Queues → Allocator → Upload → Buffers → Images → Samplers
+//    → Shaders → Pipelines → Descriptors → Scratch → Swapchain → Frames).
+//    See QuadTreeDemoRender.cpp for the full sequence.
+
+// 3. Construct the Renderer, then hand it the features.
+auto renderer = std::make_unique<Renderer>(
+    logging, *device, *physicalDevice, *queues, *swapchain, *frames,
+    *allocator, *buffers, *images, *samplers, *shaders, *pipelines,
+    *descriptors, *scratch, *upload);
+
+SpriteFeature* sprites =
+    renderer->AddFeature(std::make_unique<SpriteFeature>());
+```
+
+### Sprite rendering per frame
+
+```cpp
+// Before renderer->DrawFrame():
+sprites->Submit({ .CenterX = x, .CenterY = y, .Width = w, .Height = h,
+                  .Texture = mySlot, .SortKey = layer });
+sprites->Submit({ ... });
+
+auto status = renderer->DrawFrame();
+if (status == Renderer::DrawStatus::SwapchainOutOfDate)
+{
+    swapchain->Recreate(window->GetExtent());
+    frames->ResetAfterSwapchainRecreate();
+    renderer->NotifySwapchainRecreated();
+}
+```
+
+`SpriteFeature` stable-sorts by `SortKey` ascending before upload, then issues
+a single instanced draw.  The accumulator is cleared automatically after
+`OnDraw` consumes it.
+
+### Tilemap rendering
+
+`TilemapRenderFeature` takes non-owning references to the game's
+`DataBatch<Tilemap2d>`, `DataBatch<TilemapRenderState>`, and
+`TransformStore<Transform2f>` at construction time.  These batches must outlive
+the `Renderer`.
+
+```cpp
+DataBatch<Tilemap2d>          maps;
+DataBatch<TilemapRenderState> renderStates;
+// ... populate maps and transforms ...
+
+auto* tilemap =
+    renderer->AddFeature(std::make_unique<TilemapRenderFeature>(
+        maps, renderStates, world.Transforms));
+
+// Add a render state to make a map visible.
+TilemapRenderState state;
+state.MapKey        = mapHandle.GetToken();
+state.TransformKey  = mapHandle.GetTransformKey();
+state.TilesetTexture = tilesetSlot;  // BindlessImageIndex
+state.TilesetColumns = 8;
+state.TilesetRows    = 8;
+state.LayerZIndex    = 0;            // drawn before higher z-indices
+renderStates.Emplace(state);
+```
+
+### Texture registration
+
+All textures are registered with `VulkanDescriptorCache` before being handed
+to any feature.  The returned `BindlessImageIndex` is what goes on sprite and
+tilemap state structs.
+
+```cpp
+ImageHandle img = images->Create(info);
+images->Upload(img, pixels, size);
+
+VkSampler sampler = samplers->GetNearestRepeat();
+BindlessImageIndex slot = descriptors->RegisterSampledImage(img, sampler);
+// slot.IsValid() == true
+
+// When the image is no longer needed:
+descriptors->UnregisterSampledImage(slot);
+images->Destroy(img);
+```
+
+Re-registering the same `(image, sampler)` pair is idempotent and returns the
+same slot cheaply.
+
+---
+
+## Coordinate space (SpriteFeature)
+
+Screen pixels, origin top-left, +X right, +Y down.  `CenterX`/`CenterY` are
+the sprite's center in that space.  `Width`/`Height` are the full extents; the
+shader halves them internally.  There is no camera or view matrix at this
+layer — world-space projection is out of scope for `SpriteFeature` and belongs
+to a future `CameraFeature` or a view-matrix push constant.
+
+---
+
+## Constraints
+
+**Do not call `ServiceHost` inside `OnDraw()`.**  `OnDraw()` is the hot path.
+Every service the feature needs must be cached into member pointers during
+`Setup()`.  The `RendererServices` bundle is provided specifically for this.
+
+**Do not submit sprites after `DrawFrame()` for the same frame.**  The
+accumulator is cleared by `OnDraw()`.  Submissions must happen between the
+previous `DrawFrame()` returning and the next one being called.
+
+**Do not hold raw `IRenderFeature*` pointers across `~Renderer`.**  `AddFeature`
+returns a raw pointer whose lifetime is tied to the `Renderer` instance.  Once
+the `Renderer` is destroyed, all feature pointers are dangling.
+
+**Do not implement multi-phase features.**  Each `IRenderFeature` reports
+exactly one `RenderPhase`.  A feature that needs to draw in two phases must be
+split into two separate feature objects.
+
+**`Contribute()` must be called before the device is created.**  The `Renderer`
+never calls `Contribute()` itself — that is a pre-device hook for game boot
+code.  If a feature folds extensions into the bootstrap policy, the game must
+call `Contribute()` on the feature before constructing `VulkanDeviceService`.
+
+**`TilemapRenderFeature` data batches must outlive the `Renderer`.**  The
+feature stores non-owning pointers to the game's `DataBatch<Tilemap2d>` and
+`DataBatch<TilemapRenderState>`.  Destroying either batch while the renderer is
+alive is undefined behaviour.
+
+---
+
+## Relationship to the sprite and tilemap pipeline
+
+`Renderer` is the top of the draw stack.  Everything beneath it is Vulkan
+plumbing; everything that feeds it is game logic writing into `DataBatch`
+arrays or calling `Submit()`:
+
+```
+Game logic / systems
+       │  calls Submit() on SpriteFeature
+       │  populates DataBatch<TilemapRenderState>
+       │
+Renderer::DrawFrame()
+       │  iterates PhaseBuckets[MainColor]
+       │
+IRenderFeature::OnDraw(FrameContext)
+       │
+SpriteFeature            reads Pending[], stable-sorts by SortKey,
+       │                 uploads via VulkanFrameScratch, one instanced draw
+       │
+TilemapRenderFeature     sweeps DataBatch<TilemapRenderState> by LayerZIndex,
+                         resolves MapKey → Tilemap2d, reads world transform,
+                         emits GpuTile instances into VulkanFrameScratch,
+                         one instanced draw per tilemap layer
+```
+
+`SpriteFeature` and `TilemapRenderFeature` share the same SPIR-V (sprite
+vertex/fragment shaders) and the same 48-byte per-instance GPU layout
+(`GpuInstance` / `GpuTile`).  They do not share state at runtime; each
+maintains its own per-frame accumulator and issues its own draw call.

--- a/docs/transform.md
+++ b/docs/transform.md
@@ -1,0 +1,350 @@
+# Transform
+
+`Transform2d<T>` and `Transform3d<T>` are TRS (translation, rotation, scale)
+value types.  Together with the hierarchy and propagation services they form the
+engine's scene-graph: local transforms are authored per-object, world transforms
+are derived automatically, and the hot propagation loop does no allocation or
+recursion.
+
+---
+
+## Location
+
+```
+engine/include/math/geometry/2d/Transform2d.h
+engine/include/math/geometry/3d/Transform3d.h
+engine/include/world/transform/
+```
+
+```cpp
+#include <math/geometry/2d/Transform2d.h>
+#include <math/geometry/3d/Transform3d.h>
+#include <world/transform/TransformNode.h>
+#include <world/transform/TransformDomain.h>
+```
+
+Common aliases are `Transform2f = Transform2d<float>` and
+`Transform3f = Transform3d<float>`.
+
+---
+
+## Struct layout
+
+### 2D
+
+```cpp
+template <typename T>
+struct Transform2d
+{
+    Vec<2, T> Position;   // translation
+    T         Rotation;   // angle in radians, counter-clockwise
+    Vec<2, T> Scale;      // non-uniform scale per axis
+
+    static Transform2d Identity();   // { (0,0), 0, (1,1) }
+};
+```
+
+### 3D
+
+```cpp
+template <typename T>
+struct Transform3d
+{
+    Vec<3, T> Position;   // translation
+    Quat<T>   Rotation;   // unit quaternion
+    Vec<3, T> Scale;      // non-uniform scale per axis
+
+    static Transform3d Identity();   // { (0,0,0), identity quat, (1,1,1) }
+};
+```
+
+### Composition
+
+Both types expose `operator*` for parent-then-child composition:
+
+```cpp
+Transform2f world = parent * local;
+```
+
+Scale components multiply component-wise.  Rotation composes additively (2D) or
+via quaternion multiplication (3D).  The child's position is scaled by the
+parent's scale, then rotated by the parent's rotation, then offset by the
+parent's position.
+
+---
+
+## Hierarchy
+
+`TransformHierarchyService` owns the parent-child graph.  It is a plain data
+structure — it records relationships but does not update transforms itself.
+
+```
+engine/include/world/transform/TransformHierarchyService.h
+```
+
+```cpp
+// Attach / detach
+hierarchy.SetParent(childKey, parentKey);   // parent child; auto-registers both
+hierarchy.ClearParent(childKey);            // promote child to root
+
+// Manual registration (optional — SetParent registers implicitly)
+hierarchy.Register(key);
+hierarchy.Unregister(key);                  // orphans all children (they become roots)
+
+// Query
+bool hasParent  = hierarchy.HasParent(key);
+bool hasKids    = hierarchy.HasChildren(key);
+auto parent     = hierarchy.GetParent(key);    // returns optional key
+auto& children  = hierarchy.GetChildren(key);  // std::vector<DataBatchKey>
+auto& roots     = hierarchy.GetRoots();
+```
+
+Every structural change (register, unregister, reparent) increments a
+`VersionCounter`.  The propagation cache reads this counter to decide whether to
+rebuild.  No callers need to manage the counter directly.
+
+---
+
+## Propagation
+
+`TransformPropagationSystem<TTransform>` derives world transforms from local
+transforms in a single forward pass.
+
+```
+engine/include/world/transform/TransformPropagationSystem.h
+```
+
+```cpp
+propagation.Propagate();
+```
+
+The rules are:
+
+```
+root       →  world = local
+child of P →  world = world[P] * local
+```
+
+Internally the system maintains a cached flat order emitted by BFS from the
+roots.  Parents always appear before their children.  On each `Propagate()` call
+the cache is validated against the hierarchy and batch version counters; it is
+rebuilt only when stale.  The hot loop is a straight forward pass over the flat
+order: no hash lookups, no recursion, no allocation.
+
+**World transforms are write-only from the propagation system's perspective.**
+Outside code reads them but must not write them.  Modify the local transform to
+reposition an object; the next `Propagate()` call will derive the new world
+transform.
+
+---
+
+## TransformDomain
+
+`TransformDomain<TTransform>` is a self-contained bundle of all transform
+services.  Any subsystem that needs its own isolated transform space creates one.
+
+```
+engine/include/world/transform/TransformDomain.h
+```
+
+```cpp
+TransformDomain<Transform2f> domain;
+
+// Contained services (all accessible as members):
+domain.Transforms   // TransformStore — allocates and owns local/world pairs
+domain.Hierarchy    // TransformHierarchyService — parent-child graph
+domain.Propagation  // TransformPropagationSystem — derives world transforms
+```
+
+`World<TTransform>` owns one `TransformDomain` for game-world objects.  UI,
+editor gizmos, and particle systems can own independent `TransformDomain`
+instances with no coupling between them.
+
+---
+
+## API
+
+### TransformStore
+
+```
+engine/include/world/transform/TransformStore.h
+```
+
+```cpp
+// Allocate a transform slot (local + world share the same key)
+DataBatchHandle<TTransform> handle = domain.Transforms.Emplace(localTransform);
+DataBatchKey key = handle.GetToken();
+
+// Keyed access
+const TTransform* local = domain.Transforms.TryGetLocal(key);
+const TTransform* world = domain.Transforms.TryGetWorld(key);
+      TTransform* local = domain.Transforms.TryGetLocal(key);  // mutable
+
+// Bulk span (system sweeps — no key arithmetic in the loop)
+std::span<const TTransform> locals = domain.Transforms.GetLocalsSpan();
+std::span<const TTransform> worlds = domain.Transforms.GetWorldsSpan();
+```
+
+### TransformNode
+
+`TransformNode<TTransform>` is a reusable composition primitive for any object
+that participates in the hierarchy.
+
+```
+engine/include/world/transform/TransformNode.h
+```
+
+```cpp
+TransformNode2d node(domain, initialLocal);
+
+// Parenting
+node.SetParent(parentNode);           // accepts TransformNode or raw key
+node.SetParent(parentKey);
+node.ClearParent();
+bool parented = node.HasParent();
+auto parentKey = node.GetParentKey(); // returns optional
+
+// Key for passing to other services
+DataBatchKey key = node.TransformKey();
+```
+
+`TransformNode` is move-constructible (move transfers ownership cleanly) and
+copy-deleted.  It registers with the hierarchy on construction and unregisters
+on destruction via `TransformHierarchyRegistration`.
+
+---
+
+## Idiomatic setup
+
+### Single unparented object
+
+```cpp
+TransformNode2d obj(world.Domain, Transform2f({ 100.0f, 50.0f }, 0.0f, { 1.0f, 1.0f }));
+world.Domain.Propagation.Propagate();
+
+const Transform2f* t = world.Domain.Transforms.TryGetWorld(obj.TransformKey());
+// t->Position == (100, 50)
+```
+
+### Parent-child pair
+
+```cpp
+TransformNode2d parent(world.Domain, Transform2f({ 200.0f, 0.0f }, 0.0f, { 2.0f, 2.0f }));
+TransformNode2d child(world.Domain,  Transform2f({  10.0f, 0.0f }, 0.0f, { 1.0f, 1.0f }));
+child.SetParent(parent);
+
+world.Domain.Propagation.Propagate();
+
+const Transform2f* cw = world.Domain.Transforms.TryGetWorld(child.TransformKey());
+// cw->Position == (220, 0)  — child local (10, 0) scaled by parent (x2) then offset by (200, 0)
+// cw->Scale    == (2, 2)    — parent scale inherited
+```
+
+### Three-level hierarchy
+
+```cpp
+TransformNode2d root(world.Domain, Transform2f({ 100.0f, 0.0f }, 0.0f, { 1.0f, 1.0f }));
+TransformNode2d mid(world.Domain,  Transform2f({  50.0f, 0.0f }, 0.0f, { 1.0f, 1.0f }));
+TransformNode2d leaf(world.Domain, Transform2f({  10.0f, 0.0f }, 0.0f, { 1.0f, 1.0f }));
+
+mid.SetParent(root);
+leaf.SetParent(mid);
+
+world.Domain.Propagation.Propagate();
+
+const Transform2f* lw = world.Domain.Transforms.TryGetWorld(leaf.TransformKey());
+// lw->Position == (160, 0)  — 100 + 50 + 10
+```
+
+### Integration into a struct
+
+Types that own a transform slot follow the same pattern as `TransformNode`
+internally: allocate a slot on construction, register with the hierarchy, expose
+a key for parenting.
+
+```cpp
+struct Actor
+{
+    Actor(TransformDomain<Transform2f>& domain, const Transform2f& local)
+        : Node(domain, local)
+    {}
+
+    void SetParent(const Actor& parent)   { Node.SetParent(parent.Node); }
+    DataBatchKey TransformKey() const     { return Node.TransformKey(); }
+
+private:
+    TransformNode2d Node;
+};
+```
+
+### System sweep (world transforms)
+
+```cpp
+// Apply world positions to a physics broadphase.
+std::span<const Transform2f> worlds = world.Domain.Transforms.GetWorldsSpan();
+for (const Transform2f& t : worlds)
+    broadphase.UpdateAABB(t.Position, t.Scale);
+```
+
+---
+
+## Constraints
+
+**Always write the local transform; never write the world transform.**  World
+transforms are outputs of `Propagate()`.  Writing directly to a world transform
+will be silently overwritten on the next propagation pass.
+
+**Call `Propagate()` once per frame, after all local-transform mutations.**
+Reading a world transform before `Propagate()` has run for the current frame
+yields the value from the previous frame.  Systems that consume world transforms
+must be ordered after the propagation step.
+
+**Do not skip registration.**  A key that is added to a `TransformStore` but
+never registered with the hierarchy is treated as orphaned and will be absent
+from the propagation order.  Use `TransformNode` (which registers automatically)
+or call `hierarchy.Register(key)` manually.
+
+**`Unregister` orphans children.**  Removing a parent key from the hierarchy
+does not cascade-unregister its children.  Each child is promoted to a root and
+will propagate independently from its next `Propagate()` call.  If the children
+should also be removed, unregister them explicitly before or after the parent.
+
+**Do not store world position inside the transform's owning struct.**  Caching
+the world transform in a member variable creates a shadow copy that diverges
+silently.  Read world transforms from `TryGetWorld` or the world span.
+
+**Do not reparent inside the propagation loop.**  Modifying the hierarchy during
+`Propagate()` invalidates the cache mid-pass.  Collect reparent operations and
+apply them before the `Propagate()` call.
+
+**Scale composes multiplicatively.**  A child with local scale `(0.5, 0.5)` under
+a parent with world scale `(4, 4)` has a world scale of `(2, 2)`.  There is no
+mechanism to opt out of inherited scale; a child that must ignore a parent's
+scale must compensate explicitly in its own local transform.
+
+---
+
+## Relationship to the scene-graph pipeline
+
+The transform system is the foundation beneath every positioned object.  The
+layers compose without any reaching downward past their direct dependency:
+
+```
+Transform2d / Transform3d     pure TRS value; no ownership, no allocation
+        │
+TransformStore                allocates paired local/world slots per key
+        │
+TransformHierarchyService     records parent-child relationships; version-tracked
+        │
+TransformPropagationOrder     caches BFS-ordered flat pass; rebuilt on version change
+        │
+TransformPropagationSystem    executes forward pass: worlds[i] = worlds[parent] * locals[i]
+        │
+TransformNode / Tilemap2d     per-object wrappers; own a slot + RAII registration
+        │
+World<TTransform>             owns the domain; exposes it to gameplay systems
+```
+
+Objects (actors, tilemaps, UI elements, particles) sit at the `TransformNode`
+layer.  They author local transforms and read world transforms.  Everything below
+that line is infrastructure.


### PR DESCRIPTION
I had Claude generate docs for a few of my engine's systems, and I wish I had gotten to this sooner, because it revealed some critical flaws in Sencha's code that I need to address ASAP:

- "Constraints" section on many docs (esp. transform.md) detail a long list of "Do not ~" This needs to be enforced by code rather than discipline.
- Accessing transform data for custom game objects is painfully verbose. There needs to be either a helper method or an architectural reconsideration. 