### PR TITLE
Add entity management system

### DIFF
--- a/docs/entity.md
+++ b/docs/entity.md
@@ -1,0 +1,256 @@
+# Entity
+
+The entity system layers stable game-object identity on top of the transform
+hierarchy.  An `EntityBatch<T>` stores typed game structs in a `DataBatch<T>`
+and registers each item with `EntityRegistry` on emplacement.  Destruction goes
+through the registry so any entity — regardless of its concrete type — can be
+torn down by key, including full subtree destruction that walks the transform
+hierarchy leaves-first.
+
+---
+
+## Location
+
+```
+engine/include/world/entity/EntityKey.h
+engine/include/world/entity/EntityRecord.h
+engine/include/world/entity/EntityRegistry.h
+engine/include/world/entity/IsEntity.h
+engine/include/world/entity/EntityBatch.h
+engine/src/world/entity/EntityRegistry.cpp
+```
+
+```cpp
+#include <world/entity/EntityBatch.h>
+#include <world/entity/EntityKey.h>
+#include <world/entity/EntityRegistry.h>
+```
+
+`EntityRegistry` lives inside `World<TTransform>` as the `Entities` member.
+Gameplay code does not instantiate it directly.
+
+---
+
+## Core types
+
+**`EntityKey`** is the stable handle to an entity.  It wraps a `DataBatchKey`
+so it carries generation information — a stale key stops resolving after the
+entity is destroyed and its slot is reused.  Default-constructed `EntityKey` is
+null: `operator bool()` returns false.
+
+**`EntityRecord`** is per-entity metadata stored inside `EntityRegistry`.  It
+holds the entity's transform key (for hierarchy lookup) and a type-erased
+`OnDestroy` callback so the registry can tear down any entity type without
+knowing its concrete type.  `Owner` / `OwnerSlot` / `OnDestroy` form a triad
+that `EntityBatch<T>` fills in on each `Emplace`.
+
+**`EntityRegistry`** is the central registry mapping `EntityKey` →
+`EntityRecord`.  It issues stable keys, maintains a reverse transform-key →
+entity-key map, and invokes `OnDestroy` callbacks.  The registry removes the
+`EntityRecord` **before** invoking `OnDestroy` so that RAII teardown inside the
+callback (e.g. `TransformHierarchyRegistration`) observes a clean registry
+state.
+
+**`IsEntity`** is a C++ concept satisfied by any type that exposes
+`TransformKey() const -> DataBatchKey`.  It constrains `EntityBatch<T>` so only
+types with a valid transform key can be stored as entities.
+
+**`EntityBatch<T>`** wraps `DataBatch<T>` and auto-wires registration with
+`EntityRegistry` on `Emplace`.  It is non-copyable and non-movable because it
+stores `this` as the `Owner` pointer in each `EntityRecord`; moving would
+silently dangle those pointers.
+
+---
+
+## IsEntity conformance
+
+Any struct that embeds a `TransformNode` satisfies `IsEntity` by forwarding its
+`TransformKey()`:
+
+```cpp
+struct Goblin
+{
+    TransformNode2d Node;
+    // ... gameplay state
+
+    DataBatchKey TransformKey() const { return Node.TransformKey(); }
+};
+```
+
+The `TransformNode` member manages hierarchy registration via RAII.  No extra
+work is needed.
+
+---
+
+## API
+
+### EntityBatch<T>
+
+```cpp
+// Construction — binds to the world's entity registry.
+EntityBatch<Goblin> Goblins{ world.Entities };
+
+// Emplace — registers with EntityRegistry and returns a stable EntityKey.
+EntityKey ek = Goblins.Emplace(world.Domain, Transform2f{});
+
+// Cold-path lookup by EntityKey.
+Goblin* g = Goblins.TryGet(ek);         // nullptr if stale or wrong batch
+
+// Hot-path iteration — direct span, no registry involvement.
+for (Goblin& g : Goblins.GetItems())    { /* ... */ }
+
+size_t n = Goblins.Count();
+bool   empty = Goblins.IsEmpty();
+```
+
+### EntityRegistry
+
+```cpp
+// Usually reached through World::Entities or World::DestroySubtree.
+
+// Destroy a single entity (removes record, then invokes OnDestroy).
+world.Entities.Destroy(ek);
+
+// Destroy an entity and all transform-hierarchy descendants, leaves first.
+world.Entities.DestroySubtree(ek, world.Domain.Hierarchy);
+
+// Convenience wrapper on World — passes Domain.Hierarchy automatically.
+world.DestroySubtree(ek);
+
+// Queries
+const EntityRecord* rec = world.Entities.Find(ek);
+EntityKey fromTransform = world.Entities.FindByTransform(transformKey);
+bool live = world.Entities.IsRegistered(ek);
+size_t n  = world.Entities.Count();
+
+// Remove record only — no OnDestroy callback.
+// Use Destroy() for normal teardown; Unregister() is for cases where the
+// owning batch is already tearing down the item through its own path.
+world.Entities.Unregister(ek);
+```
+
+---
+
+## Idiomatic setup
+
+### Single entity type
+
+```cpp
+struct Goblin
+{
+    TransformNode2d Node;
+    int             Health = 100;
+
+    Goblin(TransformDomain<Transform2f>& domain, const Transform2f& local)
+        : Node(domain, local) {}
+
+    DataBatchKey TransformKey() const { return Node.TransformKey(); }
+};
+
+// Declare the batch once, bound to the world's registry.
+EntityBatch<Goblin> Goblins{ world.Entities };
+
+// Spawn a goblin.
+EntityKey ek = Goblins.Emplace(world.Domain, Transform2f({ 100.0f, 50.0f }));
+
+// Propagate transforms then read world position.
+world.Domain.Propagation.Propagate();
+const Transform2f* t = world.Domain.Transforms.TryGetWorld(
+    Goblins.TryGet(ek)->TransformKey());
+
+// Destroy the goblin.
+world.Entities.Destroy(ek);
+```
+
+### Parent-child subtree destruction
+
+```cpp
+struct Rider { TransformNode2d Node; DataBatchKey TransformKey() const { return Node.TransformKey(); } };
+struct Horse  { TransformNode2d Node; DataBatchKey TransformKey() const { return Node.TransformKey(); } };
+
+EntityBatch<Horse>  Horses{ world.Entities };
+EntityBatch<Rider>  Riders{ world.Entities };
+
+EntityKey horseKey = Horses.Emplace(world.Domain, Transform2f{{ 200.0f, 0.0f }});
+EntityKey riderKey = Riders.Emplace(world.Domain, Transform2f{{   0.0f, 40.0f }});
+
+// Parent the rider to the horse via the transform hierarchy.
+Riders.TryGet(riderKey)->Node.SetParent(Horses.TryGet(horseKey)->Node);
+
+// DestroySubtree removes the rider first (leaf), then the horse (root).
+world.DestroySubtree(horseKey);
+// Both EntityKeys are now stale.
+```
+
+### Hot-path iteration
+
+`EntityBatch<T>::GetItems()` returns a contiguous span of T with no registry
+involvement.  Use it for every per-frame sweep.
+
+```cpp
+// Physics update — no EntityKey needed.
+for (Goblin& g : Goblins.GetItems())
+    ApplyGravity(g);
+
+// Read world transforms for rendering.
+for (const Goblin& g : Goblins.GetItems())
+{
+    const Transform2f* t = world.Domain.Transforms.TryGetWorld(g.TransformKey());
+    if (t) SubmitSprite(t->Position);
+}
+```
+
+---
+
+## Constraints
+
+**`EntityBatch<T>` must outlive all `EntityKey`s it issued.**  The registry
+holds a raw pointer to the batch as `Owner`.  If the batch is destroyed while
+records are still registered, `Destroy()` will call a dangling `OnDestroy`.
+Destroy all entities before tearing down the batch, or ensure the batch lives
+for the full scene lifetime.
+
+**`EntityBatch<T>` is non-copyable and non-movable.**  The `Owner` pointer
+stored in each `EntityRecord` points to `this`.  A move would silently dangle
+every outstanding record.
+
+**Do not call `EntityRegistry::Unregister` from inside `OnDestroy`.**  The
+registry clears the record and reverse-map entry **before** invoking the
+callback.  A second `Unregister` call from inside the callback will no-op
+safely (the key is already gone), but it indicates a double-teardown bug and
+should be fixed.
+
+**`DestroySubtree` collects the full post-order before any destruction
+begins.**  Hierarchy modifications during teardown (e.g. a child's destructor
+reparenting a grandchild) do not affect the collected order.  Nodes that
+disappear from the registry between collection and destruction are silently
+skipped.
+
+**Every entity requires a non-null transform key.**  `EntityRegistry::Register`
+asserts that `record.TransformKey.Value != 0`.  Registering an entity whose
+`TransformNode` was not yet emplaced into a `TransformStore` will fire that
+assertion.
+
+**Do not use `EntityRegistry` as a general-purpose object store.**  It is
+specifically for objects that participate in the transform hierarchy and need
+cross-type destroy routing.  Plain game objects with no parenting requirements
+should use `DataBatch<T>` directly.
+
+---
+
+## Relationship to the rest of the engine
+
+```
+EntityBatch<T>            typed game struct container; auto-registers on Emplace
+       │  Emplace → EntityRegistry::Register(EntityRecord)
+       │
+EntityRegistry            key issuance, reverse transform map, OnDestroy dispatch
+       │  DestroySubtree → TransformHierarchyService::GetChildren (post-order walk)
+       │  Destroy → record removed → OnDestroy(owner, slot) → DataBatch::RemoveKey
+       │
+TransformHierarchyService parent-child graph; read by DestroySubtree to collect order
+       │
+DataBatch<T>              dense storage for the entity struct; slot freed by OnDestroy
+       │
+World<TTransform>         owns EntityRegistry + TransformDomain; exposes DestroySubtree
+```

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -23,7 +23,7 @@ Sencha is early and actively changing. The repository currently contains:
 - Vulkan bootstrap services for instance, device, queues, surface, swapchain, and frames.
 - Vulkan resource caches and helpers: allocator, buffer, image, sampler, shader, pipeline, descriptor, upload context, per-frame scratch, and barrier utilities.
 - A `Renderer` host with pluggable render features, starting with an immediate-mode `SpriteFeature` for batched sprite draws.
