### PR TITLE
Implement JSON and binary serialization for scene management

### DIFF
--- a/engine/include/core/json/JsonStringify.h
+++ b/engine/include/core/json/JsonStringify.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <core/json/JsonValue.h>
+
+#include <string>
+
+[[nodiscard]] std::string JsonStringify(const JsonValue& value, bool pretty = false);

--- a/engine/include/core/json/JsonValue.h
+++ b/engine/include/core/json/JsonValue.h
@@ -52,7 +52,9 @@ public:
 	[[nodiscard]] bool                AsBool()   const { return std::get<bool>(Data); }
 	[[nodiscard]] double              AsNumber() const { return std::get<double>(Data); }
 	[[nodiscard]] const std::string&  AsString() const { return std::get<std::string>(Data); }
+	[[nodiscard]] Array&              AsArray()        { return std::get<Array>(Data); }
 	[[nodiscard]] const Array&        AsArray()  const { return std::get<Array>(Data); }
+	[[nodiscard]] Object&             AsObject()       { return std::get<Object>(Data); }
 	[[nodiscard]] const Object&       AsObject() const { return std::get<Object>(Data); }
 
 	// -- Object field lookup (linear scan) ------------------------------------

--- a/engine/include/core/metadata/EnumSchema.h
+++ b/engine/include/core/metadata/EnumSchema.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string_view>
+
+//=============================================================================
+// EnumValue
+//
+// A single enumerator paired with its string representation. Used as elements
+// of EnumSchema<E>::Values.
+//=============================================================================
+
+template <typename E>
+struct EnumValue
+{
+    E Value;
+    std::string_view Name;
+};
+
+//=============================================================================
+// EnumSchema
+//
+// Specialize for an enum type E and provide a static constexpr array of
+// EnumValue<E> named `Values` to enable string/integer round-tripping through
+// archives.
+//
+// Usage:
+//   template <>
+//   struct EnumSchema<MyEnum>
+//   {
+//       static constexpr std::array Values = {
+//           EnumValue{ MyEnum::Foo, "foo" },
+//           EnumValue{ MyEnum::Bar, "bar" },
+//       };
+//   };
+//=============================================================================
+
+template <typename E>
+struct EnumSchema;
+
+// Satisfied when EnumSchema<E>::Values exists.
+template <typename E>
+concept HasEnumSchema = requires { EnumSchema<E>::Values; };

--- a/engine/include/core/metadata/Field.h
+++ b/engine/include/core/metadata/Field.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+//=============================================================================
+// Field
+//
+// Descriptor for a named member of Class. Carries the member pointer and
+// serialization metadata (optional flag, default value) consumed by archives
+// and schema visitors. Build instances with MakeField(), then chain Optional()
+// or Default() to annotate them.
+//
+// Usage:
+//   MakeField("health", &Actor::Health)
+//   MakeField("speed",  &Actor::Speed).Default(1.0f)
+//   MakeField("tag",    &Actor::Tag).Optional()
+//=============================================================================
+
+template <typename Class, typename Member>
+struct Field
+{
+    std::string_view Name;
+    Member Class::* Ptr = nullptr;
+    bool IsOptional = false;
+    std::optional<Member> DefaultValue;
+    std::uint32_t StableId = 0;
+
+    Field& Optional()
+    {
+        IsOptional = true;
+        return *this;
+    }
+
+    Field& Default(Member value)
+    {
+        DefaultValue = value;
+        IsOptional = true;
+        return *this;
+    }
+};
+
+template <typename Class, typename Member>
+Field<Class, Member> MakeField(std::string_view name, Member Class::* ptr)
+{
+    return { name, ptr };
+}

--- a/engine/include/core/metadata/JsonShape.h
+++ b/engine/include/core/metadata/JsonShape.h
@@ -1,0 +1,29 @@
+#pragma once
+
+enum class JsonShape
+{
+    Object,
+    Array
+};
+
+//=============================================================================
+// JsonShapeFor
+//
+// Controls whether a schema-bearing type serializes as a JSON object or a
+// JSON array. Specialize for types (e.g. Vec, Quat) where a flat array is a
+// more natural representation. Defaults to Object. Binary archives ignore
+// this trait entirely.
+//
+// Usage:
+//   template <int N, typename T>
+//   struct JsonShapeFor<Vec<N, T>>
+//   {
+//       static constexpr JsonShape Value = JsonShape::Array;
+//   };
+//=============================================================================
+
+template <typename T>
+struct JsonShapeFor
+{
+    static constexpr JsonShape Value = JsonShape::Object;
+};

--- a/engine/include/core/metadata/SchemaVisit.h
+++ b/engine/include/core/metadata/SchemaVisit.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <tuple>
+
+//=============================================================================
+// VisitSchema
+//
+// Iterates every field declared by Schema and calls visitor.Field(field, member)
+// for each one. Visitor must expose a templated Field(const FieldT&, T&) overload.
+// Two overloads are provided — const and mutable — so the same visitor type can
+// be used for both reading and writing.
+//=============================================================================
+
+template <typename Schema, typename T, typename Visitor>
+void VisitSchema(const T& value, Visitor& visitor)
+{
+    auto fields = Schema::Fields();
+    std::apply([&](auto&... field)
+    {
+        (visitor.Field(field, value.*field.Ptr), ...);
+    }, fields);
+}
+
+template <typename Schema, typename T, typename Visitor>
+void VisitSchema(T& value, Visitor& visitor)
+{
+    auto fields = Schema::Fields();
+    std::apply([&](auto&... field)
+    {
+        (visitor.Field(field, value.*field.Ptr), ...);
+    }, fields);
+}

--- a/engine/include/core/metadata/TypeSchema.h
+++ b/engine/include/core/metadata/TypeSchema.h
@@ -1,0 +1,31 @@
+#pragma once
+
+//=============================================================================
+// TypeSchema
+//
+// Specialize for a type T to make it schema-driven. The specialization must
+// provide:
+//   static constexpr std::string_view Name  — JSON key / human label
+//   static auto Fields()                    — std::tuple of Field descriptors
+//
+// Usage:
+//   template <>
+//   struct TypeSchema<MyStruct>
+//   {
+//       static constexpr std::string_view Name = "MyStruct";
+//       static auto Fields()
+//       {
+//           return std::tuple{
+//               MakeField("x", &MyStruct::X),
+//               MakeField("y", &MyStruct::Y),
+//           };
+//       }
+//   };
+//=============================================================================
+
+template <typename T, typename = void>
+struct TypeSchema;
+
+// Satisfied when TypeSchema<T>::Fields() is well-formed.
+template <typename T>
+concept HasTypeSchema = requires { TypeSchema<T>::Fields(); };

--- a/engine/include/core/serialization/Archive.h
+++ b/engine/include/core/serialization/Archive.h
@@ -1,0 +1,239 @@
+#pragma once
+
+#include <core/json/JsonValue.h>
+#include <core/metadata/EnumSchema.h>
+#include <core/metadata/JsonShape.h>
+#include <core/metadata/SchemaVisit.h>
+#include <core/metadata/TypeSchema.h>
+
+#include <cstdint>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+struct IWriteArchive;
+struct IReadArchive;
+
+template <typename T>
+void WriteArchiveValue(IWriteArchive& archive, std::string_view key, const T& value);
+
+template <typename T>
+void ReadArchiveValue(IReadArchive& archive, std::string_view key, T& value);
+
+//=============================================================================
+// IWriteArchive
+//
+// Write-side archive interface. Implementations emit fields into a destination
+// format (JSON, binary, etc.). Chain Field/BeginObject/BeginArray/End calls to
+// serialize a value; check Ok() after the root call to detect errors.
+//=============================================================================
+struct IWriteArchive
+{
+    virtual IWriteArchive& Field(std::string_view key, bool value) = 0;
+    virtual IWriteArchive& Field(std::string_view key, float value) = 0;
+    virtual IWriteArchive& Field(std::string_view key, double value) = 0;
+    virtual IWriteArchive& Field(std::string_view key, std::uint32_t value) = 0;
+    virtual IWriteArchive& Field(std::string_view key, std::string_view value) = 0;
+    virtual IWriteArchive& BeginObject(std::string_view key) = 0;
+    virtual IWriteArchive& BeginArray(std::string_view key, std::size_t count) = 0;
+    virtual IWriteArchive& End() = 0;
+    virtual bool Ok() const = 0;
+    virtual bool IsText() const = 0;
+    virtual ~IWriteArchive() = default;
+
+    template <typename FieldT, typename T>
+    IWriteArchive& Field(const FieldT& field, const T& value)
+    {
+        WriteArchiveValue(*this, field.Name, value);
+        return *this;
+    }
+};
+
+//=============================================================================
+// IReadArchive
+//
+// Read-side archive interface. Implementations pull fields from a source format.
+// HasField/BeginObject/BeginArray/End navigate the input; MarkMissingField and
+// MarkInvalidField record structural errors and set Ok() to false.
+//=============================================================================
+struct IReadArchive
+{
+    virtual IReadArchive& Field(std::string_view key, bool& value) = 0;
+    virtual IReadArchive& Field(std::string_view key, float& value) = 0;
+    virtual IReadArchive& Field(std::string_view key, double& value) = 0;
+    virtual IReadArchive& Field(std::string_view key, std::uint32_t& value) = 0;
+    virtual IReadArchive& Field(std::string_view key, std::string& value) = 0;
+    virtual IReadArchive& BeginObject(std::string_view key) = 0;
+    virtual IReadArchive& BeginArray(std::string_view key, std::size_t& count) = 0;
+    virtual IReadArchive& End() = 0;
+    virtual bool HasField(std::string_view key) const = 0;
+    virtual bool Ok() const = 0;
+    virtual bool IsText() const = 0;
+    virtual void MarkMissingField(std::string_view key) = 0;
+    virtual void MarkInvalidField(std::string_view key) = 0;
+    virtual ~IReadArchive() = default;
+
+    // Binary archives always return true from HasField, so default/optional handling
+    // only triggers for text formats where a key can genuinely be absent.
+    template <typename FieldT, typename T>
+    IReadArchive& Field(const FieldT& field, T& value)
+    {
+        if (!HasField(field.Name))
+        {
+            if (field.DefaultValue)
+                value = *field.DefaultValue;
+            else if (!field.IsOptional)
+                MarkMissingField(field.Name);
+            return *this;
+        }
+
+        ReadArchiveValue(*this, field.Name, value);
+        return *this;
+    }
+
+};
+
+template <typename E>
+    requires HasEnumSchema<E>
+std::string_view EnumToString(E value)
+{
+    for (const auto& item : EnumSchema<E>::Values)
+    {
+        if (item.Value == value)
+            return item.Name;
+    }
+    return {};
+}
+
+template <typename E>
+    requires HasEnumSchema<E>
+bool EnumFromString(std::string_view name, E& out)
+{
+    for (const auto& item : EnumSchema<E>::Values)
+    {
+        if (item.Name == name)
+        {
+            out = item.Value;
+            return true;
+        }
+    }
+    return false;
+}
+
+template <typename T>
+void WriteArchiveValue(IWriteArchive& archive, std::string_view key, const T& value)
+{
+    if constexpr (std::is_same_v<T, bool>)
+    {
+        archive.Field(key, value);
+    }
+    else if constexpr (std::is_same_v<T, float>)
+    {
+        archive.Field(key, value);
+    }
+    else if constexpr (std::is_same_v<T, double>)
+    {
+        archive.Field(key, value);
+    }
+    else if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>)
+    {
+        archive.Field(key, static_cast<std::uint32_t>(value));
+    }
+    else if constexpr (std::is_same_v<T, std::string>)
+    {
+        archive.Field(key, std::string_view(value));
+    }
+    else if constexpr (std::is_convertible_v<T, std::string_view>)
+    {
+        archive.Field(key, std::string_view(value));
+    }
+    else if constexpr (std::is_enum_v<T> && HasEnumSchema<T>)
+    {
+        if (archive.IsText())
+            archive.Field(key, EnumToString(value));
+        else
+            archive.Field(key, static_cast<std::uint32_t>(value));
+    }
+    else if constexpr (HasTypeSchema<T>)
+    {
+        // Pass the compile-time field count as a capacity hint; JSON uses it to
+        // pre-size the array, binary ignores it.
+        if constexpr (JsonShapeFor<T>::Value == JsonShape::Array)
+            archive.BeginArray(key, std::tuple_size_v<decltype(TypeSchema<T>::Fields())>);
+        else
+            archive.BeginObject(key);
+
+        VisitSchema<TypeSchema<T>>(value, archive);
+        archive.End();
+    }
+    else
+    {
+        static_assert(sizeof(T) == 0, "No archive serialization available for this type.");
+    }
+}
+
+template <typename T>
+void ReadArchiveValue(IReadArchive& archive, std::string_view key, T& value)
+{
+    if constexpr (std::is_same_v<T, bool>)
+    {
+        archive.Field(key, value);
+    }
+    else if constexpr (std::is_same_v<T, float>)
+    {
+        archive.Field(key, value);
+    }
+    else if constexpr (std::is_same_v<T, double>)
+    {
+        archive.Field(key, value);
+    }
+    else if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>)
+    {
+        std::uint32_t temp = 0;
+        archive.Field(key, temp);
+        value = static_cast<T>(temp);
+    }
+    else if constexpr (std::is_same_v<T, std::string>)
+    {
+        archive.Field(key, value);
+    }
+    else if constexpr (std::is_enum_v<T> && HasEnumSchema<T>)
+    {
+        if (archive.IsText())
+        {
+            std::string name;
+            archive.Field(key, name);
+            if (archive.Ok() && !EnumFromString(name, value))
+                archive.MarkInvalidField(key);
+        }
+        else
+        {
+            std::uint32_t temp = 0;
+            archive.Field(key, temp);
+            value = static_cast<T>(temp);
+        }
+    }
+    else if constexpr (HasTypeSchema<T>)
+    {
+        std::size_t count = 0;
+        if constexpr (JsonShapeFor<T>::Value == JsonShape::Array)
+        {
+            archive.BeginArray(key, count);
+            // Binary returns count=0 (element count not stored); only validate for text.
+            if (archive.IsText() && count != std::tuple_size_v<decltype(TypeSchema<T>::Fields())>)
+                archive.MarkInvalidField(key);
+        }
+        else
+        {
+            archive.BeginObject(key);
+        }
+
+        VisitSchema<TypeSchema<T>>(value, archive);
+        archive.End();
+    }
+    else
+    {
+        static_assert(sizeof(T) == 0, "No archive deserialization available for this type.");
+    }
+}

