### PR TITLE
Refactor TilemapRenderFeature to use a submission model for tile data

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -303,7 +303,7 @@ DataBatch<T>                implements ILifetimeOwner
 Systems (ECS-style loops)
        │  for (auto& item : batch.GetItems()) { … }
        │
-TilemapRenderFeature / TransformStore / AssetCache
+TransformStore / AssetCache
        │  store non-owning DataBatch* pointers
        │  read Items[] directly; never remove
        │

--- a/docs/grid.md
+++ b/docs/grid.md
@@ -195,8 +195,8 @@ Tilemap2d                 adds: transform slot, hierarchy registration, tile siz
 TilemapRenderState        adds: tileset texture, tileset layout, layer order
        │                  lives in: DataBatch<TilemapRenderState> (separate array)
        │
-TilemapRenderFeature      sweeps DataBatch<TilemapRenderState>, resolves MapKey
-                          → Tilemap2d, reads world transform, emits GpuTile instances
+TilemapRenderFeature      receives pre-baked GpuTile spans via Submit();
+                          sorts by sortKey, uploads, one draw per batch
 ```
 
 Maps and render states are intentionally in separate batches.  A map can exist

--- a/docs/render.md
+++ b/docs/render.md
@@ -160,29 +160,20 @@ a single instanced draw.  The accumulator is cleared automatically after
 
 ### Tilemap rendering
 
-`TilemapRenderFeature` takes non-owning references to the game's
-`DataBatch<Tilemap2d>`, `DataBatch<TilemapRenderState>`, and
-`TransformStore<Transform2f>` at construction time.  These batches must outlive
-the `Renderer`.
+`TilemapRenderFeature` is a dumb batcher, mirroring `SpriteFeature`.  Game or
+system code is responsible for baking tile data into `GpuTile` arrays and
+calling `Submit()` each frame.  The feature has no opinion on *how* tiles are
+baked; a `TilemapRenderSystem` that dirty-tracks maps and transforms is the
+expected driver.
 
 ```cpp
-DataBatch<Tilemap2d>          maps;
-DataBatch<TilemapRenderState> renderStates;
-// ... populate maps and transforms ...
-
 auto* tilemap =
-    renderer->AddFeature(std::make_unique<TilemapRenderFeature>(
-        maps, renderStates, world.Transforms));
+    renderer->AddFeature(std::make_unique<TilemapRenderFeature>());
 
-// Add a render state to make a map visible.
-TilemapRenderState state;
-state.MapKey        = mapHandle.GetToken();
-state.TransformKey  = mapHandle.GetTransformKey();
-state.TilesetTexture = tilesetSlot;  // BindlessImageIndex
-state.TilesetColumns = 8;
-state.TilesetRows    = 8;
-state.LayerZIndex    = 0;            // drawn before higher z-indices
-renderStates.Emplace(state);
+// Each frame, before renderer.DrawFrame():
+// Build the GpuTile array for one layer (world-space centres, UVs, sin/cos).
+std::vector<TilemapRenderFeature::GpuTile> tiles = BakeTiles(map, transform, state);
+tilemap->Submit(tiles, state.LayerZIndex);
 ```
 
 ### Texture registration
@@ -242,10 +233,10 @@ never calls `Contribute()` itself — that is a pre-device hook for game boot
 code.  If a feature folds extensions into the bootstrap policy, the game must
 call `Contribute()` on the feature before constructing `VulkanDeviceService`.
 
-**`TilemapRenderFeature` data batches must outlive the `Renderer`.**  The
-feature stores non-owning pointers to the game's `DataBatch<Tilemap2d>` and
-`DataBatch<TilemapRenderState>`.  Destroying either batch while the renderer is
-alive is undefined behaviour.
+**`TilemapRenderFeature` does not own or retain game data.**  The feature copies
+submitted `GpuTile` spans into a per-frame scratch buffer and clears them after
+`OnDraw`.  Callers are free to destroy or mutate their tile arrays immediately
+after `Submit()` returns.
 
 ---
 
@@ -258,7 +249,7 @@ arrays or calling `Submit()`:
 ```
 Game logic / systems
        │  calls Submit() on SpriteFeature
-       │  populates DataBatch<TilemapRenderState>
+       │  calls Submit(tiles, sortKey) on TilemapRenderFeature
        │
 Renderer::DrawFrame()
        │  iterates PhaseBuckets[MainColor]
@@ -268,10 +259,9 @@ IRenderFeature::OnDraw(FrameContext)
 SpriteFeature            reads Pending[], stable-sorts by SortKey,
        │                 uploads via VulkanFrameScratch, one instanced draw
        │