-- A `World` domain covering transform hierarchy propagation, reusable transform nodes, and a 2D tilemap.
+- A `World` domain covering transform hierarchy propagation, reusable transform nodes, a 2D tilemap, and an entity registry with typed `EntityBatch<T>` containers and subtree destruction.
 - GoogleTest coverage across core, math/geometry, world, and render code.
 - Examples for input mapping, SDL/Vulkan window startup, transform hierarchy stress testing, and a `JasmineGreen` sprite sample.
 
@@ -45,6 +45,7 @@ engine/
       features/
     window/
     world/
+      entity/
       tilemap/
       transform/
   src/
@@ -88,6 +89,7 @@ Current integrations include:
 World groups engine features that sit on top of the smaller domains:
 
 - `world/transform` — `TransformDomain` (a self-contained transform space), `TransformStore`, `TransformHierarchyService`, propagation order/system, and `TransformNode` for rule-of-zero hierarchy participation.
+- `world/entity` — `EntityRegistry`, `EntityBatch<T>`, `EntityKey`, and `EntityRecord` for stable entity identity, cross-type destroy routing, and subtree destruction.
 - `world/tilemap` — `Tilemap2d` for 2D tile grids.
 
 ### ECS Stance
@@ -126,6 +128,11 @@ test/      GoogleTest-based engine tests.
 |---|---|
 | [docs/shaders.md](shaders.md) | Shader authoring, build pipeline, metadata format, hot-reload, and planned tiers. |
 | [docs/grid.md](grid.md) | `Grid2d<T>` setup, storage model, idiomatic usage, constraints, and its role in the tilemap pipeline. |