--- a/engine/include/core/serialization/BinaryArchive.h
+++ b/engine/include/core/serialization/BinaryArchive.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <core/serialization/Archive.h>
+#include <core/serialization/BinaryReader.h>
+#include <core/serialization/BinaryWriter.h>
+
+//=============================================================================
+// BinaryWriteArchive
+//
+// IWriteArchive backed by a BinaryWriter. Keys are ignored; fields are written
+// in declaration order. BeginObject/BeginArray/End are no-ops.
+//=============================================================================
+class BinaryWriteArchive final : public IWriteArchive
+{
+public:
+    explicit BinaryWriteArchive(BinaryWriter& writer) : Writer(writer) {}
+
+    IWriteArchive& Field(std::string_view key, bool value) override;
+    IWriteArchive& Field(std::string_view key, float value) override;
+    IWriteArchive& Field(std::string_view key, double value) override;
+    IWriteArchive& Field(std::string_view key, std::uint32_t value) override;
+    IWriteArchive& Field(std::string_view key, std::string_view value) override;
+    IWriteArchive& BeginObject(std::string_view key) override;
+    IWriteArchive& BeginArray(std::string_view key, std::size_t count) override;
+    IWriteArchive& End() override;
+    bool Ok() const override { return IsOk; }
+    bool IsText() const override { return false; }
+
+private:
+    BinaryWriter& Writer;
+    bool IsOk = true;
+};
+
+//=============================================================================
+// BinaryReadArchive
+//
+// IReadArchive backed by a BinaryReader. HasField always returns true (fields
+// are positional). BeginObject/BeginArray/End are no-ops; BeginArray returns
+// count=0 because element count is not stored in the binary format.
+//=============================================================================
+class BinaryReadArchive final : public IReadArchive
+{
+public:
+    explicit BinaryReadArchive(BinaryReader& reader) : Reader(reader) {}
+
+    IReadArchive& Field(std::string_view key, bool& value) override;
+    IReadArchive& Field(std::string_view key, float& value) override;
+    IReadArchive& Field(std::string_view key, double& value) override;
+    IReadArchive& Field(std::string_view key, std::uint32_t& value) override;
+    IReadArchive& Field(std::string_view key, std::string& value) override;
+    IReadArchive& BeginObject(std::string_view key) override;
+    IReadArchive& BeginArray(std::string_view key, std::size_t& count) override;
+    IReadArchive& End() override;
+    bool HasField(std::string_view key) const override;
+    bool Ok() const override { return IsOk; }
+    bool IsText() const override { return false; }
+    void MarkMissingField(std::string_view key) override;
+    void MarkInvalidField(std::string_view key) override;
+
+private:
+    BinaryReader& Reader;
+    bool IsOk = true;
+};

--- a/engine/include/core/serialization/JsonArchive.h
+++ b/engine/include/core/serialization/JsonArchive.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <core/serialization/Archive.h>
+
+#include <string>
+#include <vector>
+
+//=============================================================================
+// JsonWriteArchive
+//
+// IWriteArchive that builds a JsonValue tree. BeginObject/BeginArray push a
+// context onto a stack; End pops it and attaches the completed value to its
+// parent. Call TakeValue() after the root write to retrieve the result.
+//=============================================================================
+class JsonWriteArchive final : public IWriteArchive
+{
+public:
+    IWriteArchive& Field(std::string_view key, bool value) override;
+    IWriteArchive& Field(std::string_view key, float value) override;
+    IWriteArchive& Field(std::string_view key, double value) override;
+    IWriteArchive& Field(std::string_view key, std::uint32_t value) override;
+    IWriteArchive& Field(std::string_view key, std::string_view value) override;
+    IWriteArchive& BeginObject(std::string_view key) override;
+    IWriteArchive& BeginArray(std::string_view key, std::size_t count) override;
+    IWriteArchive& End() override;
+    bool Ok() const override { return IsOk; }
+    bool IsText() const override { return true; }
+
+    [[nodiscard]] JsonValue TakeValue();
+
+private:
+    struct Context
+    {
+        std::string Key;
+        JsonValue Value;
+        bool IsArray = false;
+    };
+
+    void AddValue(std::string_view key, JsonValue value);
+
+    JsonValue Root;
+    std::vector<Context> Stack;
+    bool HasRoot = false;
+    bool IsOk = true;
+};
+
+//=============================================================================
+// JsonReadArchive
+//
+// IReadArchive that reads from an existing JsonValue tree. BeginObject/BeginArray
+// push the target node onto a stack; array reads advance an index cursor so
+// fields are consumed in declaration order regardless of key.
+//=============================================================================
+class JsonReadArchive final : public IReadArchive
+{
+public:
+    explicit JsonReadArchive(const JsonValue& root);
+
+    IReadArchive& Field(std::string_view key, bool& value) override;
+    IReadArchive& Field(std::string_view key, float& value) override;
+    IReadArchive& Field(std::string_view key, double& value) override;
+    IReadArchive& Field(std::string_view key, std::uint32_t& value) override;
+    IReadArchive& Field(std::string_view key, std::string& value) override;
+    IReadArchive& BeginObject(std::string_view key) override;
+    IReadArchive& BeginArray(std::string_view key, std::size_t& count) override;
+    IReadArchive& End() override;
+    bool HasField(std::string_view key) const override;
+    bool Ok() const override { return IsOk; }
+    bool IsText() const override { return true; }
+    void MarkMissingField(std::string_view key) override;
+    void MarkInvalidField(std::string_view key) override;
+
+private:
+    struct Context
+    {
+        const JsonValue* Value = nullptr;
+        bool IsArray = false;
+        mutable std::size_t Index = 0;
+    };
+
+    [[nodiscard]] const JsonValue* Current() const;
+    [[nodiscard]] const JsonValue* PeekValue(std::string_view key) const;
+    [[nodiscard]] const JsonValue* TakeValue(std::string_view key);
+
+    const JsonValue& Root;
+    std::vector<Context> Stack;
+    bool IsOk = true;
+};

--- a/engine/include/core/serialization/Serialize.h
+++ b/engine/include/core/serialization/Serialize.h
@@ -5,8 +5,12 @@
 #include <type_traits>
 #include <vector>
 
+#include <core/metadata/SchemaVisit.h>
+#include <core/metadata/TypeSchema.h>
+#include <core/serialization/BinaryArchive.h>
 #include <core/serialization/BinaryReader.h>
 #include <core/serialization/BinaryWriter.h>
+#include <core/serialization/JsonArchive.h>
 
 //=============================================================================
 // Serialize / Deserialize
@@ -47,6 +51,44 @@ bool Serialize(BinaryWriter& writer, const std::string& value);
 [[nodiscard]]
 bool Deserialize(BinaryReader& reader, std::string& value,
                  std::uint32_t maxLength = UINT32_MAX);
+
+// --- Schema-driven records --------------------------------------------------
+
+template<typename T>
+requires HasTypeSchema<T>
+bool Serialize(BinaryWriter& writer, const T& value)
+{
+    BinaryWriteArchive archive(writer);
+    WriteArchiveValue(archive, {}, value);
+    return archive.Ok();
+}
+
+template<typename T>
+requires HasTypeSchema<T>
+bool Deserialize(BinaryReader& reader, T& value)
+{
+    BinaryReadArchive archive(reader);
+    ReadArchiveValue(archive, {}, value);
+    return archive.Ok();
+}
+
+template<typename T>
+requires HasTypeSchema<T>
+JsonValue ToJson(const T& value)
+{
+    JsonWriteArchive archive;
+    WriteArchiveValue(archive, {}, value);
+    return archive.TakeValue();
+}
+
+template<typename T>
+requires HasTypeSchema<T>
+bool FromJson(const JsonValue& json, T& value)
+{
+    JsonReadArchive archive(json);
+    ReadArchiveValue(archive, {}, value);
+    return archive.Ok();
+}
 
 // --- Trivial array (bulk memcpy for trivially-copyable element types) -------
 

--- a/engine/include/math/MathSchemas.h
+++ b/engine/include/math/MathSchemas.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <core/metadata/Field.h>
+#include <core/metadata/JsonShape.h>
+#include <core/metadata/TypeSchema.h>
+#include <math/Quat.h>
+#include <math/Vec.h>
+#include <math/geometry/2d/Transform2d.h>
+#include <math/geometry/3d/Transform3d.h>
+
+#include <string_view>
+#include <tuple>
+
+template <int N, typename T>
+struct JsonShapeFor<Vec<N, T>>
+{
+    static constexpr JsonShape Value = JsonShape::Array;
+};
+
+template <typename T>
+struct JsonShapeFor<Quat<T>>
+{
+    static constexpr JsonShape Value = JsonShape::Array;
+};
+
+template <typename T>
+struct TypeSchema<Vec<2, T>>
+{
+    static constexpr std::string_view Name = "Vec2";
+
+    static auto Fields()
+    {
+        return std::tuple{
+            MakeField("x", &Vec<2, T>::X),
+            MakeField("y", &Vec<2, T>::Y),
+        };
+    }
+};
+
+template <typename T>
+struct TypeSchema<Vec<3, T>>
+{
+    static constexpr std::string_view Name = "Vec3";
+
+    static auto Fields()
+    {
+        return std::tuple{
+            MakeField("x", &Vec<3, T>::X),
+            MakeField("y", &Vec<3, T>::Y),
+            MakeField("z", &Vec<3, T>::Z),
+        };
+    }
+};
+
+template <typename T>
+struct TypeSchema<Vec<4, T>>
+{
+    static constexpr std::string_view Name = "Vec4";
+
+    static auto Fields()
+    {
+        return std::tuple{
+            MakeField("x", &Vec<4, T>::X),
+            MakeField("y", &Vec<4, T>::Y),
+            MakeField("z", &Vec<4, T>::Z),
+            MakeField("w", &Vec<4, T>::W),
+        };
+    }
+};
+
+template <typename T>
+struct TypeSchema<Quat<T>>
+{
+    static constexpr std::string_view Name = "Quat";
+
+    static auto Fields()
+    {
+        return std::tuple{
+            MakeField("x", &Quat<T>::X),
+            MakeField("y", &Quat<T>::Y),
+            MakeField("z", &Quat<T>::Z),
+            MakeField("w", &Quat<T>::W),
+        };
+    }
+};
+
+template <typename T>
+struct TypeSchema<Transform3d<T>>
+{
+    static constexpr std::string_view Name = "Transform3d";
+
+    static auto Fields()
+    {
+        return std::tuple{
+            MakeField("position", &Transform3d<T>::Position),
+            MakeField("rotation", &Transform3d<T>::Rotation),
+            MakeField("scale", &Transform3d<T>::Scale),
+        };
+    }
+};
+
+template <typename T>
+struct TypeSchema<Transform2d<T>>
+{
+    static constexpr std::string_view Name = "Transform2d";
+
+    static auto Fields()
+    {
+        return std::tuple{
+            MakeField("position", &Transform2d<T>::Position),
+            MakeField("rotation", &Transform2d<T>::Rotation),
+            MakeField("scale", &Transform2d<T>::Scale),
+        };
+    }
+};