-TilemapRenderFeature     sweeps DataBatch<TilemapRenderState> by LayerZIndex,
-                         resolves MapKey → Tilemap2d, reads world transform,
-                         emits GpuTile instances into VulkanFrameScratch,
-                         one instanced draw per tilemap layer
+TilemapRenderFeature     stable-sorts Batches[] by SortKey,
+                         uploads flat GpuTile array via VulkanFrameScratch,
+                         one instanced draw per batch (firstInstance offset)
 ```
 
 `SpriteFeature` and `TilemapRenderFeature` share the same SPIR-V (sprite

--- a/engine/include/render/features/TilemapRenderFeature.h
+++ b/engine/include/render/features/TilemapRenderFeature.h
@@ -1,17 +1,13 @@
 #pragma once
 
-#include <core/batch/DataBatch.h>
-#include <math/geometry/2d/Transform2d.h>
 #include <render/Renderer.h>
 #include <render/backend/vulkan/VulkanDescriptorCache.h>
 #include <render/backend/vulkan/VulkanPipelineCache.h>
 #include <render/backend/vulkan/VulkanShaderCache.h>
-#include <render/features/TilemapRenderState.h>
-#include <world/tilemap/Tilemap2d.h>
-#include <world/transform/TransformStore.h>
 #include <vulkan/vulkan.h>
 
 #include <cstdint>
+#include <span>
 #include <vector>
 
 class VulkanBufferService;
@@ -22,48 +18,33 @@ class VulkanFrameScratch;
 //
 // IRenderFeature that drives the tilemap draw pass each frame.
 //
-// DOD contract:
-//   - Maps and RenderStates live in separate DataBatch arrays owned by the
-//     caller (typically the game bootstrap). This feature holds non-owning
-//     references to both. Lifetimes must outlive the Renderer.
-//   - OnDraw() sweeps DataBatch<TilemapRenderState> in LayerZIndex order,
-//     resolves each state's MapKey and TransformKey, then emits one instanced
-//     draw call per tilemap layer into the per-frame scratch buffer.
-//   - No virtual dispatch, no inheritance, no heap allocation per tile.
+// Usage model (mirrors SpriteFeature):
 //
-// Tile encoding:
-//   - Tile ID 0 is the "empty" sentinel; no quad is emitted for it.
-//   - Tile IDs 1..N map to tileset index N-1, laid out row-major in the
-//     spritesheet: col = (id-1) % TilesetColumns, row = (id-1) / TilesetColumns.
+//   TilemapRenderFeature* tiles =
+//       renderer.AddFeature(std::make_unique<TilemapRenderFeature>());
+//
+//   // Each frame, before renderer.DrawFrame():
+//   tiles->Submit(gpuTileSpan, layerZIndex);
+//   renderer.DrawFrame();
+//
+// The feature is a dumb batcher: it accumulates pre-baked GpuTile instances
+// submitted by game or system code, stable-sorts the batches by sort key,
+// uploads the tile data through VulkanFrameScratch as a per-instance vertex
+// buffer, and issues one instanced draw per batch. No staging, no retained
+// state, no per-tile pointer chasing.
+//
+// Tile baking (world-space transforms, UV rect computation, sin/cos) is the
+// caller's responsibility. A TilemapRenderSystem or similar should track dirty
+// state and only rebuild tile arrays when the map, transform, or render state
+// actually changes.
 //
 // GPU program:
 //   - Reuses the sprite vertex/fragment SPIR-V (instanced quads, bindless
 //     texture array). GpuTile is layout-compatible with SpriteFeature::GpuInstance.
-//   - Tiles are axis-aligned at their natural size; SinRot=0, CosRot=1.
-//   - Tilemap world transforms (translation, rotation, non-uniform scale) are
-//     applied to each tile center via Transform2d::TransformPoint before upload.
 //=============================================================================
 class TilemapRenderFeature : public IRenderFeature
 {
 public:
-    // Maps        — game-owned DataBatch<Tilemap2d>; feature reads, never writes.
-    // RenderStates — game-owned DataBatch<TilemapRenderState>; feature reads, never writes.
-    // Transforms  — world transform store; TryGetWorld(TransformKey) is called per-map per-frame.
-    TilemapRenderFeature(
-        DataBatch<Tilemap2d>&          maps,
-        DataBatch<TilemapRenderState>& renderStates,
-        TransformStore<Transform2f>&   transforms);
-
-    ~TilemapRenderFeature() override = default;
-
-    // -- IRenderFeature -------------------------------------------------------
-
-    [[nodiscard]] RenderPhase GetPhase() const override { return RenderPhase::MainColor; }
-    void Setup(const RendererServices& services) override;
-    void OnDraw(const FrameContext& frame) override;
-    void Teardown() override;
-
-private:
     // 48-byte per-tile instance record — layout-compatible with
     // SpriteFeature::GpuInstance so the sprite SPIR-V can be reused directly.
     struct GpuTile
@@ -74,11 +55,35 @@ private:
         float    UvMax[2];        // UV rect top-right on the tileset
         uint32_t Color;           // Packed rgba8 tint (0xFFFFFFFF = opaque white)
         uint32_t TextureIndex;    // Bindless tileset slot
-        float    SinRot;          // 0.0f — tiles are drawn axis-aligned
-        float    CosRot;          // 1.0f — tiles are drawn axis-aligned
+        float    SinRot;          // sin(worldRotation) — 0.0f for axis-aligned tiles
+        float    CosRot;          // cos(worldRotation) — 1.0f for axis-aligned tiles
     };
     static_assert(sizeof(GpuTile) == 48, "GpuTile must remain 48 bytes to match sprite layout");
 
+    TilemapRenderFeature() = default;
+    ~TilemapRenderFeature() override = default;
+
+    // -- IRenderFeature -------------------------------------------------------
+
+    [[nodiscard]] RenderPhase GetPhase() const override { return RenderPhase::MainColor; }
+    void Setup(const RendererServices& services) override;
+    void OnDraw(const FrameContext& frame) override;
+    void Teardown() override;
+
+    // -- Public submission API ------------------------------------------------
+
+    // Append a pre-baked tile layer to this frame's batch.
+    // tiles   — caller-owned span; contents are copied immediately.
+    // sortKey — ascending draw order (lower draws first / behind).
+    void Submit(std::span<const GpuTile> tiles, int32_t sortKey = 0);
+
+    // Drop all pending tile data without drawing. OnDraw clears automatically;
+    // call this only when aborting a frame before DrawFrame.
+    void ClearPending();
+
+    [[nodiscard]] bool IsValid() const { return Valid; }
+
+private:
     // Per-draw UBO written into the frame scratch ring.
     // std140-padded to 16 bytes; must match frame_ubo.glsli.
     struct FrameUbo
@@ -87,21 +92,24 @@ private:
         float _pad[2];
     };
 
+    // One entry per Submit call, sorted by SortKey in OnDraw.
+    struct Batch
+    {
+        int32_t  SortKey;
+        uint32_t Offset; // First tile index in TileData
+        uint32_t Count;  // Number of tiles in this batch
+    };
+
     [[nodiscard]] bool BuildPipeline(VkFormat colorFormat);
 
-    // Non-owning references to game-side DataBatch instances.
-    DataBatch<Tilemap2d>*          Maps         = nullptr;
-    DataBatch<TilemapRenderState>* RenderStates = nullptr;
-    TransformStore<Transform2f>*   Transforms   = nullptr;
-
     // Cached service pointers (populated in Setup; never re-queried on hot path).
-    LoggingProvider*       Logging      = nullptr;
+    LoggingProvider*       Logging       = nullptr;
     VulkanDeviceService*   DeviceService = nullptr;
-    VulkanBufferService*   Buffers      = nullptr;
-    VulkanShaderCache*     Shaders      = nullptr;
-    VulkanPipelineCache*   Pipelines    = nullptr;
-    VulkanDescriptorCache* Descriptors  = nullptr;
-    VulkanFrameScratch*    Scratch      = nullptr;
+    VulkanBufferService*   Buffers       = nullptr;
+    VulkanShaderCache*     Shaders       = nullptr;
+    VulkanPipelineCache*   Pipelines     = nullptr;
+    VulkanDescriptorCache* Descriptors   = nullptr;
+    VulkanFrameScratch*    Scratch       = nullptr;
 
     ShaderHandle     VertexShader;
     ShaderHandle     FragmentShader;
@@ -109,11 +117,10 @@ private:
     VkPipeline       CachedPipeline    = VK_NULL_HANDLE;
     VkFormat         CachedColorFormat = VK_FORMAT_UNDEFINED;
 
-    // Per-frame tile instance accumulator. Cleared at the end of every OnDraw.
-    std::vector<GpuTile>   Pending;
-    // Scratch index array for sorting render states by LayerZIndex without
-    // mutating the DataBatch. Retained across frames to avoid reallocation.
-    std::vector<uint32_t>  SortedIndices;
+    // Flat tile store — tiles from all Submit calls concatenated in arrival order.
+    // Batches index into this array via Offset + Count.
+    std::vector<GpuTile> TileData;
+    std::vector<Batch>   Batches;
 
     bool Valid = false;
 };

--- a/engine/src/render/backend/vulkan/features/TilemapRenderFeature.cpp
+++ b/engine/src/render/backend/vulkan/features/TilemapRenderFeature.cpp
@@ -14,20 +14,7 @@
 #include <render/backend/vulkan/VulkanShaderCache.h>
 
 #include <algorithm>
-#include <cmath>
 #include <cstring>
-
-// ── Construction ─────────────────────────────────────────────────────────────
-
-TilemapRenderFeature::TilemapRenderFeature(
-    DataBatch<Tilemap2d>&          maps,
-    DataBatch<TilemapRenderState>& renderStates,
-    TransformStore<Transform2f>&   transforms)
-    : Maps(&maps)
-    , RenderStates(&renderStates)
-    , Transforms(&transforms)
-{
-}
 
 // ── IRenderFeature: Setup ─────────────────────────────────────────────────────
 
@@ -88,9 +75,25 @@ void TilemapRenderFeature::Teardown()
     CachedPipeline     = VK_NULL_HANDLE;
     CachedColorFormat  = VK_FORMAT_UNDEFINED;
     PipelineLayout     = VK_NULL_HANDLE;
-    Pending.clear();
-    Pending.shrink_to_fit();
+    ClearPending();
     Valid = false;
+}
+
+// ── Public submission API ─────────────────────────────────────────────────────
+
+void TilemapRenderFeature::Submit(std::span<const GpuTile> tiles, int32_t sortKey)
+{
+    if (!Valid || tiles.empty()) return;
+
+    const auto offset = static_cast<uint32_t>(TileData.size());
+    TileData.insert(TileData.end(), tiles.begin(), tiles.end());
+    Batches.push_back({ sortKey, offset, static_cast<uint32_t>(tiles.size()) });
+}
+
+void TilemapRenderFeature::ClearPending()
+{
+    TileData.clear();
+    Batches.clear();
 }
 
 // ── Pipeline ──────────────────────────────────────────────────────────────────
@@ -167,106 +170,17 @@ bool TilemapRenderFeature::BuildPipeline(VkFormat colorFormat)
 
 void TilemapRenderFeature::OnDraw(const FrameContext& frame)
 {
-    if (!Valid) return;
-
-    // ── Sweep render states ───────────────────────────────────────────────────
-    //
-    // Build a sorted view of active render states (ascending LayerZIndex).
-    // We sort indices rather than the batch itself so the DataBatch is not
-    // mutated and its generational keys stay stable.
-
-    std::span<const TilemapRenderState> states = RenderStates->GetItems();
-    if (states.empty()) return;
-
-    // Collect indices sorted by LayerZIndex.
-    SortedIndices.clear();
-    SortedIndices.resize(states.size());
-    for (size_t i = 0; i < states.size(); ++i)
-        SortedIndices[i] = static_cast<uint32_t>(i);
-
-    std::stable_sort(SortedIndices.begin(), SortedIndices.end(),
-        [&](uint32_t a, uint32_t b)
-        {
-            return states[a].LayerZIndex < states[b].LayerZIndex;
-        });
-
-    // ── Generate tile instances ───────────────────────────────────────────────
-
-    Pending.clear();
-
-    for (uint32_t stateIdx : SortedIndices)
-    {
-        const TilemapRenderState& rs = states[stateIdx];
-        if (!rs.TilesetTexture.IsValid()) continue;
-
-        const Tilemap2d* map = Maps->TryGet(rs.MapKey);
-        if (!map) continue;
-
-        const Transform2f* worldXf = Transforms->TryGetWorld(rs.TransformKey);
-        if (!worldXf) continue;
-
-        const uint32_t cols     = map->Width();
-        const uint32_t rows     = map->Height();
-        const float    tileSize = map->GetTileSize();
-        const float    half     = tileSize * 0.5f;
-
-        // Derive per-tile scale from the world transform's Scale.
-        // If scale is non-uniform, tiles are stretched; this is intentional.
-        const float halfW = half * worldXf->Scale.X;
-        const float halfH = half * worldXf->Scale.Y;
-
-        const float sinRot = std::sin(worldXf->Rotation);
-        const float cosRot = std::cos(worldXf->Rotation);
-
-        const float invCols = rs.TilesetColumns > 0
-            ? 1.0f / static_cast<float>(rs.TilesetColumns) : 1.0f;
-        const float invRows = rs.TilesetRows > 0
-            ? 1.0f / static_cast<float>(rs.TilesetRows) : 1.0f;
-
-        for (uint32_t row = 0; row < rows; ++row)
-        {
-            for (uint32_t col = 0; col < cols; ++col)
-            {
-                const uint32_t tileId = map->GetTile(col, row);
-                if (tileId == 0) continue; // 0 == empty cell
-
-                // Tile IDs are 1-based; tileset index = tileId - 1.
-                const uint32_t tsIndex = tileId - 1u;
-                const uint32_t tsCol   = tsIndex % rs.TilesetColumns;
-                const uint32_t tsRow   = tsIndex / rs.TilesetColumns;
-
-                // Local centre of this tile in the tilemap's local space.
-                const float localX = (static_cast<float>(col) + 0.5f) * tileSize;
-                const float localY = (static_cast<float>(row) + 0.5f) * tileSize;
-
-                // World centre via full TRS (TransformPoint applies scale then rotate then translate).
-                const Vec<2, float> worldCentre =
-                    worldXf->TransformPoint(Vec<2, float>(localX, localY));
-
-                GpuTile& t        = Pending.emplace_back();
-                t.Center[0]       = worldCentre.X;
-                t.Center[1]       = worldCentre.Y;
-                t.HalfExtents[0]  = halfW;
-                t.HalfExtents[1]  = halfH;
-                t.UvMin[0]        = static_cast<float>(tsCol)     * invCols;
-                t.UvMin[1]        = static_cast<float>(tsRow)     * invRows;
-                t.UvMax[0]        = static_cast<float>(tsCol + 1) * invCols;
-                t.UvMax[1]        = static_cast<float>(tsRow + 1) * invRows;
-                t.Color           = 0xFFFFFFFFu; // opaque white
-                t.TextureIndex    = rs.TilesetTexture.Value;
-                t.SinRot          = sinRot;
-                t.CosRot          = cosRot;
-            }
-        }
-    }
-
-    if (Pending.empty()) return;
+    if (!Valid || Batches.empty()) return;
 
     if (!BuildPipeline(frame.TargetFormat))
     {
-        Pending.clear();
+        ClearPending();
         return;
     }
+
+    // Sort batches ascending by SortKey so lower layers draw first (behind).
+    std::stable_sort(Batches.begin(), Batches.end(),
+        [](const Batch& a, const Batch& b) { return a.SortKey < b.SortKey; });
 
     // ── Upload frame UBO ──────────────────────────────────────────────────────
 
@@ -274,7 +188,7 @@ void TilemapRenderFeature::OnDraw(const FrameContext& frame)
         Scratch->AllocateUniform(sizeof(FrameUbo));
     if (!uboAlloc.IsValid())
     {
-        Pending.clear();
+        ClearPending();
         return;
     }
 
@@ -288,21 +202,21 @@ void TilemapRenderFeature::OnDraw(const FrameContext& frame)
     // ── Upload tile instance buffer ───────────────────────────────────────────
 
     const VkDeviceSize instanceBytes =
-        sizeof(GpuTile) * static_cast<VkDeviceSize>(Pending.size());
+        sizeof(GpuTile) * static_cast<VkDeviceSize>(TileData.size());
     const VulkanFrameScratch::Allocation vboAlloc =
         Scratch->AllocateVertex(instanceBytes);
     if (!vboAlloc.IsValid())
     {
-        Pending.clear();
+        ClearPending();
         return;
     }
 
-    std::memcpy(vboAlloc.Mapped, Pending.data(), instanceBytes);
+    std::memcpy(vboAlloc.Mapped, TileData.data(), instanceBytes);
 
     const VkBuffer ringBuffer = Buffers->GetBuffer(vboAlloc.Buffer);
     if (ringBuffer == VK_NULL_HANDLE)
     {
-        Pending.clear();
+        ClearPending();
         return;
     }
 
@@ -335,8 +249,11 @@ void TilemapRenderFeature::OnDraw(const FrameContext& frame)
     const VkDeviceSize vboOffset = vboAlloc.Offset;
     vkCmdBindVertexBuffers(frame.Cmd, 0, 1, &ringBuffer, &vboOffset);
 
-    // 6 vertices per tile (two triangles, no index buffer), N instances.
-    vkCmdDraw(frame.Cmd, 6, static_cast<uint32_t>(Pending.size()), 0, 0);
+    // One draw call per batch, in sorted order.
+    // firstInstance offsets into the flat tile VBO so batches are drawn
+    // in z-order without any re-copy or reorder of the tile data.
+    for (const Batch& batch : Batches)
+        vkCmdDraw(frame.Cmd, 6, batch.Count, 0, batch.Offset);
 
-    Pending.clear();
+    ClearPending();
 }


### PR DESCRIPTION
Silly old code was rebuilding the tilemap render state by pointer every frame. 