+| [docs/transform.md](transform.md) | Transform value types (`Transform2d`, `Transform3d`), hierarchy propagation, transform systems, and domain structure |
+| [docs/render.md](render.md) | `Renderer` architecture, render feature system, Vulkan backend integration, and rendering pipeline overview |
+| [docs/data.md](data.md) | Data containers, batch storage, serialization, and memory management |
+| [docs/audio.md](audio.md) | Audio system design, integration, and usage examples |
+| [docs/entity.md](entity.md) | `EntityBatch<T>`, `EntityRegistry`, `EntityKey`, subtree destruction, and the `IsEntity` concept. |
 
 ## Requirements
 

--- a/docs/transform.md
+++ b/docs/transform.md
@@ -156,9 +156,9 @@ domain.Hierarchy    // TransformHierarchyService — parent-child graph
 domain.Propagation  // TransformPropagationSystem — derives world transforms
 ```
 
-`World<TTransform>` owns one `TransformDomain` for game-world objects.  UI,
-editor gizmos, and particle systems can own independent `TransformDomain`
-instances with no coupling between them.
+`World<TTransform>` owns one `TransformDomain` and one `EntityRegistry` for
+game-world objects.  UI, editor gizmos, and particle systems can own
+independent `TransformDomain` instances with no coupling between them.
 
 ---
 
@@ -344,9 +344,11 @@ TransformPropagationSystem    executes forward pass: worlds[i] = worlds[parent] 
         │
 TransformNode / Tilemap2d     per-object wrappers; own a slot + RAII registration
         │
-World<TTransform>             owns the domain; exposes it to gameplay systems
+EntityBatch<T> / EntityRegistry   typed entity containers + cross-type destroy routing
+        │
+World<TTransform>             owns the domain + EntityRegistry; exposes it to gameplay
 ```
 