--- a/engine/include/render/Camera.h
+++ b/engine/include/render/Camera.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <array>
+#include <core/metadata/EnumSchema.h>
+#include <core/metadata/Field.h>
+#include <core/metadata/TypeSchema.h>
 #include <core/service/IService.h>
 #include <world/entity/EntityId.h>
 #include <math/Mat.h>
@@ -10,11 +14,23 @@
 #include <world/SparseSetStore.h>
 #include <vulkan/vulkan.h>
 
+#include <string_view>
+#include <tuple>
+
 // Which projection formula a CameraComponent uses.
 enum class ProjectionKind
 {
     Perspective,
     Orthographic
+};
+
+template <>
+struct EnumSchema<ProjectionKind>
+{
+    static constexpr std::array Values = {
+        EnumValue{ ProjectionKind::Perspective, "perspective" },
+        EnumValue{ ProjectionKind::Orthographic, "orthographic" },
+    };
 };
 
 //=============================================================================
@@ -36,6 +52,24 @@ struct CameraComponent
 };
 
 using CameraStore = SparseSetStore<CameraComponent>;
+
+template <>
+struct TypeSchema<CameraComponent>
+{
+    static constexpr std::string_view Name = "Camera";
+
+    static auto Fields()
+    {
+        return std::tuple{
+            MakeField("projection", &CameraComponent::Projection),
+            MakeField("fov_y_radians", &CameraComponent::FovYRadians),
+            MakeField("near_plane", &CameraComponent::NearPlane),
+            MakeField("far_plane", &CameraComponent::FarPlane),
+            MakeField("orthographic_height", &CameraComponent::OrthographicHeight)
+                .Default(CameraComponent{}.OrthographicHeight),
+        };
+    }
+};
 
 //=============================================================================
 // ActiveCameraService

--- a/engine/include/render/Material.h
+++ b/engine/include/render/Material.h
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <core/metadata/Field.h>
+#include <core/metadata/TypeSchema.h>
 #include <core/service/IService.h>
 #include <math/Vec.h>
 
 #include <cstdint>
+#include <string_view>
+#include <tuple>
 #include <vector>
 
 // Versioned handle to a material owned by MaterialStore. Generation 0 is null.
@@ -14,6 +18,20 @@ struct MaterialHandle
 
     [[nodiscard]] bool IsValid() const { return Index != UINT32_MAX && Generation != 0; }
     bool operator==(const MaterialHandle&) const = default;
+};
+
+template <>
+struct TypeSchema<MaterialHandle>
+{
+    static constexpr std::string_view Name = "MaterialHandle";
+
+    static auto Fields()
+    {
+        return std::tuple{
+            MakeField("index", &MaterialHandle::Index),
+            MakeField("generation", &MaterialHandle::Generation),
+        };
+    }
 };
 
 // Identifies the render pass a material belongs to. Used as the high bits of the sort key.

--- a/engine/include/render/MeshRendererComponent.h
+++ b/engine/include/render/MeshRendererComponent.h
@@ -1,11 +1,15 @@
 #pragma once
 
+#include <core/metadata/Field.h>
+#include <core/metadata/TypeSchema.h>
 #include <world/entity/EntityId.h>
 #include <render/Material.h>
 #include <render/MeshTypes.h>
 #include <world/SparseSetStore.h>
 
 #include <cstdint>
+#include <string_view>
+#include <tuple>
 
 //=============================================================================
 // MeshRendererComponent
@@ -24,3 +28,20 @@ struct MeshRendererComponent
 };
 
 using MeshRendererStore = SparseSetStore<MeshRendererComponent>;
+
+template <>
+struct TypeSchema<MeshRendererComponent>
+{
+    static constexpr std::string_view Name = "MeshRenderer";
+
+    static auto Fields()
+    {
+        return std::tuple{
+            MakeField("mesh", &MeshRendererComponent::Mesh),
+            MakeField("material", &MeshRendererComponent::Material),
+            MakeField("visible", &MeshRendererComponent::Visible),
+            MakeField("layer_mask", &MeshRendererComponent::LayerMask),
+            MakeField("submesh_mask", &MeshRendererComponent::SubmeshMask),
+        };
+    }
+};

--- a/engine/include/render/MeshTypes.h
+++ b/engine/include/render/MeshTypes.h
@@ -1,10 +1,14 @@
 #pragma once
 
+#include <core/metadata/Field.h>
+#include <core/metadata/TypeSchema.h>
 #include <graphics/vulkan/VulkanBufferService.h>
 #include <math/Vec.h>
 #include <math/geometry/3d/Aabb3d.h>
 
 #include <cstdint>
+#include <string_view>
+#include <tuple>
 #include <vector>
 
 // Interleaved vertex layout expected by the mesh forward shader (position, normal, uv0).
@@ -48,6 +52,20 @@ struct MeshHandle
 
     [[nodiscard]] bool IsValid() const { return Index != UINT32_MAX && Generation != 0; }
     bool operator==(const MeshHandle&) const = default;
+};
+
+template <>
+struct TypeSchema<MeshHandle>
+{
+    static constexpr std::string_view Name = "MeshHandle";
+
+    static auto Fields()
+    {
+        return std::tuple{
+            MakeField("index", &MeshHandle::Index),
+            MakeField("generation", &MeshHandle::Generation),
+        };
+    }
 };
 
 //=============================================================================

--- a/engine/include/world/entity/EntityRegistry.h
+++ b/engine/include/world/entity/EntityRegistry.h
@@ -68,6 +68,21 @@ public:
 
     size_t Count() const { return LiveCount; }
 