-Objects (actors, tilemaps, UI elements, particles) sit at the `TransformNode`
-layer.  They author local transforms and read world transforms.  Everything below
-that line is infrastructure.
+Objects (actors, tilemaps, UI elements, particles) sit at the `TransformNode` /
+`EntityBatch` layer.  They author local transforms and read world transforms.
+Everything below that line is infrastructure.

--- a/engine/include/world/World.h
+++ b/engine/include/world/World.h
@@ -3,6 +3,8 @@
 #include <core/service/IService.h>
 #include <math/geometry/2d/Transform2d.h>
 #include <math/geometry/3d/Transform3d.h>
+#include <world/entity/EntityKey.h>
+#include <world/entity/EntityRegistry.h>
 #include <world/transform/TransformDomain.h>
 
 //=============================================================================
@@ -10,9 +12,8 @@
 //
 // Gameplay-facing service bundle for transform-dimensioned game-world state.
 // World owns a TransformDomain (the self-contained transform space used by
-// the game simulation) and registers with ServiceHost so gameplay code can
-// resolve it and reach transform state through `Transforms` and
-// `TransformHierarchy`.
+// the game simulation) and an EntityRegistry, and registers with ServiceHost
+// so gameplay code can resolve it by dimension.
 //
 // World is NOT the only TransformDomain in the engine. UI, editor gizmos, or
 // any other subsystem that wants an isolated coordinate space creates its own
@@ -33,11 +34,23 @@ public:
 	{
 	}
 
-	// -- The transform space owned by this world --------------------------
+	// -- The transform space owned by this world ---------------------------
 
 	TransformDomain<TTransform> Domain;
 
-	// -- Gameplay-facing shortcuts (forward into Domain) ------------------
+	// -- Entity registry ---------------------------------------------------
+
+	EntityRegistry Entities;
+
+	// Destroy an entity and all of its transform-hierarchy descendants,
+	// leaves first. Convenience wrapper — passes Domain.Hierarchy so callers
+	// don't have to.
+	void DestroySubtree(EntityKey root)
+	{
+		Entities.DestroySubtree(root, Domain.Hierarchy);
+	}
+
+	// -- Gameplay-facing shortcuts (forward into Domain) -------------------
 
 	TransformStore<TTransform>& Transforms;
 	TransformHierarchyService& TransformHierarchy;

--- a/engine/include/world/entity/EntityBatch.h
+++ b/engine/include/world/entity/EntityBatch.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <core/batch/DataBatch.h>
+#include <core/batch/DataBatchKey.h>
+#include <span>
+#include <world/entity/EntityKey.h>
+#include <world/entity/EntityRecord.h>
+#include <world/entity/EntityRegistry.h>
+#include <world/entity/IsEntity.h>
+
+//=============================================================================
+// EntityBatch<T>
+//
+// Typed entity container. Wraps DataBatch<T> and auto-wires registration with
+// EntityRegistry on emplace. T must satisfy IsEntity — it must expose a
+// TransformKey() const -> DataBatchKey method. The minimal conforming struct
+// just forwards from its embedded TransformNode:
+//
+//   struct Goblin
+//   {
+//       TransformNode2d Node;
+//       // ... state
+//       DataBatchKey TransformKey() const { return Node.TransformKey(); }
+//   };
+//
+//   EntityBatch<Goblin> Goblins{ world.Entities };
+//   EntityKey ek = Goblins.Emplace(domain, Transform2f{});
+//   world.DestroySubtree(ek);  // recursively destroys Goblin + all children
+//
+// EntityBatch<T> is non-copyable and non-movable because it stores `this` as
+// the Owner pointer in each EntityRecord. Moving would silently dangle those
+// pointers.
+//
+// Hot-path iteration should use GetItems() directly — it returns a contiguous
+// span of T with no registry involvement. EntityKey -> T lookup via TryGet()
+// is a cold-path operation (one registry Find + one batch TryGet).
+//=============================================================================
+template <IsEntity T>
+class EntityBatch
+{
+public:
+	explicit EntityBatch(EntityRegistry& registry)
+		: Registry(registry)
+	{}
+
+	EntityBatch(const EntityBatch&) = delete;
+	EntityBatch& operator=(const EntityBatch&) = delete;
+	EntityBatch(EntityBatch&&) = delete;
+	EntityBatch& operator=(EntityBatch&&) = delete;
+
+	// -- Emplacement -----------------------------------------------------------
+
+	template <typename... Args>
+	EntityKey Emplace(Args&&... args)
+	{
+		DataBatchKey batchKey = Batch.EmplaceUnowned(std::forward<Args>(args)...);
+		T* item = Batch.TryGet(batchKey);
+
+		return Registry.Register({
+			.TransformKey = item->TransformKey(),
+			.Owner        = this,
+			.OwnerSlot    = batchKey.Value,
+			.OnDestroy    = &EntityBatch::OnDestroyItem,
+		});
+	}
+
+	// -- Access ----------------------------------------------------------------
+
+	// Look up an entity struct by entity key. Cold path — goes through the
+	// registry to resolve the batch slot. Use GetItems() for bulk iteration.
+	T* TryGet(EntityKey key)
+	{
+		const EntityRecord* record = Registry.Find(key);
+		if (!record || record->Owner != this) return nullptr;
+		return Batch.TryGet(DataBatchKey{ record->OwnerSlot });
+	}
+
+	const T* TryGet(EntityKey key) const
+	{
+		const EntityRecord* record = Registry.Find(key);
+		if (!record || record->Owner != this) return nullptr;
+		return Batch.TryGet(DataBatchKey{ record->OwnerSlot });
+	}
+
+	// Contiguous span of all live entities. Does not involve EntityRegistry.
+	std::span<T>       GetItems()       { return Batch.GetItems(); }
+	std::span<const T> GetItems() const { return Batch.GetItems(); }
+
+	size_t Count()   const { return Batch.Count(); }
+	bool   IsEmpty() const { return Batch.IsEmpty(); }
+
+private:
+	static void OnDestroyItem(void* self, uint32_t slot)
+	{
+		static_cast<EntityBatch<T>*>(self)->Batch.RemoveKey(DataBatchKey{ slot });
+	}
+
+	DataBatch<T>    Batch;
+	EntityRegistry& Registry;
+};

--- a/engine/include/world/entity/EntityKey.h
+++ b/engine/include/world/entity/EntityKey.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <core/batch/DataBatchKey.h>
+#include <cstddef>
+#include <functional>
+
+//=============================================================================
+// EntityKey
+//
+// Stable handle identifying an entity inside an EntityRegistry. Wraps a
+// DataBatchKey so it carries generation information — stale keys stop
+// resolving after the entity is destroyed and its slot is reused.
+//
+// Default-constructed EntityKey is null: operator bool() returns false.
+//=============================================================================
+struct EntityKey
+{
+	DataBatchKey Value;
+
+	constexpr EntityKey() = default;
+	constexpr explicit EntityKey(DataBatchKey key) : Value(key) {}
+
+	explicit operator bool() const { return Value.Value != 0; }
+	bool operator==(const EntityKey&) const = default;
+};
+
+template<> struct std::hash<EntityKey>
+{
+	std::size_t operator()(const EntityKey& k) const noexcept
+	{
+		return std::hash<uint32_t>{}(k.Value.Value);
+	}
+};