+    std::vector<EntityId> GetAliveEntities() const
+    {
+        std::vector<EntityId> entities;
+        entities.reserve(LiveCount);
+
+        for (EntityIndex index = 0; index < Entries.size(); ++index)
+        {
+            const Entry& entry = Entries[index];
+            if (entry.Alive)
+                entities.push_back(EntityId{ index, entry.Generation });
+        }
+
+        return entities;
+    }
+
 private:
     struct Entry
     {

--- a/engine/include/world/serialization/ComponentSerializer.h
+++ b/engine/include/world/serialization/ComponentSerializer.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <core/metadata/SchemaVisit.h>
+#include <core/metadata/TypeSchema.h>
+#include <world/serialization/ComponentStorageTraits.h>
+#include <world/serialization/IComponentSerializer.h>
+
+//=============================================================================
+// ComponentSerializer
+//
+// Generic IComponentSerializer for any Component with a TypeSchema. Delegates
+// storage access to ComponentStorageTraits<Component>.
+//=============================================================================
+template <typename Component>
+    requires HasTypeSchema<Component>
+class ComponentSerializer final : public IComponentSerializer
+{
+    using Traits = ComponentStorageTraits<Component>;
+
+public:
+    std::string_view JsonKey() const override { return TypeSchema<Component>::Name; }
+    std::uint32_t BinaryChunkId() const override { return Traits::BinaryChunkId; }
+
+    bool HasComponent(EntityId entity, const Registry& registry) const override
+    {
+        const auto* store = registry.Components.TryGet<typename Traits::Store>();
+        return store && store->TryGet(entity);
+    }
+
+    bool Save(IWriteArchive& archive, EntityId entity, const Registry& registry) const override
+    {
+        const auto* store = registry.Components.TryGet<typename Traits::Store>();
+        const Component* component = store ? store->TryGet(entity) : nullptr;
+        if (!component)
+            return true;
+
+        WriteArchiveValue(archive, {}, *component);
+        return archive.Ok();
+    }
+
+    bool Load(IReadArchive& archive, EntityId entity, Registry& registry) override
+    {
+        Component component{};
+        ReadArchiveValue(archive, {}, component);
+        if (!archive.Ok())
+            return false;
+
+        return Traits::Add(registry, entity, component);
+    }
+
+    bool Remove(EntityId entity, Registry& registry) const override
+    {
+        auto* store = registry.Components.TryGet<typename Traits::Store>();
+        return !store || !store->TryGet(entity) || store->Remove(entity);
+    }
+};
+
+//=============================================================================
+// ComponentSerializer<TransformComponent<Transform3f>>
+//
+// Persists only the Local transform. World is excluded because it is
+// recomputed by the propagation system after load.
+//=============================================================================
+template <>
+class ComponentSerializer<TransformComponent<Transform3f>> final : public IComponentSerializer
+{
+    using Component = TransformComponent<Transform3f>;
+    using Traits = ComponentStorageTraits<Component>;
+
+public:
+    std::string_view JsonKey() const override { return TypeSchema<Component>::Name; }
+    std::uint32_t BinaryChunkId() const override { return Traits::BinaryChunkId; }
+
+    bool HasComponent(EntityId entity, const Registry& registry) const override
+    {
+        const auto* store = registry.Components.TryGet<typename Traits::Store>();
+        return store && store->TryGet(entity);
+    }
+
+    bool Save(IWriteArchive& archive, EntityId entity, const Registry& registry) const override
+    {
+        const auto* store = registry.Components.TryGet<typename Traits::Store>();
+        const Component* component = store ? store->TryGet(entity) : nullptr;
+        if (!component)
+            return true;
+
+        WriteArchiveValue(archive, {}, component->Local);
+        return archive.Ok();
+    }
+
+    bool Load(IReadArchive& archive, EntityId entity, Registry& registry) override
+    {
+        Component component{};
+        ReadArchiveValue(archive, {}, component.Local);
+        // World is not persisted; propagation recalculates it on first update.
+        component.World = Transform3f::Identity();
+        if (!archive.Ok())
+            return false;
+
+        return Traits::Add(registry, entity, component);
+    }
+
+    bool Remove(EntityId entity, Registry& registry) const override
+    {
+        auto* store = registry.Components.TryGet<typename Traits::Store>();
+        return !store || !store->TryGet(entity) || store->Remove(entity);
+    }
+};

--- a/engine/include/world/serialization/ComponentStorageTraits.h
+++ b/engine/include/world/serialization/ComponentStorageTraits.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <render/Camera.h>
+#include <render/MeshRendererComponent.h>
+#include <world/registry/Registry.h>
+#include <world/serialization/SceneFormat.h>
+#include <world/transform/TransformHierarchyService.h>
+#include <world/transform/TransformPropagationOrderService.h>
+#include <world/transform/TransformSchemas.h>
+#include <world/transform/TransformStore.h>
+
+#include <utility>
+
+//=============================================================================
+// ComponentStorageTraits
+//
+// Maps a component type to its store type, binary chunk ID, and the Add
+// function that inserts a deserialized instance into the registry. Specialize
+// for each component type that participates in scene serialization.
+//=============================================================================
+template <typename T>
+struct ComponentStorageTraits;
+
+template <>
+struct ComponentStorageTraits<MeshRendererComponent>
+{
+    using Store = MeshRendererStore;
+    static constexpr std::uint32_t BinaryChunkId = SceneChunk::MeshRenders;
+
+    static bool Add(Registry& registry, EntityId entity, MeshRendererComponent component)
+    {
+        return registry.Components.Ensure<Store>().Add(entity, component);
+    }
+};
+
+template <>
+struct ComponentStorageTraits<CameraComponent>
+{
+    using Store = CameraStore;
+    static constexpr std::uint32_t BinaryChunkId = SceneChunk::Cameras;
+
+    static bool Add(Registry& registry, EntityId entity, CameraComponent component)
+    {
+        return registry.Components.Ensure<Store>().Add(entity, component);
+    }
+};
+
+template <>
+struct ComponentStorageTraits<TransformComponent<Transform3f>>
+{
+    using Store = TransformStore<Transform3f>;
+    static constexpr std::uint32_t BinaryChunkId = SceneChunk::Transforms;
+
+    static bool Add(Registry& registry, EntityId entity, TransformComponent<Transform3f> component)
+    {
+        auto& order = registry.Resources.Ensure<TransformPropagationOrderService>();
+        auto& hierarchy = registry.Resources.Ensure<TransformHierarchyService>();
+        // Register in hierarchy before adding to the store so that propagation
+        // order is valid when the store observer runs.
+        hierarchy.Register(entity);
+        return registry.Components.Ensure<Store>(order).Add(entity, component);
+    }
+};

--- a/engine/include/world/serialization/IComponentSerializer.h
+++ b/engine/include/world/serialization/IComponentSerializer.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <core/serialization/Archive.h>
+#include <world/entity/EntityId.h>
+#include <world/registry/Registry.h>
+
+#include <cstdint>
+#include <string_view>
+
+//=============================================================================
+// IComponentSerializer
+//
+// Interface for saving and loading a single component type to/from an archive.
+// Each implementation handles one component kind; the scene serializer iterates
+// all registered implementations to read/write a full registry.
+//=============================================================================
+struct IComponentSerializer
+{
+    virtual std::string_view JsonKey() const = 0;
+    virtual std::uint32_t BinaryChunkId() const = 0;
+
+    virtual bool HasComponent(EntityId entity, const Registry& registry) const = 0;
+    virtual bool Save(IWriteArchive& archive, EntityId entity, const Registry& registry) const = 0;
+    virtual bool Load(IReadArchive& archive, EntityId entity, Registry& registry) = 0;
+    virtual bool Remove(EntityId entity, Registry& registry) const = 0;
+
+    virtual ~IComponentSerializer() = default;
+};

--- a/engine/include/world/serialization/SceneFormat.h
+++ b/engine/include/world/serialization/SceneFormat.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+
+constexpr std::uint32_t MakeFourCC(char a, char b, char c, char d)
+{
+    return static_cast<std::uint32_t>(static_cast<unsigned char>(a))
+        | (static_cast<std::uint32_t>(static_cast<unsigned char>(b)) << 8)
+        | (static_cast<std::uint32_t>(static_cast<unsigned char>(c)) << 16)
+        | (static_cast<std::uint32_t>(static_cast<unsigned char>(d)) << 24);
+}
+
+constexpr std::uint32_t SceneMagic = MakeFourCC('S', 'C', 'N', 'E');
+constexpr std::uint32_t SceneVersion = 1;
+
+//=============================================================================
+// SceneChunk
+//
+// Four-character chunk identifiers written into the binary scene stream.
+// Unknown chunk IDs are skipped during load for forward compatibility.
+//=============================================================================
+namespace SceneChunk
+{
+    constexpr std::uint32_t Registry = MakeFourCC('R', 'E', 'G', 'V');
+    constexpr std::uint32_t Transforms = MakeFourCC('X', 'F', 'R', 'M');
+    constexpr std::uint32_t MeshRenders = MakeFourCC('M', 'E', 'S', 'H');
+    constexpr std::uint32_t Cameras = MakeFourCC('C', 'A', 'M', 'R');
+    constexpr std::uint32_t Hierarchy = MakeFourCC('H', 'I', 'E', 'R');
+}

--- a/engine/include/world/serialization/SceneSerializer.h
+++ b/engine/include/world/serialization/SceneSerializer.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <core/json/JsonValue.h>
+#include <core/serialization/BinaryReader.h>
+#include <core/serialization/BinaryWriter.h>
+#include <world/serialization/ComponentSerializer.h>
+#include <world/serialization/IComponentSerializer.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+//=============================================================================
+// SceneSaveError / SceneLoadError
+//
+// Populated on failure; Message contains a human-readable description of the
+// error. Pass a pointer to either type into Save/Load functions to receive it.
+//=============================================================================
+struct SceneSaveError
+{
+    std::string Message;
+};
+
+struct SceneLoadError
+{
+    std::string Message;
+};
+
+void RegisterComponentSerializer(std::unique_ptr<IComponentSerializer> serializer);
+void ClearComponentSerializers();
+void InitSceneSerializer();
+
+template <typename Component>
+void RegisterComponent()
+{
+    RegisterComponentSerializer(std::make_unique<ComponentSerializer<Component>>());
+}
+
+[[nodiscard]] const std::vector<std::unique_ptr<IComponentSerializer>>& GetComponentSerializerEntries();
+
+[[nodiscard]] bool SaveSceneBinary(const Registry& registry, BinaryWriter& writer,
+    SceneSaveError* error = nullptr);
+[[nodiscard]] bool LoadSceneBinary(BinaryReader& reader, Registry& registry,
+    SceneLoadError* error = nullptr);
+
+[[nodiscard]] JsonValue SaveSceneJson(const Registry& registry);
+[[nodiscard]] bool LoadSceneJson(const JsonValue& root, Registry& registry,
+    SceneLoadError* error = nullptr);

--- a/engine/include/world/transform/TransformSchemas.h
+++ b/engine/include/world/transform/TransformSchemas.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <core/metadata/Field.h>
+#include <core/metadata/TypeSchema.h>
+#include <math/MathSchemas.h>
+#include <world/transform/TransformStore.h>
+
+#include <string_view>
+#include <tuple>
+
+template <>
+struct TypeSchema<TransformComponent<Transform3f>>
+{
+    static constexpr std::string_view Name = "Transform";
+
+    static auto Fields()
+    {
+        return std::tuple{
+            MakeField("local", &TransformComponent<Transform3f>::Local),
+        };
+    }
+};

--- a/engine/src/core/json/JsonStringify.cpp
+++ b/engine/src/core/json/JsonStringify.cpp
@@ -1,0 +1,119 @@
+#include <core/json/JsonStringify.h>
+
+#include <charconv>
+#include <cstdio>
+#include <string>
+
+namespace
+{
+    void AppendIndent(std::string& out, int depth)
+    {
+        out.append(static_cast<size_t>(depth) * 2u, ' ');
+    }
+
+    void AppendEscapedString(std::string& out, const std::string& value)
+    {
+        out.push_back('"');
+        for (unsigned char c : value)
+        {
+            switch (c)
+            {
+            case '"': out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\b': out += "\\b"; break;
+            case '\f': out += "\\f"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:
+                if (c < 0x20)
+                {
+                    char buffer[7] = {};
+                    std::snprintf(buffer, sizeof(buffer), "\\u%04x", c);
+                    out += buffer;
+                }
+                else
+                {
+                    out.push_back(static_cast<char>(c));
+                }
+                break;
+            }
+        }
+        out.push_back('"');
+    }
+
+    void AppendNumber(std::string& out, double value)
+    {
+        char buffer[64] = {};
+        auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), value);
+        if (ec == std::errc{})
+            out.append(buffer, ptr);
+    }
+
+    void StringifyValue(std::string& out, const JsonValue& value, bool pretty, int depth)
+    {
+        if (value.IsNull())
+        {
+            out += "null";
+        }
+        else if (value.IsBool())
+        {
+            out += value.AsBool() ? "true" : "false";
+        }
+        else if (value.IsNumber())
+        {
+            AppendNumber(out, value.AsNumber());
+        }
+        else if (value.IsString())
+        {
+            AppendEscapedString(out, value.AsString());
+        }
+        else if (value.IsArray())
+        {
+            const auto& array = value.AsArray();
+            out.push_back('[');
+            if (!array.empty())
+            {
+                if (pretty) out.push_back('\n');
+                for (size_t i = 0; i < array.size(); ++i)
+                {
+                    if (pretty) AppendIndent(out, depth + 1);
+                    StringifyValue(out, array[i], pretty, depth + 1);
+                    if (i + 1 < array.size()) out.push_back(',');
+                    if (pretty) out.push_back('\n');
+                }
+                if (pretty) AppendIndent(out, depth);
+            }
+            out.push_back(']');
+        }
+        else
+        {
+            const auto& object = value.AsObject();
+            out.push_back('{');
+            if (!object.empty())
+            {
+                if (pretty) out.push_back('\n');
+                for (size_t i = 0; i < object.size(); ++i)
+                {
+                    const auto& [key, child] = object[i];
+                    if (pretty) AppendIndent(out, depth + 1);
+                    AppendEscapedString(out, key);
+                    out.push_back(':');
+                    if (pretty) out.push_back(' ');
+                    StringifyValue(out, child, pretty, depth + 1);
+                    if (i + 1 < object.size()) out.push_back(',');
+                    if (pretty) out.push_back('\n');
+                }
+                if (pretty) AppendIndent(out, depth);
+            }
+            out.push_back('}');
+        }
+    }
+}
+
+std::string JsonStringify(const JsonValue& value, bool pretty)
+{
+    std::string out;
+    StringifyValue(out, value, pretty, 0);
+    return out;
+}

--- a/engine/src/core/serialization/BinaryArchive.cpp
+++ b/engine/src/core/serialization/BinaryArchive.cpp
@@ -1,0 +1,128 @@
+#include <core/serialization/BinaryArchive.h>
+
+#include <limits>
+#include <string>
+
+IWriteArchive& BinaryWriteArchive::Field(std::string_view, bool value)
+{
+    IsOk = IsOk && Writer.Write(value);
+    return *this;
+}
+
+IWriteArchive& BinaryWriteArchive::Field(std::string_view, float value)
+{
+    IsOk = IsOk && Writer.Write(value);
+    return *this;
+}
+
+IWriteArchive& BinaryWriteArchive::Field(std::string_view, double value)
+{
+    IsOk = IsOk && Writer.Write(value);
+    return *this;
+}
+
+IWriteArchive& BinaryWriteArchive::Field(std::string_view, std::uint32_t value)
+{
+    IsOk = IsOk && Writer.Write(value);
+    return *this;
+}
+
+IWriteArchive& BinaryWriteArchive::Field(std::string_view, std::string_view value)
+{
+    if (value.size() > std::numeric_limits<std::uint32_t>::max())
+    {
+        IsOk = false;
+        return *this;
+    }
+
+    const auto size = static_cast<std::uint32_t>(value.size());
+    IsOk = IsOk && Writer.Write(size);
+    if (size > 0)
+        IsOk = IsOk && Writer.WriteBytes(value.data(), static_cast<std::streamsize>(size));
+    return *this;
+}
+
+IWriteArchive& BinaryWriteArchive::BeginObject(std::string_view)
+{
+    return *this;
+}
+
+IWriteArchive& BinaryWriteArchive::BeginArray(std::string_view, std::size_t)
+{
+    return *this;
+}
+
+IWriteArchive& BinaryWriteArchive::End()
+{
+    return *this;
+}
+
+IReadArchive& BinaryReadArchive::Field(std::string_view, bool& value)
+{
+    IsOk = IsOk && Reader.Read(value);
+    return *this;
+}
+
+IReadArchive& BinaryReadArchive::Field(std::string_view, float& value)
+{
+    IsOk = IsOk && Reader.Read(value);
+    return *this;
+}
+
+IReadArchive& BinaryReadArchive::Field(std::string_view, double& value)
+{
+    IsOk = IsOk && Reader.Read(value);
+    return *this;
+}
+
+IReadArchive& BinaryReadArchive::Field(std::string_view, std::uint32_t& value)
+{
+    IsOk = IsOk && Reader.Read(value);
+    return *this;
+}
+
+IReadArchive& BinaryReadArchive::Field(std::string_view, std::string& value)
+{
+    std::uint32_t size = 0;
+    IsOk = IsOk && Reader.Read(size);
+    if (!IsOk)
+        return *this;
+
+    value.resize(size);
+    if (size > 0)
+        IsOk = IsOk && Reader.ReadBytes(value.data(), static_cast<std::streamsize>(size));
+    return *this;
+}
+
+IReadArchive& BinaryReadArchive::BeginObject(std::string_view)
+{
+    return *this;
+}
+
+IReadArchive& BinaryReadArchive::BeginArray(std::string_view, std::size_t& count)
+{
+    // Binary schemas carry fixed-size arrays without storing their element count.
+    // Generic schema readers ignore this value for binary archives.
+    count = 0;
+    return *this;
+}
+
+IReadArchive& BinaryReadArchive::End()
+{
+    return *this;
+}
+
+bool BinaryReadArchive::HasField(std::string_view) const
+{
+    return true;
+}
+
+void BinaryReadArchive::MarkMissingField(std::string_view)
+{
+    IsOk = false;
+}
+
+void BinaryReadArchive::MarkInvalidField(std::string_view)
+{
+    IsOk = false;
+}

--- a/engine/src/core/serialization/JsonArchive.cpp
+++ b/engine/src/core/serialization/JsonArchive.cpp
@@ -1,0 +1,256 @@
+#include <core/serialization/JsonArchive.h>
+
+#include <limits>
+
+namespace
+{
+    JsonValue Number(double value)
+    {
+        return JsonValue(value);
+    }
+}
+
+IWriteArchive& JsonWriteArchive::Field(std::string_view key, bool value)
+{
+    AddValue(key, JsonValue(value));
+    return *this;
+}
+
+IWriteArchive& JsonWriteArchive::Field(std::string_view key, float value)
+{
+    AddValue(key, Number(static_cast<double>(value)));
+    return *this;
+}
+
+IWriteArchive& JsonWriteArchive::Field(std::string_view key, double value)
+{
+    AddValue(key, Number(value));
+    return *this;
+}
+
+IWriteArchive& JsonWriteArchive::Field(std::string_view key, std::uint32_t value)
+{
+    AddValue(key, Number(static_cast<double>(value)));
+    return *this;
+}
+
+IWriteArchive& JsonWriteArchive::Field(std::string_view key, std::string_view value)
+{
+    AddValue(key, JsonValue(std::string(value)));
+    return *this;
+}
+
+IWriteArchive& JsonWriteArchive::BeginObject(std::string_view key)
+{
+    Stack.push_back(Context{ std::string(key), JsonValue(JsonValue::Object{}), false });
+    return *this;
+}
+
+IWriteArchive& JsonWriteArchive::BeginArray(std::string_view key, std::size_t count)
+{
+    JsonValue::Array array;
+    array.reserve(count);
+    Stack.push_back(Context{ std::string(key), JsonValue(std::move(array)), true });
+    return *this;
+}
+
+IWriteArchive& JsonWriteArchive::End()
+{
+    if (Stack.empty())
+    {
+        IsOk = false;
+        return *this;
+    }
+
+    Context complete = std::move(Stack.back());
+    Stack.pop_back();
+    AddValue(complete.Key, std::move(complete.Value));
+    return *this;
+}
+
+JsonValue JsonWriteArchive::TakeValue()
+{
+    if (!Stack.empty())
+        IsOk = false;
+    return std::move(Root);
+}
+
+void JsonWriteArchive::AddValue(std::string_view key, JsonValue value)
+{
+    if (Stack.empty())
+    {
+        Root = std::move(value);
+        HasRoot = true;
+        return;
+    }
+
+    JsonValue& parent = Stack.back().Value;
+    if (Stack.back().IsArray)
+    {
+        parent.AsArray().emplace_back(std::move(value));
+        return;
+    }
+
+    parent.AsObject().emplace_back(std::string(key), std::move(value));
+}
+
+JsonReadArchive::JsonReadArchive(const JsonValue& root)
+    : Root(root)
+{
+}
+
+IReadArchive& JsonReadArchive::Field(std::string_view key, bool& value)
+{
+    const JsonValue* json = TakeValue(key);
+    if (!json || !json->IsBool())
+    {
+        IsOk = false;
+        return *this;
+    }
+
+    value = json->AsBool();
+    return *this;
+}
+
+IReadArchive& JsonReadArchive::Field(std::string_view key, float& value)
+{
+    const JsonValue* json = TakeValue(key);
+    if (!json || !json->IsNumber())
+    {
+        IsOk = false;
+        return *this;
+    }
+
+    value = static_cast<float>(json->AsNumber());
+    return *this;
+}
+
+IReadArchive& JsonReadArchive::Field(std::string_view key, double& value)
+{
+    const JsonValue* json = TakeValue(key);
+    if (!json || !json->IsNumber())
+    {
+        IsOk = false;
+        return *this;
+    }
+
+    value = json->AsNumber();
+    return *this;
+}
+
+IReadArchive& JsonReadArchive::Field(std::string_view key, std::uint32_t& value)
+{
+    const JsonValue* json = TakeValue(key);
+    if (!json || !json->IsNumber() || json->AsNumber() < 0.0
+        || json->AsNumber() > static_cast<double>(std::numeric_limits<std::uint32_t>::max()))
+    {
+        IsOk = false;
+        return *this;
+    }
+
+    value = static_cast<std::uint32_t>(json->AsNumber());
+    return *this;
+}
+
+IReadArchive& JsonReadArchive::Field(std::string_view key, std::string& value)
+{
+    const JsonValue* json = TakeValue(key);
+    if (!json || !json->IsString())
+    {
+        IsOk = false;
+        return *this;
+    }
+
+    value = json->AsString();
+    return *this;
+}
+
+IReadArchive& JsonReadArchive::BeginObject(std::string_view key)
+{
+    const JsonValue* json = TakeValue(key);
+    if (!json || !json->IsObject())
+    {
+        IsOk = false;
+        Stack.push_back(Context{});
+        return *this;
+    }
+
+    Stack.push_back(Context{ json, false, 0 });
+    return *this;
+}
+
+IReadArchive& JsonReadArchive::BeginArray(std::string_view key, std::size_t& count)
+{
+    const JsonValue* json = TakeValue(key);
+    if (!json || !json->IsArray())
+    {
+        IsOk = false;
+        Stack.push_back(Context{});
+        count = 0;
+        return *this;
+    }
+
+    count = json->AsArray().size();
+    Stack.push_back(Context{ json, true, 0 });
+    return *this;
+}
+
+IReadArchive& JsonReadArchive::End()
+{
+    if (Stack.empty())
+    {
+        IsOk = false;
+        return *this;
+    }
+
+    Stack.pop_back();
+    return *this;
+}
+
+bool JsonReadArchive::HasField(std::string_view key) const
+{
+    return PeekValue(key) != nullptr;
+}
+
+void JsonReadArchive::MarkMissingField(std::string_view)
+{
+    IsOk = false;
+}
+
+void JsonReadArchive::MarkInvalidField(std::string_view)
+{
+    IsOk = false;
+}
+
+const JsonValue* JsonReadArchive::Current() const
+{
+    return Stack.empty() ? &Root : Stack.back().Value;
+}
+
+const JsonValue* JsonReadArchive::PeekValue(std::string_view key) const
+{
+    const JsonValue* current = Current();
+    if (!current)
+        return nullptr;
+
+    if (Stack.empty())
+        return key.empty() ? current : current->Find(key);
+
+    const Context& context = Stack.back();
+    if (context.IsArray)
+    {
+        if (!current->IsArray() || context.Index >= current->AsArray().size())
+            return nullptr;
+        return &current->AsArray()[context.Index];
+    }
+
+    return current->IsObject() ? current->Find(key) : nullptr;
+}
+
+const JsonValue* JsonReadArchive::TakeValue(std::string_view key)
+{
+    const JsonValue* value = PeekValue(key);
+    if (!Stack.empty() && Stack.back().IsArray && value)
+        ++Stack.back().Index;
+    return value;
+}