--- a/engine/include/world/entity/EntityRecord.h
+++ b/engine/include/world/entity/EntityRecord.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <core/batch/DataBatchKey.h>
+
+//=============================================================================
+// EntityRecord
+//
+// Per-entity metadata stored inside EntityRegistry. Holds the entity's
+// transform key (for hierarchy lookup) and a type-erased destroy callback
+// so the registry can tear down any entity type without knowing its concrete
+// type.
+//
+// Owner / OwnerSlot / OnDestroy form a triad:
+//   Owner     — opaque pointer to the EntityBatch<T> that owns this entity
+//   OwnerSlot — the raw DataBatchKey.Value the batch uses to address the item
+//   OnDestroy — called by EntityRegistry::Destroy() to remove the entity from
+//               its owning batch; must NOT call EntityRegistry::Unregister —
+//               the registry handles that after the callback returns
+//=============================================================================
+struct EntityRecord
+{
+	DataBatchKey TransformKey;
+	void*        Owner     = nullptr;
+	uint32_t     OwnerSlot = 0;
+	void (*OnDestroy)(void* owner, uint32_t slot) = nullptr;
+};

--- a/engine/include/world/entity/EntityRegistry.h
+++ b/engine/include/world/entity/EntityRegistry.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <core/batch/DataBatch.h>
+#include <core/batch/DataBatchKey.h>
+#include <unordered_map>
+#include <vector>
+#include <world/entity/EntityKey.h>
+#include <world/entity/EntityRecord.h>
+#include <world/transform/TransformHierarchyService.h>
+
+//=============================================================================
+// EntityRegistry
+//
+// Central registry mapping EntityKey -> EntityRecord. Lives inside
+// World<TTransform> — one registry per world dimension (2D or 3D).
+//
+// Responsibilities:
+//   - Issue stable EntityKeys backed by DataBatch generation tracking
+//   - Maintain the single transform-key -> entity-key reverse map
+//   - Invoke type-erased OnDestroy callbacks for Destroy() and DestroySubtree()
+//
+// The registry does NOT own entity structs. Those are owned by the
+// application's EntityBatch<T>. The registry only owns the EntityRecord
+// metadata and the reverse lookup.
+//
+// Destroy ordering: the registry removes the EntityRecord and reverse-map
+// entry BEFORE invoking OnDestroy. This ensures a clean registry state
+// during any RAII teardown (TransformHierarchyRegistration, etc.) triggered
+// by the callback.
+//=============================================================================
+class EntityRegistry
+{
+public:
+	EntityRegistry() = default;
+
+	EntityRegistry(const EntityRegistry&) = delete;
+	EntityRegistry& operator=(const EntityRegistry&) = delete;
+	EntityRegistry(EntityRegistry&&) = delete;
+	EntityRegistry& operator=(EntityRegistry&&) = delete;
+
+	// -- Registration ----------------------------------------------------------
+
+	// Register an entity and return its stable key.
+	// record.TransformKey must be non-null — all entities require a transform.
+	EntityKey Register(const EntityRecord& record);
+
+	// Remove an entity's record without invoking its destroy callback.
+	// Prefer Destroy() for normal teardown.
+	void Unregister(EntityKey key);
+
+	// -- Destruction -----------------------------------------------------------
+
+	// Remove the entity's record and invoke its OnDestroy callback.
+	// The record is removed from the registry before OnDestroy fires so that
+	// RAII teardown inside the callback (e.g. TransformHierarchyRegistration)
+	// observes a clean registry state.
+	void Destroy(EntityKey key);
+
+	// Destroy an entity and all of its transform-hierarchy descendants,
+	// leaves first. The full subtree is collected before any destruction
+	// begins so that hierarchy modifications during teardown do not affect
+	// the traversal order.
+	void DestroySubtree(EntityKey root, const TransformHierarchyService& hierarchy);
+
+	// -- Queries ---------------------------------------------------------------
+
+	const EntityRecord* Find(EntityKey key) const;
+	EntityKey           FindByTransform(DataBatchKey transformKey) const;
+	bool                IsRegistered(EntityKey key) const;
+	size_t              Count() const;
+
+private:
+	static void CollectPostOrder(
+		const TransformHierarchyService& hierarchy,
+		DataBatchKey key,
+		std::vector<DataBatchKey>& out);
+
+	DataBatch<EntityRecord>                Records;
+	std::unordered_map<uint32_t, uint32_t> TransformToEntity;
+};

--- a/engine/include/world/entity/IsEntity.h
+++ b/engine/include/world/entity/IsEntity.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <core/batch/DataBatchKey.h>
+
+//=============================================================================
+// IsEntity concept
+//
+// Satisfied by any type that exposes a TransformKey() const -> DataBatchKey
+// method. Used to constrain EntityBatch<T> so only types with a valid
+// transform key can be stored as entities.
+//
+// The minimal conforming struct:
+//
+//   struct Goblin
+//   {
+//       TransformNode2d Node;
+//       DataBatchKey TransformKey() const { return Node.TransformKey(); }
+//   };
+//=============================================================================
+template <typename T>
+concept IsEntity = requires(const T& t)
+{
+	{ t.TransformKey() } -> std::same_as<DataBatchKey>;
+};

--- a/engine/src/world/entity/EntityRegistry.cpp
+++ b/engine/src/world/entity/EntityRegistry.cpp
@@ -1,0 +1,87 @@
+#include <world/entity/EntityRegistry.h>
+
+EntityKey EntityRegistry::Register(const EntityRecord& record)
+{
+	assert(record.TransformKey.Value != 0 && "Entities must have a transform.");
+	assert(record.Owner != nullptr     && "EntityRecord Owner must not be null.");
+	assert(record.OnDestroy != nullptr && "EntityRecord OnDestroy must not be null.");
+
+	DataBatchKey batchKey = Records.EmplaceUnowned(record);
+	TransformToEntity[record.TransformKey.Value] = batchKey.Value;
+	return EntityKey{ batchKey };
+}
+
+void EntityRegistry::Unregister(EntityKey key)
+{
+	const EntityRecord* record = Records.TryGet(key.Value);
+	if (!record) return;
+
+	TransformToEntity.erase(record->TransformKey.Value);
+	Records.RemoveKey(key.Value);
+}
+
+void EntityRegistry::Destroy(EntityKey key)
+{
+	const EntityRecord* record = Records.TryGet(key.Value);
+	if (!record) return;
+
+	// Capture before the record is invalidated by RemoveKey.
+	auto onDestroy    = record->OnDestroy;
+	auto owner        = record->Owner;
+	auto ownerSlot    = record->OwnerSlot;
+	auto transformKey = record->TransformKey;
+
+	TransformToEntity.erase(transformKey.Value);
+	Records.RemoveKey(key.Value);
+
+	if (onDestroy)
+		onDestroy(owner, ownerSlot);
+}
+
+void EntityRegistry::DestroySubtree(EntityKey root, const TransformHierarchyService& hierarchy)
+{
+	const EntityRecord* rootRecord = Records.TryGet(root.Value);
+	if (!rootRecord) return;
+
+	std::vector<DataBatchKey> postOrder;
+	CollectPostOrder(hierarchy, rootRecord->TransformKey, postOrder);
+
+	for (DataBatchKey tkey : postOrder)
+	{
+		EntityKey ek = FindByTransform(tkey);
+		if (ek)
+			Destroy(ek);
+	}
+}
+
+const EntityRecord* EntityRegistry::Find(EntityKey key) const
+{
+	return Records.TryGet(key.Value);
+}
+
+EntityKey EntityRegistry::FindByTransform(DataBatchKey transformKey) const
+{
+	auto it = TransformToEntity.find(transformKey.Value);
+	if (it == TransformToEntity.end()) return EntityKey{};
+	return EntityKey{ DataBatchKey{ it->second } };
+}
+
+bool EntityRegistry::IsRegistered(EntityKey key) const
+{
+	return Records.Contains(key.Value);
+}
+
+size_t EntityRegistry::Count() const
+{
+	return Records.Count();
+}
+
+void EntityRegistry::CollectPostOrder(
+	const TransformHierarchyService& hierarchy,
+	DataBatchKey key,
+	std::vector<DataBatchKey>& out)
+{
+	for (uint32_t childVal : hierarchy.GetChildren(key))
+		CollectPostOrder(hierarchy, DataBatchKey{ childVal }, out);
+	out.push_back(key);
+}


### PR DESCRIPTION
Sencha is now a more opinionated engine, with a first-class contract for what an entity is.

A few months ago I would have resisted this harder, but my view of Sencha has shifted more toward “engine” than “framework.” That makes stronger built-in assumptions feel acceptable, as long as they stay narrow and explicit.

We are also rejecting inheritance below the bootstrap service-hosting layer. If that holds, then the only thing that meaningfully qualifies as an entity is possession of a TransformNode, which I think is still a lenient contract for experimentation. :)