--- a/engine/src/world/serialization/SceneSerializer.cpp
+++ b/engine/src/world/serialization/SceneSerializer.cpp
@@ -1,0 +1,565 @@
+#include <world/serialization/SceneSerializer.h>
+
+#include <core/serialization/BinaryArchive.h>
+#include <core/serialization/BinaryFormat.h>
+#include <core/serialization/JsonArchive.h>
+#include <core/serialization/Serialize.h>
+#include <render/Camera.h>
+#include <render/MeshRendererComponent.h>
+#include <world/serialization/SceneFormat.h>
+#include <world/transform/TransformHierarchyService.h>
+#include <world/transform/TransformPropagationOrderService.h>
+#include <world/transform/TransformSchemas.h>
+#include <world/transform/TransformStore.h>
+
+#include <algorithm>
+#include <memory>
+#include <sstream>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+
+namespace
+{
+    std::vector<std::unique_ptr<IComponentSerializer>>& SerializerEntries()
+    {
+        static std::vector<std::unique_ptr<IComponentSerializer>> entries;
+        return entries;
+    }
+
+    void SetError(SceneSaveError* error, std::string message)
+    {
+        if (error)
+            error->Message = std::move(message);
+    }
+
+    void SetError(SceneLoadError* error, std::string message)
+    {
+        if (error)
+            error->Message = std::move(message);
+    }
+
+    IComponentSerializer* FindByChunkMutable(std::uint32_t chunkId)
+    {
+        for (const auto& entry : SerializerEntries())
+        {
+            if (entry->BinaryChunkId() == chunkId)
+                return entry.get();
+        }
+        return nullptr;
+    }
+
+    IComponentSerializer* FindByJsonKey(std::string_view key)
+    {
+        for (const auto& entry : SerializerEntries())
+        {
+            if (key == entry->JsonKey())
+                return entry.get();
+        }
+        return nullptr;
+    }
+
+    bool SaveRegistryChunk(const std::vector<EntityId>& entities, BinaryWriter& writer)
+    {
+        ChunkWriter chunk;
+        if (!chunk.Begin(writer, SceneChunk::Registry, SceneVersion))
+            return false;
+
+        const auto count = static_cast<std::uint32_t>(entities.size());
+        if (!Serialize(writer, count))
+            return false;
+
+        for (EntityId entity : entities)
+        {
+            if (!Serialize(writer, entity.Index)
+                || !Serialize(writer, entity.Generation))
+            {
+                return false;
+            }
+        }
+
+        return chunk.End(writer);
+    }
+
+    void CollectHierarchyPairs(
+        const TransformHierarchyService& hierarchy,
+        EntityId entity,
+        std::vector<std::pair<EntityId, EntityId>>& pairs)
+    {
+        for (EntityId child : hierarchy.GetChildren(entity))
+        {
+            pairs.emplace_back(child, entity);
+            CollectHierarchyPairs(hierarchy, child, pairs);
+        }
+    }
+
+    bool SaveHierarchyChunk(const Registry& registry, BinaryWriter& writer)
+    {
+        const auto* hierarchy = registry.Resources.TryGet<TransformHierarchyService>();
+        if (!hierarchy)
+            return true;
+
+        std::vector<std::pair<EntityId, EntityId>> pairs;
+        for (EntityId root : hierarchy->GetRoots())
+            CollectHierarchyPairs(*hierarchy, root, pairs);
+
+        ChunkWriter chunk;
+        if (!chunk.Begin(writer, SceneChunk::Hierarchy, SceneVersion))
+            return false;
+
+        const auto count = static_cast<std::uint32_t>(pairs.size());
+        if (!Serialize(writer, count))
+            return false;
+
+        for (const auto& [child, parent] : pairs)
+        {
+            if (!Serialize(writer, child.Index)
+                || !Serialize(writer, parent.Index))
+            {
+                return false;
+            }
+        }
+
+        return chunk.End(writer);
+    }
+
+    EntityId RemapEntity(
+        EntityIndex savedIndex,
+        const std::unordered_map<EntityIndex, EntityId>& remap)
+    {
+        auto it = remap.find(savedIndex);
+        return it == remap.end() ? EntityId{} : it->second;
+    }
+
+    bool LoadRegistryChunk(BinaryReader& reader,
+                           Registry& registry,
+                           std::unordered_map<EntityIndex, EntityId>& remap,
+                           std::vector<EntityId>& loadedEntities)
+    {
+        std::uint32_t count = 0;
+        if (!Deserialize(reader, count))
+            return false;
+
+        remap.reserve(count);
+        for (std::uint32_t i = 0; i < count; ++i)
+        {
+            EntityIndex savedIndex = 0;
+            std::uint16_t savedGeneration = 0;
+            if (!Deserialize(reader, savedIndex)
+                || !Deserialize(reader, savedGeneration))
+            {
+                return false;
+            }
+
+            EntityId runtime = registry.Entities.Create();
+            remap[savedIndex] = runtime;
+            loadedEntities.push_back(runtime);
+        }
+
+        return true;
+    }
+
+    bool LoadHierarchyChunk(BinaryReader& reader,
+                            std::uint32_t count,
+                            Registry& registry,
+                            const std::unordered_map<EntityIndex, EntityId>& remap)
+    {
+        auto& hierarchy = registry.Resources.Ensure<TransformHierarchyService>();
+
+        for (std::uint32_t i = 0; i < count; ++i)
+        {
+            EntityIndex childIndex = 0;
+            EntityIndex parentIndex = 0;
+            if (!Deserialize(reader, childIndex)
+                || !Deserialize(reader, parentIndex))
+            {
+                return false;
+            }
+
+            EntityId child = RemapEntity(childIndex, remap);
+            EntityId parent = RemapEntity(parentIndex, remap);
+            if (!child.IsValid() || !parent.IsValid())
+                return false;
+
+            hierarchy.SetParent(child, parent);
+        }
+
+        return true;
+    }
+
+    bool SaveComponentChunkBinary(const IComponentSerializer& serializer,
+                                  const std::vector<EntityId>& entities,
+                                  const Registry& registry,
+                                  BinaryWriter& writer)
+    {
+        // Buffer component data first so the entity count (unknown upfront) can be
+        // written before the payload, as required by the chunk format.
+        std::stringstream payload(std::ios::in | std::ios::out | std::ios::binary);
+        BinaryWriter payloadWriter(payload);
+
+        std::uint32_t count = 0;
+        for (EntityId entity : entities)
+        {
+            if (!serializer.HasComponent(entity, registry))
+                continue;
+
+            if (!Serialize(payloadWriter, entity.Index))
+                return false;
+
+            BinaryWriteArchive archive(payloadWriter);
+            if (!serializer.Save(archive, entity, registry) || !archive.Ok())
+                return false;
+
+            ++count;
+        }
+
+        const std::string payloadBytes = payload.str();
+        if (!Serialize(writer, count))
+            return false;
+
+        if (!payloadBytes.empty()
+            && !writer.WriteBytes(payloadBytes.data(), static_cast<std::streamsize>(payloadBytes.size())))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool LoadComponentChunkBinary(IComponentSerializer& serializer,
+                                  BinaryReader& reader,
+                                  std::uint32_t count,
+                                  Registry& registry,
+                                  const std::unordered_map<EntityIndex, EntityId>& remap)
+    {
+        for (std::uint32_t i = 0; i < count; ++i)
+        {
+            EntityIndex savedOwner = 0;
+            if (!Deserialize(reader, savedOwner))
+                return false;
+
+            EntityId owner = RemapEntity(savedOwner, remap);
+            if (!owner.IsValid())
+                return false;
+
+            BinaryReadArchive archive(reader);
+            if (!serializer.Load(archive, owner, registry) || !archive.Ok())
+                return false;
+        }
+        return true;
+    }
+
+    void RollbackLoadedEntities(Registry& registry, const std::vector<EntityId>& entities)
+    {
+        if (auto* hierarchy = registry.Resources.TryGet<TransformHierarchyService>())
+        {
+            for (auto it = entities.rbegin(); it != entities.rend(); ++it)
+                hierarchy->Unregister(*it);
+        }
+
+        for (auto it = entities.rbegin(); it != entities.rend(); ++it)
+        {
+            for (const auto& serializer : SerializerEntries())
+                serializer->Remove(*it, registry);
+            registry.Entities.Destroy(*it);
+        }
+    }
+}
+
+void RegisterComponentSerializer(std::unique_ptr<IComponentSerializer> serializer)
+{
+    if (!serializer)
+        return;
+
+    auto& entries = SerializerEntries();
+    const auto duplicate = std::ranges::find_if(entries, [&](const auto& existing)
+    {
+        return existing->BinaryChunkId() == serializer->BinaryChunkId()
+            || existing->JsonKey() == serializer->JsonKey();
+    });
+
+    if (duplicate == entries.end())
+        entries.push_back(std::move(serializer));
+}
+
+void ClearComponentSerializers()
+{
+    SerializerEntries().clear();
+}
+
+void InitSceneSerializer()
+{
+    RegisterComponent<TransformComponent<Transform3f>>();
+    RegisterComponent<MeshRendererComponent>();
+    RegisterComponent<CameraComponent>();
+}
+
+const std::vector<std::unique_ptr<IComponentSerializer>>& GetComponentSerializerEntries()
+{
+    return SerializerEntries();
+}
+
+bool SaveSceneBinary(const Registry& registry, BinaryWriter& writer, SceneSaveError* error)
+{
+    const auto entities = registry.Entities.GetAliveEntities();
+
+    if (!WriteBinaryHeader(writer, SceneMagic, SceneVersion))
+    {
+        SetError(error, "Failed to write scene header.");
+        return false;
+    }
+
+    if (!SaveRegistryChunk(entities, writer))
+    {
+        SetError(error, "Failed to write entity registry chunk.");
+        return false;
+    }
+
+    if (!SaveHierarchyChunk(registry, writer))
+    {
+        SetError(error, "Failed to write transform hierarchy chunk.");
+        return false;
+    }
+
+    for (const auto& entry : SerializerEntries())
+    {
+        ChunkWriter chunk;
+        if (!chunk.Begin(writer, entry->BinaryChunkId(), SceneVersion)
+            || !SaveComponentChunkBinary(*entry, entities, registry, writer)
+            || !chunk.End(writer))
+        {
+            SetError(error, "Failed to write component chunk.");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool LoadSceneBinary(BinaryReader& reader, Registry& registry, SceneLoadError* error)
+{
+    BinaryHeader header;
+    if (!ReadBinaryHeader(reader, header)
+        || !ValidateBinaryHeader(header, SceneMagic, SceneVersion))
+    {
+        SetError(error, "Invalid scene header.");
+        return false;
+    }
+
+    std::unordered_map<EntityIndex, EntityId> remap;
+    std::vector<EntityId> loadedEntities;
+    bool loadedRegistry = false;
+
+    while (true)
+    {
+        ChunkReader chunk;
+        if (!chunk.ReadHeader(reader))
+            break;
+
+        const ChunkHeader& chunkHeader = chunk.GetHeader();
+        bool ok = true;
+
+        if (chunkHeader.Id == SceneChunk::Registry)
+        {
+            ok = LoadRegistryChunk(reader, registry, remap, loadedEntities);
+            loadedRegistry = ok;
+        }
+        else if (chunkHeader.Id == SceneChunk::Hierarchy)
+        {
+            std::uint32_t count = 0;
+            ok = Deserialize(reader, count)
+                && LoadHierarchyChunk(reader, count, registry, remap);
+        }
+        else if (IComponentSerializer* entry = FindByChunkMutable(chunkHeader.Id))
+        {
+            std::uint32_t count = 0;
+            ok = Deserialize(reader, count)
+                && LoadComponentChunkBinary(*entry, reader, count, registry, remap);
+        }
+
+        if (!ok)
+        {
+            RollbackLoadedEntities(registry, loadedEntities);
+            SetError(error, "Failed to read scene chunk.");
+            return false;
+        }
+
+        if (!chunk.Skip(reader))
+        {
+            RollbackLoadedEntities(registry, loadedEntities);
+            SetError(error, "Failed to skip scene chunk remainder.");
+            return false;
+        }
+    }
+
+    if (!loadedRegistry)
+    {
+        RollbackLoadedEntities(registry, loadedEntities);
+        SetError(error, "Scene is missing entity registry chunk.");
+        return false;
+    }
+
+    return true;
+}
+
+JsonValue SaveSceneJson(const Registry& registry)
+{
+    JsonValue::Array entitiesJson;
+    JsonValue::Array hierarchyJson;
+    const auto entities = registry.Entities.GetAliveEntities();
+    std::unordered_map<EntityIndex, std::uint32_t> entityToJsonIndex;
+    entityToJsonIndex.reserve(entities.size());
+
+    for (std::uint32_t i = 0; i < entities.size(); ++i)
+    {
+        EntityId entity = entities[i];
+        entityToJsonIndex[entity.Index] = i;
+
+        JsonValue::Object componentsJson;
+        for (const auto& entry : SerializerEntries())
+        {
+            JsonWriteArchive archive;
+            if (!entry->Save(archive, entity, registry) || !archive.Ok())
+                continue;
+
+            JsonValue component = archive.TakeValue();
+            if (!component.IsNull())
+                componentsJson.emplace_back(std::string(entry->JsonKey()), std::move(component));
+        }
+
+        entitiesJson.emplace_back(JsonValue::Object{
+            { "components", JsonValue(std::move(componentsJson)) },
+        });
+    }
+
+    if (const auto* hierarchy = registry.Resources.TryGet<TransformHierarchyService>())
+    {
+        for (EntityId child : entities)
+        {
+            EntityId parent = hierarchy->GetParent(child);
+            if (!parent.IsValid())
+                continue;
+
+            auto childIt = entityToJsonIndex.find(child.Index);
+            auto parentIt = entityToJsonIndex.find(parent.Index);
+            if (childIt == entityToJsonIndex.end() || parentIt == entityToJsonIndex.end())
+                continue;
+
+            hierarchyJson.emplace_back(JsonValue::Object{
+                { "child", JsonValue(static_cast<double>(childIt->second)) },
+                { "parent", JsonValue(static_cast<double>(parentIt->second)) },
+            });
+        }
+    }
+
+    return JsonValue(JsonValue::Object{
+        { "version", JsonValue(static_cast<double>(SceneVersion)) },
+        { "entities", JsonValue(std::move(entitiesJson)) },
+        { "hierarchy", JsonValue(std::move(hierarchyJson)) },
+    });
+}
+
+bool LoadSceneJson(const JsonValue& root, Registry& registry, SceneLoadError* error)
+{
+    if (!root.IsObject())
+    {
+        SetError(error, "Scene JSON root must be an object.");
+        return false;
+    }
+
+    const JsonValue* version = root.Find("version");
+    const JsonValue* entitiesValue = root.Find("entities");
+    if (!version || !version->IsNumber()
+        || static_cast<std::uint32_t>(version->AsNumber()) != SceneVersion
+        || !entitiesValue || !entitiesValue->IsArray())
+    {
+        SetError(error, "Scene JSON has an invalid version or entity list.");
+        return false;
+    }
+
+    std::vector<EntityId> entities;
+    entities.reserve(entitiesValue->AsArray().size());
+
+    for (const JsonValue& entityValue : entitiesValue->AsArray())
+    {
+        if (!entityValue.IsObject())
+        {
+            RollbackLoadedEntities(registry, entities);
+            SetError(error, "Scene JSON entity must be an object.");
+            return false;
+        }
+
+        EntityId entity = registry.Entities.Create();
+        entities.push_back(entity);
+
+        const JsonValue* components = entityValue.Find("components");
+        if (!components)
+            continue;
+
+        if (!components->IsObject())
+        {
+            RollbackLoadedEntities(registry, entities);
+            SetError(error, "Scene JSON components must be an object.");
+            return false;
+        }
+
+        for (const auto& [key, componentData] : components->AsObject())
+        {
+            IComponentSerializer* entry = FindByJsonKey(key);
+            if (!entry)
+                continue;
+
+            JsonReadArchive archive(componentData);
+            if (!entry->Load(archive, entity, registry) || !archive.Ok())
+            {
+                RollbackLoadedEntities(registry, entities);
+                SetError(error, "Failed to load JSON component.");
+                return false;
+            }
+        }
+    }
+
+    const JsonValue* hierarchyValue = root.Find("hierarchy");
+    if (hierarchyValue && !hierarchyValue->IsArray())
+    {
+        RollbackLoadedEntities(registry, entities);
+        SetError(error, "Scene JSON hierarchy must be an array.");
+        return false;
+    }
+
+    if (hierarchyValue)
+    {
+        auto& hierarchy = registry.Resources.Ensure<TransformHierarchyService>();
+        for (const JsonValue& relation : hierarchyValue->AsArray())
+        {
+            if (!relation.IsObject())
+            {
+                RollbackLoadedEntities(registry, entities);
+                SetError(error, "Scene JSON hierarchy relation must be an object.");
+                return false;
+            }
+
+            const JsonValue* child = relation.Find("child");
+            const JsonValue* parent = relation.Find("parent");
+            if (!child || !parent || !child->IsNumber() || !parent->IsNumber())
+            {
+                RollbackLoadedEntities(registry, entities);
+                SetError(error, "Scene JSON hierarchy relation is invalid.");
+                return false;
+            }
+
+            const auto childIndex = static_cast<size_t>(child->AsNumber());
+            const auto parentIndex = static_cast<size_t>(parent->AsNumber());
+            if (childIndex >= entities.size() || parentIndex >= entities.size())
+            {
+                RollbackLoadedEntities(registry, entities);
+                SetError(error, "Scene JSON hierarchy references an unknown entity.");
+                return false;
+            }
+
+            hierarchy.SetParent(entities[childIndex], entities[parentIndex]);
+        }
+    }
+
+    return true;
+}

--- a/test/core/SerializationTests.cpp
+++ b/test/core/SerializationTests.cpp
@@ -1,19 +1,219 @@
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cstdint>
 #include <sstream>
 #include <string>
+#include <string_view>
+#include <tuple>
 #include <vector>
 
+#include <core/metadata/EnumSchema.h>
+#include <core/metadata/Field.h>
+#include <core/metadata/SchemaVisit.h>
+#include <core/metadata/TypeSchema.h>
+#include <core/json/JsonValue.h>
 #include <core/serialization/BinaryReader.h>
 #include <core/serialization/BinaryWriter.h>
 #include <core/serialization/Serialize.h>
 #include <core/serialization/BinaryFormat.h>
+#include <math/MathSchemas.h>
 
 // Helper: create a binary read/write stringstream.
 static std::stringstream MakeBinaryStream()
 {
     return std::stringstream(std::ios::in | std::ios::out | std::ios::binary);
+}
+
+enum class SchemaTestKind
+{
+    First,
+    Second
+};
+
+template <>
+struct EnumSchema<SchemaTestKind>
+{
+    static constexpr std::array Values = {
+        EnumValue{ SchemaTestKind::First, "first" },
+        EnumValue{ SchemaTestKind::Second, "second" },
+    };
+};
+
+struct SchemaTestRecord
+{
+    std::uint32_t Id = 0;
+    float Weight = 0.0f;
+    bool Enabled = false;
+    SchemaTestKind Kind = SchemaTestKind::First;
+    std::uint32_t OptionalCount = 0;
+
+    bool operator==(const SchemaTestRecord&) const = default;
+};
+
+template <>
+struct TypeSchema<SchemaTestRecord>
+{
+    static constexpr std::string_view Name = "SchemaTestRecord";
+
+    static auto Fields()
+    {
+        return std::tuple{
+            MakeField("id", &SchemaTestRecord::Id),
+            MakeField("weight", &SchemaTestRecord::Weight),
+            MakeField("enabled", &SchemaTestRecord::Enabled),
+            MakeField("kind", &SchemaTestRecord::Kind),
+            MakeField("optional_count", &SchemaTestRecord::OptionalCount).Default(std::uint32_t{ 77 }),
+        };
+    }
+};
+
+struct EnumOnlyRecord
+{
+    SchemaTestKind Kind = SchemaTestKind::First;
+};
+
+template <>
+struct TypeSchema<EnumOnlyRecord>
+{
+    static constexpr std::string_view Name = "EnumOnlyRecord";
+
+    static auto Fields()
+    {
+        return std::tuple{
+            MakeField("kind", &EnumOnlyRecord::Kind),
+        };
+    }
+};
+
+struct FieldNameCollector
+{
+    std::vector<std::string_view>& Names;
+
+    template <typename FieldT, typename T>
+    void Field(const FieldT& field, const T&)
+    {
+        Names.push_back(field.Name);
+    }
+};
+
+TEST(SerializationTests, SchemaTraversalVisitsFieldsInDeclaredOrder)
+{
+    SchemaTestRecord record{};
+    std::vector<std::string_view> names;
+    FieldNameCollector visitor{ names };
+
+    VisitSchema<TypeSchema<SchemaTestRecord>>(record, visitor);
+
+    ASSERT_EQ(names.size(), 5u);
+    EXPECT_EQ(names[0], "id");
+    EXPECT_EQ(names[1], "weight");
+    EXPECT_EQ(names[2], "enabled");
+    EXPECT_EQ(names[3], "kind");
+    EXPECT_EQ(names[4], "optional_count");
+}
+
+TEST(SerializationTests, SchemaBinaryRoundTripsStandaloneRecord)
+{
+    auto stream = MakeBinaryStream();
+    BinaryWriter writer(stream);
+
+    const SchemaTestRecord expected{
+        .Id = 42,
+        .Weight = 3.5f,
+        .Enabled = true,
+        .Kind = SchemaTestKind::Second,
+        .OptionalCount = 9,
+    };
+    ASSERT_TRUE(Serialize(writer, expected));
+
+    stream.seekg(0);
+    BinaryReader reader(stream);
+
+    SchemaTestRecord actual{};
+    ASSERT_TRUE(Deserialize(reader, actual));
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(SerializationTests, SchemaJsonRoundTripsStandaloneRecordAndIgnoresUnknownFields)
+{
+    const JsonValue json(JsonValue::Object{
+        { "id", JsonValue(42) },
+        { "weight", JsonValue(3.5) },
+        { "enabled", JsonValue(true) },
+        { "kind", JsonValue("second") },
+        { "optional_count", JsonValue(9) },
+        { "unknown", JsonValue("ignored") },
+    });
+
+    SchemaTestRecord actual{};
+    ASSERT_TRUE(FromJson(json, actual));
+
+    EXPECT_EQ(actual.Id, 42u);
+    EXPECT_FLOAT_EQ(actual.Weight, 3.5f);
+    EXPECT_TRUE(actual.Enabled);
+    EXPECT_EQ(actual.Kind, SchemaTestKind::Second);
+    EXPECT_EQ(actual.OptionalCount, 9u);
+
+    JsonValue roundTrip = ToJson(actual);
+    ASSERT_TRUE(roundTrip.IsObject());
+    EXPECT_NE(roundTrip.Find("id"), nullptr);
+    EXPECT_EQ(roundTrip.Find("unknown"), nullptr);
+}
+
+TEST(SerializationTests, OptionalJsonFieldMissingAssignsDeclaredDefault)
+{
+    const JsonValue json(JsonValue::Object{
+        { "id", JsonValue(12) },
+        { "weight", JsonValue(1.25) },
+        { "enabled", JsonValue(false) },
+        { "kind", JsonValue("first") },
+    });
+
+    SchemaTestRecord actual{};
+    ASSERT_TRUE(FromJson(json, actual));
+    EXPECT_EQ(actual.OptionalCount, 77u);
+}
+
+TEST(SerializationTests, EnumWritesAsStringInJsonAndIntegerInBinary)
+{
+    const EnumOnlyRecord expected{ .Kind = SchemaTestKind::Second };
+
+    JsonValue json = ToJson(expected);
+    ASSERT_TRUE(json.IsObject());
+    const JsonValue* kind = json.Find("kind");
+    ASSERT_NE(kind, nullptr);
+    ASSERT_TRUE(kind->IsString());
+    EXPECT_EQ(kind->AsString(), "second");
+
+    auto stream = MakeBinaryStream();
+    BinaryWriter writer(stream);
+    ASSERT_TRUE(Serialize(writer, expected));
+
+    stream.seekg(0);
+    BinaryReader reader(stream);
+    std::uint32_t rawKind = 0;
+    ASSERT_TRUE(Deserialize(reader, rawKind));
+    EXPECT_EQ(rawKind, static_cast<std::uint32_t>(SchemaTestKind::Second));
+}
+
+TEST(SerializationTests, MathSchemasPreserveJsonShapes)
+{
+    JsonValue vec = ToJson(Vec3d(1.0f, 2.0f, 3.0f));
+    ASSERT_TRUE(vec.IsArray());
+    ASSERT_EQ(vec.AsArray().size(), 3u);
+    EXPECT_DOUBLE_EQ(vec.AsArray()[0].AsNumber(), 1.0);
+    EXPECT_DOUBLE_EQ(vec.AsArray()[1].AsNumber(), 2.0);
+    EXPECT_DOUBLE_EQ(vec.AsArray()[2].AsNumber(), 3.0);
+
+    JsonValue transform = ToJson(Transform3f(
+        Vec3d(1.0f, 2.0f, 3.0f),
+        Quatf::Identity(),
+        Vec3d(4.0f, 5.0f, 6.0f)));
+    ASSERT_TRUE(transform.IsObject());
+    EXPECT_NE(transform.Find("position"), nullptr);
+    EXPECT_NE(transform.Find("rotation"), nullptr);
+    EXPECT_NE(transform.Find("scale"), nullptr);
 }
 
 //=============================================================================

--- a/test/runtime/SceneSerializerTests.cpp
+++ b/test/runtime/SceneSerializerTests.cpp
@@ -1,0 +1,369 @@
+#include <gtest/gtest.h>
+
+#include <core/json/JsonParser.h>
+#include <core/json/JsonStringify.h>
+#include <core/serialization/BinaryFormat.h>
+#include <core/serialization/BinaryReader.h>
+#include <core/serialization/BinaryWriter.h>
+#include <core/serialization/Serialize.h>
+#include <math/geometry/3d/Transform3d.h>
+#include <render/Camera.h>
+#include <render/MeshRendererComponent.h>
+#include <world/registry/Registry.h>
+#include <world/serialization/SceneFormat.h>
+#include <world/serialization/SceneSerializer.h>
+#include <world/transform/TransformHierarchyService.h>
+#include <world/transform/TransformPropagationOrderService.h>
+#include <world/transform/TransformStore.h>
+
+#include <sstream>
+
+namespace
+{
+    std::stringstream MakeBinaryStream()
+    {
+        return std::stringstream(std::ios::in | std::ios::out | std::ios::binary);
+    }
+
+    Registry MakeSceneRegistry()
+    {
+        Registry registry;
+        auto& order = registry.Resources.Register<TransformPropagationOrderService>();
+        registry.Resources.Register<TransformHierarchyService>();
+        registry.Components.Register<TransformStore<Transform3f>>(order);
+        registry.Components.Register<MeshRendererStore>();
+        registry.Components.Register<CameraStore>();
+        return registry;
+    }
+
+    void ResetSceneSerializers()
+    {
+        ClearComponentSerializers();
+        InitSceneSerializer();
+    }
+
+    Transform3f MakeTransform(float x, float y, float z)
+    {
+        return Transform3f(
+            Vec3d(x, y, z),
+            Quatf::Identity(),
+            Vec3d(1.0f, 2.0f, 3.0f));
+    }
+}
+
+TEST(SceneSerializer, BinaryRoundTripsCleanRegistry)
+{
+    ResetSceneSerializers();
+    Registry source = MakeSceneRegistry();
+
+    EntityId parent = source.Entities.Create();
+    EntityId child = source.Entities.Create();
+
+    auto& transforms = source.Components.Get<TransformStore<Transform3f>>();
+    auto& hierarchy = source.Resources.Get<TransformHierarchyService>();
+    transforms.Add(parent, MakeTransform(1.0f, 2.0f, 3.0f));
+    transforms.Add(child, MakeTransform(4.0f, 5.0f, 6.0f));
+    hierarchy.Register(parent);
+    hierarchy.SetParent(child, parent);
+
+    MeshRendererComponent meshRenderer{
+        .Mesh = MeshHandle{ .Index = 7, .Generation = 2 },
+        .Material = MaterialHandle{ .Index = 9, .Generation = 3 },
+        .Visible = false,
+        .LayerMask = 0x00FF00FFu,
+        .SubmeshMask = 0x0000000Fu,
+    };
+    source.Components.Get<MeshRendererStore>().Add(child, meshRenderer);
+
+    CameraComponent camera{
+        .Projection = ProjectionKind::Orthographic,
+        .FovYRadians = 0.75f,
+        .NearPlane = 0.25f,
+        .FarPlane = 250.0f,
+        .OrthographicHeight = 12.0f,
+    };
+    source.Components.Get<CameraStore>().Add(parent, camera);
+
+    auto stream = MakeBinaryStream();
+    BinaryWriter writer(stream);
+    ASSERT_TRUE(SaveSceneBinary(source, writer));
+
+    stream.seekg(0);
+    BinaryReader reader(stream);
+    Registry loaded;
+    SceneLoadError error;
+    ASSERT_TRUE(LoadSceneBinary(reader, loaded, &error)) << error.Message;
+
+    EXPECT_EQ(loaded.Entities.Count(), 2u);
+
+    auto& loadedTransforms = loaded.Components.Get<TransformStore<Transform3f>>();
+    auto& loadedHierarchy = loaded.Resources.Get<TransformHierarchyService>();
+    auto& loadedMeshes = loaded.Components.Get<MeshRendererStore>();
+    auto& loadedCameras = loaded.Components.Get<CameraStore>();
+
+    ASSERT_EQ(loadedTransforms.Count(), 2u);
+    ASSERT_EQ(loadedMeshes.Count(), 1u);
+    ASSERT_EQ(loadedCameras.Count(), 1u);
+
+    const auto owners = loadedTransforms.GetOwnerIds();
+    EntityId loadedParent{ owners[0], 1 };
+    EntityId loadedChild{ owners[1], 1 };
+    if (loadedHierarchy.GetParent(loadedParent).IsValid())
+        std::swap(loadedParent, loadedChild);
+
+    ASSERT_TRUE(loadedHierarchy.GetParent(loadedChild).IsValid());
+    EXPECT_EQ(loadedHierarchy.GetParent(loadedChild).Index, loadedParent.Index);
+    ASSERT_NE(loadedTransforms.TryGet(loadedParent), nullptr);
+    EXPECT_EQ(loadedTransforms.TryGet(loadedParent)->Local.Position, Vec3d(1.0f, 2.0f, 3.0f));
+
+    const MeshRendererComponent* loadedMesh = loadedMeshes.TryGet(loadedChild);
+    ASSERT_NE(loadedMesh, nullptr);
+    EXPECT_EQ(loadedMesh->Mesh, meshRenderer.Mesh);
+    EXPECT_EQ(loadedMesh->Material, meshRenderer.Material);
+    EXPECT_EQ(loadedMesh->Visible, meshRenderer.Visible);
+    EXPECT_EQ(loadedMesh->LayerMask, meshRenderer.LayerMask);
+    EXPECT_EQ(loadedMesh->SubmeshMask, meshRenderer.SubmeshMask);
+
+    const CameraComponent* loadedCamera = loadedCameras.TryGet(loadedParent);
+    ASSERT_NE(loadedCamera, nullptr);
+    EXPECT_EQ(loadedCamera->Projection, ProjectionKind::Orthographic);
+    EXPECT_FLOAT_EQ(loadedCamera->OrthographicHeight, 12.0f);
+}
+
+TEST(SceneSerializer, BinaryLoadIsAdditiveAndRemapsEntityIndices)
+{
+    ResetSceneSerializers();
+    Registry source = MakeSceneRegistry();
+    EntityId sourceEntity = source.Entities.Create();
+    source.Resources.Get<TransformHierarchyService>().Register(sourceEntity);
+    source.Components.Get<TransformStore<Transform3f>>().Add(sourceEntity, MakeTransform(8.0f, 0.0f, 0.0f));
+
+    auto stream = MakeBinaryStream();
+    BinaryWriter writer(stream);
+    ASSERT_TRUE(SaveSceneBinary(source, writer));
+
+    Registry loaded = MakeSceneRegistry();
+    EntityId preexisting = loaded.Entities.Create();
+    loaded.Components.Get<TransformStore<Transform3f>>().Add(preexisting, MakeTransform(-1.0f, 0.0f, 0.0f));
+
+    stream.seekg(0);
+    BinaryReader reader(stream);
+    ASSERT_TRUE(LoadSceneBinary(reader, loaded));
+
+    EXPECT_EQ(loaded.Entities.Count(), 2u);
+    auto& transforms = loaded.Components.Get<TransformStore<Transform3f>>();
+    ASSERT_EQ(transforms.Count(), 2u);
+    EXPECT_NE(transforms.TryGet(EntityId{ sourceEntity.Index, sourceEntity.Generation })->Local.Position,
+        Vec3d(8.0f, 0.0f, 0.0f));
+
+    bool foundRemapped = false;
+    for (const auto& component : transforms.GetItems())
+        foundRemapped = foundRemapped || component.Local.Position == Vec3d(8.0f, 0.0f, 0.0f);
+    EXPECT_TRUE(foundRemapped);
+}
+
+TEST(SceneSerializer, JsonRoundTripsThroughStringifyAndParser)
+{
+    ResetSceneSerializers();
+    Registry source = MakeSceneRegistry();
+    EntityId entity = source.Entities.Create();
+    source.Resources.Get<TransformHierarchyService>().Register(entity);
+    source.Components.Get<TransformStore<Transform3f>>().Add(entity, MakeTransform(2.0f, 3.0f, 4.0f));
+    source.Components.Get<CameraStore>().Add(entity, CameraComponent{});
+
+    JsonValue json = SaveSceneJson(source);
+    std::string text = JsonStringify(json, true);
+    auto parsed = JsonParse(text);
+    ASSERT_TRUE(parsed.has_value());
+
+    Registry loaded;
+    ASSERT_TRUE(LoadSceneJson(*parsed, loaded));
+
+    ASSERT_EQ(loaded.Entities.Count(), 1u);
+    auto& loadedTransforms = loaded.Components.Get<TransformStore<Transform3f>>();
+    ASSERT_EQ(loadedTransforms.Count(), 1u);
+    EXPECT_EQ(loadedTransforms.GetItems()[0].Local.Position, Vec3d(2.0f, 3.0f, 4.0f));
+    EXPECT_EQ(loaded.Components.Get<CameraStore>().Count(), 1u);
+}
+
+TEST(SceneSerializer, LoadsHandAuthoredJson)
+{
+    ResetSceneSerializers();
+    auto parsed = JsonParse(R"({
+        "version": 1,
+        "entities": [
+            {
+                "components": {
+                    "Transform": {
+                        "position": [0, 0, 0],
+                        "rotation": [0, 0, 0, 1],
+                        "scale": [1, 1, 1]
+                    },
+                    "MeshRenderer": {
+                        "mesh": { "index": 3, "generation": 1 },
+                        "material": { "index": 4, "generation": 2 },
+                        "visible": true,
+                        "layer_mask": 4294967295,
+                        "submesh_mask": 15
+                    }
+                }
+            },
+            {
+                "components": {
+                    "Transform": {
+                        "position": [5, 0, 0],
+                        "rotation": [0, 0, 0, 1],
+                        "scale": [1, 1, 1]
+                    },
+                    "Camera": {
+                        "projection": "perspective",
+                        "fov_y_radians": 1.0,
+                        "near_plane": 0.1,
+                        "far_plane": 1000.0
+                    }
+                }
+            }
+        ],
+        "hierarchy": [
+            { "child": 0, "parent": 1 }
+        ]
+    })");
+    ASSERT_TRUE(parsed.has_value());
+
+    Registry loaded;
+    ASSERT_TRUE(LoadSceneJson(*parsed, loaded));
+
+    EXPECT_EQ(loaded.Entities.Count(), 2u);
+    EXPECT_EQ(loaded.Components.Get<TransformStore<Transform3f>>().Count(), 2u);
+    EXPECT_EQ(loaded.Components.Get<MeshRendererStore>().Count(), 1u);
+    EXPECT_EQ(loaded.Components.Get<CameraStore>().Count(), 1u);
+    EXPECT_EQ(loaded.Resources.Get<TransformHierarchyService>().GetRoots().size(), 1u);
+}
+
+TEST(SceneSerializer, JsonLoadRollsBackEntitiesAndComponentsOnFailure)
+{
+    ResetSceneSerializers();
+    auto parsed = JsonParse(R"({
+        "version": 1,
+        "entities": [
+            {
+                "components": {
+                    "Transform": {
+                        "position": [1, 2, 3],
+                        "rotation": [0, 0, 0, 1],
+                        "scale": [1, 1, 1]
+                    }
+                }
+            }
+        ],
+        "hierarchy": [
+            { "child": 0, "parent": 4 }
+        ]
+    })");
+    ASSERT_TRUE(parsed.has_value());
+
+    Registry loaded = MakeSceneRegistry();
+    SceneLoadError error;
+    EXPECT_FALSE(LoadSceneJson(*parsed, loaded, &error));
+
+    EXPECT_EQ(loaded.Entities.Count(), 0u);
+    EXPECT_EQ(loaded.Components.Get<TransformStore<Transform3f>>().Count(), 0u);
+    EXPECT_EQ(loaded.Resources.Get<TransformHierarchyService>().Count(), 0u);
+}
+
+TEST(SceneSerializer, BinaryLoadRollsBackCreatedEntitiesOnFailure)
+{
+    ResetSceneSerializers();
+    auto stream = MakeBinaryStream();
+    BinaryWriter writer(stream);
+
+    ASSERT_TRUE(WriteBinaryHeader(writer, SceneMagic, SceneVersion));
+
+    {
+        ChunkWriter chunk;
+        ASSERT_TRUE(chunk.Begin(writer, SceneChunk::Registry, SceneVersion));
+        ASSERT_TRUE(Serialize(writer, std::uint32_t{ 1 }));
+        ASSERT_TRUE(Serialize(writer, EntityIndex{ 0 }));
+        ASSERT_TRUE(Serialize(writer, std::uint16_t{ 1 }));
+        ASSERT_TRUE(chunk.End(writer));
+    }
+
+    {
+        ChunkWriter chunk;
+        ASSERT_TRUE(chunk.Begin(writer, SceneChunk::Cameras, SceneVersion));
+        ASSERT_TRUE(Serialize(writer, std::uint32_t{ 1 }));
+        ASSERT_TRUE(Serialize(writer, EntityIndex{ 99 }));
+        ASSERT_TRUE(chunk.End(writer));
+    }
+
+    stream.seekg(0);
+    BinaryReader reader(stream);
+    Registry loaded = MakeSceneRegistry();
+    SceneLoadError error;
+    EXPECT_FALSE(LoadSceneBinary(reader, loaded, &error));
+
+    EXPECT_EQ(loaded.Entities.Count(), 0u);
+    EXPECT_EQ(loaded.Components.Get<CameraStore>().Count(), 0u);
+}
+
+TEST(SceneSerializer, BinarySkipsUnknownChunks)
+{
+    ResetSceneSerializers();
+    auto stream = MakeBinaryStream();
+    BinaryWriter writer(stream);
+
+    ASSERT_TRUE(WriteBinaryHeader(writer, SceneMagic, SceneVersion));
+
+    {
+        ChunkWriter chunk;
+        ASSERT_TRUE(chunk.Begin(writer, SceneChunk::Registry, SceneVersion));
+        ASSERT_TRUE(Serialize(writer, std::uint32_t{ 1 }));
+        ASSERT_TRUE(Serialize(writer, EntityIndex{ 0 }));
+        ASSERT_TRUE(Serialize(writer, std::uint16_t{ 1 }));
+        ASSERT_TRUE(chunk.End(writer));
+    }
+
+    {
+        ChunkWriter chunk;
+        ASSERT_TRUE(chunk.Begin(writer, MakeFourCC('T', 'E', 'S', 'T'), SceneVersion));
+        ASSERT_TRUE(Serialize(writer, std::uint32_t{ 0xDEADBEEFu }));
+        ASSERT_TRUE(chunk.End(writer));
+    }
+
+    {
+        ChunkWriter chunk;
+        ASSERT_TRUE(chunk.Begin(writer, SceneChunk::Cameras, SceneVersion));
+        ASSERT_TRUE(Serialize(writer, std::uint32_t{ 1 }));
+        ASSERT_TRUE(Serialize(writer, EntityIndex{ 0 }));
+        ASSERT_TRUE(Serialize(writer, CameraComponent{}));
+        ASSERT_TRUE(chunk.End(writer));
+    }
+
+    stream.seekg(0);
+    BinaryReader reader(stream);
+    Registry loaded;
+    ASSERT_TRUE(LoadSceneBinary(reader, loaded));
+
+    EXPECT_EQ(loaded.Entities.Count(), 1u);
+    EXPECT_EQ(loaded.Components.Get<CameraStore>().Count(), 1u);
+}
+
+TEST(SceneSerializer, HandlesEmptyRegistry)
+{
+    ResetSceneSerializers();
+    Registry source;
+    auto stream = MakeBinaryStream();
+    BinaryWriter writer(stream);
+    ASSERT_TRUE(SaveSceneBinary(source, writer));
+
+    stream.seekg(0);
+    BinaryReader reader(stream);
+    Registry loaded;
+    ASSERT_TRUE(LoadSceneBinary(reader, loaded));
+    EXPECT_EQ(loaded.Entities.Count(), 0u);
+
+    JsonValue json = SaveSceneJson(source);
+    Registry jsonLoaded;
+    ASSERT_TRUE(LoadSceneJson(json, jsonLoaded));
+    EXPECT_EQ(jsonLoaded.Entities.Count(), 0u);
+}


### PR DESCRIPTION
- Added JsonArchive for writing and reading JSON data structures.
- Introduced SceneSerializer for handling scene serialization in binary and JSON formats.
- Implemented tests for serialization and deserialization of scene data, including entity hierarchy and component data.
- Enhanced error handling during scene loading and added rollback mechanisms for failed loads.
- Created utility functions for managing entity transformations and component serialization.