### PR TITLE
feat: Enhance scene serialization with asset reference handling

### DIFF
--- a/engine/include/core/assets/AssetRef.h
+++ b/engine/include/core/assets/AssetRef.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+//=============================================================================
+// AssetType
+//
+// Stable tag identifying what kind of asset an AssetRef points at.
+// Serialized as a string ("Mesh", "Material", ...) in text formats.
+//=============================================================================
+enum class AssetType : uint16_t
+{
+    Unknown  = 0,
+    Mesh     = 1,
+    Material = 2,
+    Texture  = 3,
+    Scene    = 4,
+    Geometry = 5,
+    Audio    = 6,
+    Script   = 7,
+};
+
+inline std::string_view AssetTypeToString(AssetType type)
+{
+    switch (type)
+    {
+    case AssetType::Mesh:     return "Mesh";
+    case AssetType::Material: return "Material";
+    case AssetType::Texture:  return "Texture";
+    case AssetType::Scene:    return "Scene";
+    case AssetType::Geometry: return "Geometry";
+    case AssetType::Audio:    return "Audio";
+    case AssetType::Script:   return "Script";
+    default:                  return "Unknown";
+    }
+}
+
+inline bool AssetTypeFromString(std::string_view name, AssetType& out)
+{
+    if (name == "Mesh")     { out = AssetType::Mesh;     return true; }
+    if (name == "Material") { out = AssetType::Material; return true; }
+    if (name == "Texture")  { out = AssetType::Texture;  return true; }
+    if (name == "Scene")    { out = AssetType::Scene;    return true; }
+    if (name == "Geometry") { out = AssetType::Geometry; return true; }
+    if (name == "Audio")    { out = AssetType::Audio;    return true; }
+    if (name == "Script")   { out = AssetType::Script;   return true; }
+    return false;
+}
+
+//=============================================================================
+// AssetRef
+//
+// Stable, serializable reference to an asset. Used in scene files and editor
+// data; never stored in runtime components (those use cache handles).
+//
+// Fields:
+//   Type  - expected asset type; validated on resolve.
+//   Path  - virtual asset path, e.g. "asset://meshes/dev/cube.smesh".
+//           Used as the primary identity until AssetId is introduced.
+//=============================================================================
+struct AssetRef
+{
+    AssetType   Type = AssetType::Unknown;
+    std::string Path;
+
+    bool IsValid() const
+    {
+        return Type != AssetType::Unknown && !Path.empty();
+    }
+};

--- a/engine/include/core/assets/AssetRegistry.h
+++ b/engine/include/core/assets/AssetRegistry.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <core/assets/AssetRef.h>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+struct AssetRecord
+{
+    AssetType Type = AssetType::Unknown;
+    std::string Path;
+    std::string FilePath;
+    uint64_t ContentHash = 0;
+    uint32_t Version = 1;
+};
+
+class AssetRegistry
+{
+public:
+    bool Register(AssetRecord record);
+
+    [[nodiscard]] const AssetRecord* FindByPath(std::string_view path) const;
+    [[nodiscard]] bool Contains(std::string_view path) const;
+
+private:
+    std::unordered_map<std::string, AssetRecord> RecordsByPath;
+};
+
+bool ScanAssetsDirectory(std::string_view rootDirectory, AssetRegistry& registry);

--- a/engine/include/core/assets/AssetSystem.h
+++ b/engine/include/core/assets/AssetSystem.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <core/assets/AssetRegistry.h>
+#include <render/Material.h>
+#include <render/MeshTypes.h>
+
+#include <string_view>
+
+class MaterialCache;
+class MeshCache;
+
+class AssetSystem
+{
+public:
+    AssetSystem(AssetRegistry& registry,
+                MeshCache& meshes,
+                MaterialCache& materials);
+    AssetSystem(AssetRegistry& registry,
+                MeshCache* meshes,
+                MaterialCache* materials);
+
+    [[nodiscard]] MeshHandle LoadMesh(std::string_view path);
+    [[nodiscard]] MaterialHandle LoadMaterial(std::string_view path);
+
+    [[nodiscard]] const AssetRecord* Resolve(std::string_view path, AssetType expectedType) const;
+
+private:
+    AssetRegistry& Registry;
+    MeshCache* Meshes = nullptr;
+    MaterialCache* Materials = nullptr;
+};

--- a/engine/include/core/serialization/Archive.h
+++ b/engine/include/core/serialization/Archive.h
@@ -40,6 +40,7 @@ struct IWriteArchive
     virtual IWriteArchive& End() = 0;
     virtual bool Ok() const = 0;
     virtual bool IsText() const = 0;
+    virtual void MarkInvalidField(std::string_view key) = 0;
     virtual ~IWriteArchive() = default;
 
     template <typename FieldT, typename T>
@@ -68,6 +69,8 @@ struct IReadArchive
     virtual IReadArchive& BeginArray(std::string_view key, std::size_t& count) = 0;
     virtual IReadArchive& End() = 0;
     virtual bool HasField(std::string_view key) const = 0;
+    virtual bool IsString(std::string_view key) const = 0;
+    virtual bool IsObject(std::string_view key) const = 0;
     virtual bool Ok() const = 0;
     virtual bool IsText() const = 0;
     virtual void MarkMissingField(std::string_view key) = 0;

--- a/engine/include/core/serialization/BinaryArchive.h
+++ b/engine/include/core/serialization/BinaryArchive.h
@@ -25,6 +25,7 @@ public:
     IWriteArchive& End() override;
     bool Ok() const override { return IsOk; }
     bool IsText() const override { return false; }
+    void MarkInvalidField(std::string_view key) override;
 
 private:
     BinaryWriter& Writer;
@@ -52,6 +53,8 @@ public:
     IReadArchive& BeginArray(std::string_view key, std::size_t& count) override;
     IReadArchive& End() override;
     bool HasField(std::string_view key) const override;
+    bool IsString(std::string_view key) const override;
+    bool IsObject(std::string_view key) const override;
     bool Ok() const override { return IsOk; }
     bool IsText() const override { return false; }
     void MarkMissingField(std::string_view key) override;

--- a/engine/include/core/serialization/JsonArchive.h
+++ b/engine/include/core/serialization/JsonArchive.h
@@ -25,6 +25,7 @@ public:
     IWriteArchive& End() override;
     bool Ok() const override { return IsOk; }
     bool IsText() const override { return true; }
+    void MarkInvalidField(std::string_view key) override;
 
     [[nodiscard]] JsonValue TakeValue();
 
@@ -65,6 +66,8 @@ public:
     IReadArchive& BeginArray(std::string_view key, std::size_t& count) override;
     IReadArchive& End() override;
     bool HasField(std::string_view key) const override;
+    bool IsString(std::string_view key) const override;
+    bool IsObject(std::string_view key) const override;
     bool Ok() const override { return IsOk; }
     bool IsText() const override { return true; }
     void MarkMissingField(std::string_view key) override;

--- a/engine/include/world/serialization/ComponentSerializer.h
+++ b/engine/include/world/serialization/ComponentSerializer.h
@@ -4,6 +4,66 @@
 #include <core/metadata/TypeSchema.h>
 #include <world/serialization/ComponentStorageTraits.h>
 #include <world/serialization/IComponentSerializer.h>
+#include <world/serialization/SceneFieldCodec.h>
+
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+
+namespace SceneComponentSerialization
+{
+    template<typename Component>
+    bool SaveFields(IWriteArchive& archive,
+                    const Component& component,
+                    SceneSerializationContext& context)
+    {
+        archive.BeginObject(std::string_view{});
+
+        bool ok = true;
+        auto fields = TypeSchema<Component>::Fields();
+        std::apply([&](auto&... field)
+        {
+            ((ok = SceneFieldCodec<std::remove_cvref_t<decltype(component.*field.Ptr)>>::Save(
+                archive, field.Name, component.*field.Ptr, context) && ok), ...);
+        }, fields);
+
+        archive.End();
+        return ok && archive.Ok();
+    }
+
+    template<typename Component>
+    bool LoadFields(IReadArchive& archive,
+                    Component& component,
+                    SceneSerializationContext& context)
+    {
+        archive.BeginObject(std::string_view{});
+
+        bool ok = true;
+        auto fields = TypeSchema<Component>::Fields();
+        std::apply([&](auto&... field)
+        {
+            (([&]
+            {
+                if (!archive.HasField(field.Name))
+                {
+                    if (field.DefaultValue)
+                        component.*field.Ptr = *field.DefaultValue;
+                    else if (!field.IsOptional)
+                        archive.MarkMissingField(field.Name);
+                    ok = archive.Ok() && ok;
+                    return;
+                }
+
+                using FieldType = std::remove_cvref_t<decltype(component.*field.Ptr)>;
+                ok = SceneFieldCodec<FieldType>::Load(
+                    archive, field.Name, component.*field.Ptr, context) && ok;
+            }()), ...);
+        }, fields);
+
+        archive.End();
+        return ok && archive.Ok();
+    }
+}
 
 //=============================================================================
 // ComponentSerializer
@@ -27,22 +87,26 @@ public:
         return store && store->TryGet(entity);
     }
 
-    bool Save(IWriteArchive& archive, EntityId entity, const Registry& registry) const override
+    bool Save(IWriteArchive& archive,
+              EntityId entity,
+              const Registry& registry,
+              SceneSerializationContext& context) const override
     {
         const auto* store = registry.Components.TryGet<typename Traits::Store>();
         const Component* component = store ? store->TryGet(entity) : nullptr;
         if (!component)
             return true;
 
-        WriteArchiveValue(archive, {}, *component);
-        return archive.Ok();
+        return SceneComponentSerialization::SaveFields(archive, *component, context);
     }
 
-    bool Load(IReadArchive& archive, EntityId entity, Registry& registry) override
+    bool Load(IReadArchive& archive,
+              EntityId entity,
+              Registry& registry,
+              SceneSerializationContext& context) override
     {
         Component component{};
-        ReadArchiveValue(archive, {}, component);
-        if (!archive.Ok())
+        if (!SceneComponentSerialization::LoadFields(archive, component, context))
             return false;
 
         return Traits::Add(registry, entity, component);
@@ -77,7 +141,10 @@ public:
         return store && store->TryGet(entity);
     }
 
-    bool Save(IWriteArchive& archive, EntityId entity, const Registry& registry) const override
+    bool Save(IWriteArchive& archive,
+              EntityId entity,
+              const Registry& registry,
+              SceneSerializationContext&) const override
     {
         const auto* store = registry.Components.TryGet<typename Traits::Store>();
         const Component* component = store ? store->TryGet(entity) : nullptr;
@@ -88,7 +155,10 @@ public:
         return archive.Ok();
     }
 
-    bool Load(IReadArchive& archive, EntityId entity, Registry& registry) override
+    bool Load(IReadArchive& archive,
+              EntityId entity,
+              Registry& registry,
+              SceneSerializationContext&) override
     {
         Component component{};
         ReadArchiveValue(archive, {}, component.Local);

--- a/engine/include/world/serialization/IComponentSerializer.h
+++ b/engine/include/world/serialization/IComponentSerializer.h
@@ -3,6 +3,7 @@
 #include <core/serialization/Archive.h>
 #include <world/entity/EntityId.h>
 #include <world/registry/Registry.h>
+#include <world/serialization/SceneSerializationContext.h>
 
 #include <cstdint>
 #include <string_view>
@@ -20,8 +21,14 @@ struct IComponentSerializer
     virtual std::uint32_t BinaryChunkId() const = 0;
 
     virtual bool HasComponent(EntityId entity, const Registry& registry) const = 0;
-    virtual bool Save(IWriteArchive& archive, EntityId entity, const Registry& registry) const = 0;
-    virtual bool Load(IReadArchive& archive, EntityId entity, Registry& registry) = 0;
+    virtual bool Save(IWriteArchive& archive,
+                      EntityId entity,
+                      const Registry& registry,
+                      SceneSerializationContext& context) const = 0;
+    virtual bool Load(IReadArchive& archive,
+                      EntityId entity,
+                      Registry& registry,
+                      SceneSerializationContext& context) = 0;
     virtual bool Remove(EntityId entity, Registry& registry) const = 0;
 
     virtual ~IComponentSerializer() = default;

--- a/engine/include/world/serialization/SceneFieldCodec.h
+++ b/engine/include/world/serialization/SceneFieldCodec.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <core/assets/AssetRef.h>
+#include <core/serialization/Archive.h>
+#include <render/Material.h>
+#include <render/MeshTypes.h>
+#include <world/serialization/SceneSerializationContext.h>
+
+#include <cassert>
+#include <cstdio>
+#include <string>
+#include <string_view>
+
+//=============================================================================
+// SceneFieldCodec
+//
+// TypeSchema<T> describes fields and structure. SceneFieldCodec<T> describes
+// how each field type is persisted in scene files.
+//=============================================================================
+template<typename T>
+struct SceneFieldCodec
+{
+    static bool Save(IWriteArchive& archive,
+                     std::string_view key,
+                     const T& value,
+                     SceneSerializationContext&)
+    {
+        WriteArchiveValue(archive, key, value);
+        return archive.Ok();
+    }
+
+    static bool Load(IReadArchive& archive,
+                     std::string_view key,
+                     T& value,
+                     SceneSerializationContext&)
+    {
+        ReadArchiveValue(archive, key, value);
+        return archive.Ok();
+    }
+};
+
+template<>
+struct SceneFieldCodec<MeshHandle>
+{
+    static bool Save(IWriteArchive& archive,
+                     std::string_view key,
+                     MeshHandle value,
+                     SceneSerializationContext& context);
+
+    static bool Load(IReadArchive& archive,
+                     std::string_view key,
+                     MeshHandle& value,
+                     SceneSerializationContext& context);
+};
+
+template<>
+struct SceneFieldCodec<MaterialHandle>
+{
+    static bool Save(IWriteArchive& archive,
+                     std::string_view key,
+                     MaterialHandle value,
+                     SceneSerializationContext& context);
+
+    static bool Load(IReadArchive& archive,
+                     std::string_view key,
+                     MaterialHandle& value,
+                     SceneSerializationContext& context);
+};
+

--- a/engine/include/world/serialization/SceneSerializationContext.h
+++ b/engine/include/world/serialization/SceneSerializationContext.h
@@ -1,0 +1,19 @@
+#pragma once
+
+class AssetSystem;
+class MaterialCache;
+class MeshCache;
+
+//=============================================================================
+// SceneSerializationContext
+//
+// Explicit dependencies used by scene field codecs to convert stable persisted
+// references into runtime handles, and runtime handles back into stable refs.
+//=============================================================================
+struct SceneSerializationContext
+{
+    AssetSystem* Assets = nullptr;
+
+    MeshCache* Meshes = nullptr;
+    MaterialCache* Materials = nullptr;
+};

--- a/engine/include/world/serialization/SceneSerializer.h
+++ b/engine/include/world/serialization/SceneSerializer.h
@@ -5,6 +5,7 @@
 #include <core/serialization/BinaryWriter.h>
 #include <world/serialization/ComponentSerializer.h>
 #include <world/serialization/IComponentSerializer.h>
+#include <world/serialization/SceneSerializationContext.h>
 
 #include <cstdint>
 #include <memory>
@@ -41,9 +42,23 @@ void RegisterComponent()
 
 [[nodiscard]] bool SaveSceneBinary(const Registry& registry, BinaryWriter& writer,
     SceneSaveError* error = nullptr);
+[[nodiscard]] bool SaveSceneBinary(const Registry& registry,
+    BinaryWriter& writer,
+    SceneSerializationContext& context,
+    SceneSaveError* error = nullptr);
 [[nodiscard]] bool LoadSceneBinary(BinaryReader& reader, Registry& registry,
+    SceneLoadError* error = nullptr);
+[[nodiscard]] bool LoadSceneBinary(BinaryReader& reader,
+    Registry& registry,
+    SceneSerializationContext& context,
     SceneLoadError* error = nullptr);
 
 [[nodiscard]] JsonValue SaveSceneJson(const Registry& registry);
+[[nodiscard]] JsonValue SaveSceneJson(const Registry& registry,
+    SceneSerializationContext& context);
 [[nodiscard]] bool LoadSceneJson(const JsonValue& root, Registry& registry,
+    SceneLoadError* error = nullptr);
+[[nodiscard]] bool LoadSceneJson(const JsonValue& root,
+    Registry& registry,
+    SceneSerializationContext& context,
     SceneLoadError* error = nullptr);

--- a/engine/src/core/assets/AssetRegistry.cpp
+++ b/engine/src/core/assets/AssetRegistry.cpp
@@ -1,0 +1,79 @@
+#include <core/assets/AssetRegistry.h>
+
+#include <filesystem>
+
+namespace
+{
+    AssetType AssetTypeFromExtension(std::string_view extension)
+    {
+        if (extension == ".smesh") return AssetType::Mesh;
+        if (extension == ".smat")  return AssetType::Material;
+        if (extension == ".stex")  return AssetType::Texture;
+        if (extension == ".smap")  return AssetType::Scene;
+        return AssetType::Unknown;
+    }
+
+    std::string MakeVirtualAssetPath(const std::filesystem::path& root,
+                                     const std::filesystem::path& file)
+    {
+        std::filesystem::path relative = std::filesystem::relative(file, root);
+        return std::string("asset://") + relative.generic_string();
+    }
+}
+
+bool AssetRegistry::Register(AssetRecord record)
+{
+    if (record.Path.empty() || record.Type == AssetType::Unknown)
+        return false;
+
+    auto [_, inserted] = RecordsByPath.emplace(record.Path, std::move(record));
+    return inserted;
+}
+
+const AssetRecord* AssetRegistry::FindByPath(std::string_view path) const
+{
+    auto it = RecordsByPath.find(std::string(path));
+    return it == RecordsByPath.end() ? nullptr : &it->second;
+}
+
+bool AssetRegistry::Contains(std::string_view path) const
+{
+    return FindByPath(path) != nullptr;
+}
+
+bool ScanAssetsDirectory(std::string_view rootDirectory, AssetRegistry& registry)
+{
+    if (rootDirectory.empty())
+        return false;
+
+    const std::filesystem::path root{std::string(rootDirectory)};
+    std::error_code ec;
+    if (!std::filesystem::is_directory(root, ec))
+        return false;
+
+    bool ok = true;
+    for (std::filesystem::recursive_directory_iterator it(root, ec), end; it != end; it.increment(ec))
+    {
+        if (ec)
+        {
+            ok = false;
+            ec.clear();
+            continue;
+        }
+
+        if (!it->is_regular_file(ec))
+            continue;
+
+        const AssetType type = AssetTypeFromExtension(it->path().extension().generic_string());
+        if (type == AssetType::Unknown)
+            continue;
+
+        AssetRecord record;
+        record.Type = type;
+        record.Path = MakeVirtualAssetPath(root, it->path());
+        record.FilePath = it->path().generic_string();
+        ok = registry.Register(std::move(record)) && ok;
+    }
+
+    return ok;
+}

--- a/engine/src/core/assets/AssetSystem.cpp
+++ b/engine/src/core/assets/AssetSystem.cpp
@@ -1,0 +1,116 @@
+#include <core/assets/AssetSystem.h>
+
+#include <render/MaterialCache.h>
+#include <render/MeshCache.h>
+
+#include <cstdio>
+
+AssetSystem::AssetSystem(AssetRegistry& registry,
+                         MeshCache& meshes,
+                         MaterialCache& materials)
+    : Registry(registry)
+    , Meshes(&meshes)
+    , Materials(&materials)
+{
+}
+
+AssetSystem::AssetSystem(AssetRegistry& registry,
+                         MeshCache* meshes,
+                         MaterialCache* materials)
+    : Registry(registry)
+    , Meshes(meshes)
+    , Materials(materials)
+{
+}
+
+const AssetRecord* AssetSystem::Resolve(std::string_view path, AssetType expectedType) const
+{
+    if (path.empty())
+    {
+        std::fprintf(stderr, "AssetSystem: empty asset path\n");
+        return nullptr;
+    }
+
+    const AssetRecord* record = Registry.FindByPath(path);
+    if (!record)
+    {
+        std::fprintf(stderr, "AssetSystem: asset path not registered: %.*s\n",
+            static_cast<int>(path.size()), path.data());
+        return nullptr;
+    }
+
+    if (record->Type != expectedType)
+    {
+        std::fprintf(stderr, "AssetSystem: expected %.*s asset, got %.*s for path %s\n",
+            static_cast<int>(AssetTypeToString(expectedType).size()),
+            AssetTypeToString(expectedType).data(),
+            static_cast<int>(AssetTypeToString(record->Type).size()),
+            AssetTypeToString(record->Type).data(),
+            record->Path.c_str());
+        return nullptr;
+    }
+
+    return record;
+}
+
+MeshHandle AssetSystem::LoadMesh(std::string_view path)
+{
+    const AssetRecord* record = Resolve(path, AssetType::Mesh);
+    if (!record)
+        return {};
+
+    if (!record->FilePath.empty())
+    {
+        std::fprintf(stderr, "AssetSystem: mesh asset loading from file not implemented: %s\n",
+            record->FilePath.c_str());
+        return {};
+    }
+
+    if (!Meshes)
+    {
+        std::fprintf(stderr, "AssetSystem: missing MeshCache for mesh asset %s\n",
+            record->Path.c_str());
+        return {};
+    }
+
+    MeshHandle handle = Meshes->Acquire(record->Path);
+    if (!handle.IsValid())
+    {
+        std::fprintf(stderr, "AssetSystem: mesh cache has no runtime resource for path %s\n",
+            record->Path.c_str());
+        return {};
+    }
+
+    return handle;
+}
+
+MaterialHandle AssetSystem::LoadMaterial(std::string_view path)
+{
+    const AssetRecord* record = Resolve(path, AssetType::Material);
+    if (!record)
+        return {};
+
+    if (!record->FilePath.empty())
+    {
+        std::fprintf(stderr, "AssetSystem: material asset loading from file not implemented: %s\n",
+            record->FilePath.c_str());
+        return {};
+    }
+
+    if (!Materials)
+    {
+        std::fprintf(stderr, "AssetSystem: missing MaterialCache for material asset %s\n",
+            record->Path.c_str());
+        return {};
+    }
+
+    MaterialHandle handle = Materials->Acquire(record->Path);
+    if (!handle.IsValid())
+    {
+        std::fprintf(stderr, "AssetSystem: material cache has no runtime resource for path %s\n",
+            record->Path.c_str());
+        return {};
+    }
+
+    return handle;
+}

--- a/engine/src/core/serialization/BinaryArchive.cpp
+++ b/engine/src/core/serialization/BinaryArchive.cpp
@@ -57,6 +57,11 @@ IWriteArchive& BinaryWriteArchive::End()
     return *this;
 }
 
+void BinaryWriteArchive::MarkInvalidField(std::string_view)
+{
+    IsOk = false;
+}
+
 IReadArchive& BinaryReadArchive::Field(std::string_view, bool& value)
 {
     IsOk = IsOk && Reader.Read(value);
@@ -115,6 +120,16 @@ IReadArchive& BinaryReadArchive::End()
 bool BinaryReadArchive::HasField(std::string_view) const
 {
     return true;
+}
+
+bool BinaryReadArchive::IsString(std::string_view) const
+{
+    return false;
+}
+
+bool BinaryReadArchive::IsObject(std::string_view) const
+{
+    return false;
 }
 
 void BinaryReadArchive::MarkMissingField(std::string_view)

--- a/engine/src/core/serialization/JsonArchive.cpp
+++ b/engine/src/core/serialization/JsonArchive.cpp
@@ -68,6 +68,11 @@ IWriteArchive& JsonWriteArchive::End()
     return *this;
 }
 
+void JsonWriteArchive::MarkInvalidField(std::string_view)
+{
+    IsOk = false;
+}
+
 JsonValue JsonWriteArchive::TakeValue()
 {
     if (!Stack.empty())
@@ -210,6 +215,18 @@ IReadArchive& JsonReadArchive::End()
 bool JsonReadArchive::HasField(std::string_view key) const
 {
     return PeekValue(key) != nullptr;
+}
+
+bool JsonReadArchive::IsString(std::string_view key) const
+{
+    const JsonValue* value = PeekValue(key);
+    return value && value->IsString();
+}
+
+bool JsonReadArchive::IsObject(std::string_view key) const
+{
+    const JsonValue* value = PeekValue(key);
+    return value && value->IsObject();
 }
 
 void JsonReadArchive::MarkMissingField(std::string_view)

--- a/engine/src/world/serialization/SceneFieldCodec.cpp
+++ b/engine/src/world/serialization/SceneFieldCodec.cpp
@@ -1,0 +1,230 @@
+#include <world/serialization/SceneFieldCodec.h>
+
+#include <core/assets/AssetSystem.h>
+#include <render/MaterialCache.h>
+#include <render/MeshCache.h>
+
+namespace
+{
+    bool RejectBinaryWrite(IWriteArchive& archive, std::string_view key)
+    {
+        assert(false && "Binary scene serialization for AssetRef-backed handles is not implemented yet");
+        std::fprintf(stderr,
+            "SceneFieldCodec: binary scene serialization for field \"%.*s\" is not implemented yet\n",
+            static_cast<int>(key.size()), key.data());
+        archive.MarkInvalidField(key);
+        return false;
+    }
+
+    bool RejectBinaryRead(IReadArchive& archive, std::string_view key)
+    {
+        assert(false && "Binary scene serialization for AssetRef-backed handles is not implemented yet");
+        std::fprintf(stderr,
+            "SceneFieldCodec: binary scene deserialization for field \"%.*s\" is not implemented yet\n",
+            static_cast<int>(key.size()), key.data());
+        archive.MarkInvalidField(key);
+        return false;
+    }
+
+    bool ReadLegacyAssetRef(IReadArchive& archive,
+                            std::string_view key,
+                            AssetType expected,
+                            std::string& outPath)
+    {
+        std::string typeText;
+        std::string path;
+
+        archive.BeginObject(key);
+        archive.Field(std::string_view{"type"}, typeText);
+        archive.Field(std::string_view{"path"}, path);
+        archive.End();
+
+        if (!archive.Ok())
+            return false;
+
+        AssetType type = AssetType::Unknown;
+        if (!AssetTypeFromString(typeText, type))
+        {
+            std::fprintf(stderr,
+                "SceneFieldCodec: field \"%.*s\" has unknown asset type \"%s\"\n",
+                static_cast<int>(key.size()), key.data(), typeText.c_str());
+            archive.MarkInvalidField(key);
+            return false;
+        }
+
+        if (type != expected)
+        {
+            std::fprintf(stderr,
+                "SceneFieldCodec: field \"%.*s\" expected asset type \"%.*s\", got \"%s\"\n",
+                static_cast<int>(key.size()), key.data(),
+                static_cast<int>(AssetTypeToString(expected).size()), AssetTypeToString(expected).data(),
+                typeText.c_str());
+            archive.MarkInvalidField(key);
+            return false;
+        }
+
+        if (path.empty())
+        {
+            std::fprintf(stderr,
+                "SceneFieldCodec: field \"%.*s\" has an empty asset path\n",
+                static_cast<int>(key.size()), key.data());
+            archive.MarkMissingField(key);
+            return false;
+        }
+
+        outPath = std::move(path);
+        return true;
+    }
+
+    bool ReadTypedAssetPath(IReadArchive& archive,
+                            std::string_view key,
+                            AssetType expected,
+                            std::string& outPath)
+    {
+        if (archive.IsString(key))
+        {
+            archive.Field(key, outPath);
+            if (!archive.Ok())
+                return false;
+
+            if (!outPath.empty())
+                return true;
+
+            std::fprintf(stderr,
+                "SceneFieldCodec: field \"%.*s\" has an empty asset path\n",
+                static_cast<int>(key.size()), key.data());
+            archive.MarkMissingField(key);
+            return false;
+        }
+
+        if (archive.IsObject(key))
+            return ReadLegacyAssetRef(archive, key, expected, outPath);
+
+        std::fprintf(stderr,
+            "SceneFieldCodec: field \"%.*s\" must be an asset path string or legacy AssetRef object\n",
+            static_cast<int>(key.size()), key.data());
+        archive.MarkInvalidField(key);
+        return false;
+    }
+
+    bool WriteTypedAssetPath(IWriteArchive& archive,
+                             std::string_view key,
+                             std::string_view path)
+    {
+        if (path.empty())
+        {
+            std::fprintf(stderr,
+                "SceneFieldCodec: field \"%.*s\" has no registered asset path\n",
+                static_cast<int>(key.size()), key.data());
+            archive.MarkInvalidField(key);
+            return false;
+        }
+
+        archive.Field(key, path);
+        return archive.Ok();
+    }
+}
+
+bool SceneFieldCodec<MeshHandle>::Save(IWriteArchive& archive,
+                                       std::string_view key,
+                                       MeshHandle value,
+                                       SceneSerializationContext& context)
+{
+    if (!archive.IsText())
+        return RejectBinaryWrite(archive, key);
+
+    if (!context.Meshes)
+    {
+        std::fprintf(stderr, "SceneFieldCodec<MeshHandle>: missing MeshCache for field \"%.*s\"\n",
+            static_cast<int>(key.size()), key.data());
+        archive.MarkInvalidField(key);
+        return false;
+    }
+
+    return WriteTypedAssetPath(archive, key, context.Meshes->GetName(value));
+}
+
+bool SceneFieldCodec<MeshHandle>::Load(IReadArchive& archive,
+                                       std::string_view key,
+                                       MeshHandle& value,
+                                       SceneSerializationContext& context)
+{
+    if (!archive.IsText())
+        return RejectBinaryRead(archive, key);
+
+    std::string path;
+    if (!ReadTypedAssetPath(archive, key, AssetType::Mesh, path))
+        return false;
+
+    if (!context.Assets)
+    {
+        std::fprintf(stderr, "SceneFieldCodec<MeshHandle>: missing AssetSystem for field \"%.*s\"\n",
+            static_cast<int>(key.size()), key.data());
+        archive.MarkInvalidField(key);
+        return false;
+    }
+
+    value = context.Assets->LoadMesh(path);
+    if (!value.IsValid())
+    {
+        std::fprintf(stderr,
+            "SceneFieldCodec<MeshHandle>: failed to load mesh asset \"%s\"\n",
+            path.c_str());
+        archive.MarkInvalidField(key);
+        return false;
+    }
+
+    return archive.Ok();
+}
+
+bool SceneFieldCodec<MaterialHandle>::Save(IWriteArchive& archive,
+                                           std::string_view key,
+                                           MaterialHandle value,
+                                           SceneSerializationContext& context)
+{
+    if (!archive.IsText())
+        return RejectBinaryWrite(archive, key);
+
+    if (!context.Materials)
+    {
+        std::fprintf(stderr, "SceneFieldCodec<MaterialHandle>: missing MaterialCache for field \"%.*s\"\n",
+            static_cast<int>(key.size()), key.data());
+        archive.MarkInvalidField(key);
+        return false;
+    }
+
+    return WriteTypedAssetPath(archive, key, context.Materials->GetName(value));
+}
+
+bool SceneFieldCodec<MaterialHandle>::Load(IReadArchive& archive,
+                                           std::string_view key,
+                                           MaterialHandle& value,
+                                           SceneSerializationContext& context)
+{
+    if (!archive.IsText())
+        return RejectBinaryRead(archive, key);
+
+    std::string path;
+    if (!ReadTypedAssetPath(archive, key, AssetType::Material, path))
+        return false;
+
+    if (!context.Assets)
+    {
+        std::fprintf(stderr, "SceneFieldCodec<MaterialHandle>: missing AssetSystem for field \"%.*s\"\n",
+            static_cast<int>(key.size()), key.data());
+        archive.MarkInvalidField(key);
+        return false;
+    }
+
+    value = context.Assets->LoadMaterial(path);
+    if (!value.IsValid())
+    {
+        std::fprintf(stderr,
+            "SceneFieldCodec<MaterialHandle>: failed to load material asset \"%s\"\n",
+            path.c_str());
+        archive.MarkInvalidField(key);
+        return false;
+    }
+
+    return archive.Ok();
+}

--- a/engine/src/world/serialization/SceneSerializer.cpp
+++ b/engine/src/world/serialization/SceneSerializer.cpp
@@ -190,7 +190,8 @@ namespace
     bool SaveComponentChunkBinary(const IComponentSerializer& serializer,
                                   const std::vector<EntityId>& entities,
                                   const Registry& registry,
-                                  BinaryWriter& writer)
+                                  BinaryWriter& writer,
+                                  SceneSerializationContext& context)
     {
         // Buffer component data first so the entity count (unknown upfront) can be
         // written before the payload, as required by the chunk format.
@@ -207,7 +208,7 @@ namespace
                 return false;
 
             BinaryWriteArchive archive(payloadWriter);
-            if (!serializer.Save(archive, entity, registry) || !archive.Ok())
+            if (!serializer.Save(archive, entity, registry, context) || !archive.Ok())
                 return false;
 
             ++count;
@@ -230,7 +231,8 @@ namespace
                                   BinaryReader& reader,
                                   std::uint32_t count,
                                   Registry& registry,
-                                  const std::unordered_map<EntityIndex, EntityId>& remap)
+                                  const std::unordered_map<EntityIndex, EntityId>& remap,
+                                  SceneSerializationContext& context)
     {
         for (std::uint32_t i = 0; i < count; ++i)
         {
@@ -243,7 +245,7 @@ namespace
                 return false;
 
             BinaryReadArchive archive(reader);
-            if (!serializer.Load(archive, owner, registry) || !archive.Ok())
+            if (!serializer.Load(archive, owner, registry, context) || !archive.Ok())
                 return false;
         }
         return true;
@@ -290,8 +292,8 @@ void ClearComponentSerializers()
 void InitSceneSerializer()
 {
     RegisterComponent<TransformComponent<Transform3f>>();
-    RegisterComponent<MeshRendererComponent>();
     RegisterComponent<CameraComponent>();
+    RegisterComponent<MeshRendererComponent>();
 }
 
 const std::vector<std::unique_ptr<IComponentSerializer>>& GetComponentSerializerEntries()
@@ -300,6 +302,15 @@ const std::vector<std::unique_ptr<IComponentSerializer>>& GetComponentSerializer
 }
 
 bool SaveSceneBinary(const Registry& registry, BinaryWriter& writer, SceneSaveError* error)
+{
+    SceneSerializationContext context;
+    return SaveSceneBinary(registry, writer, context, error);
+}
+
+bool SaveSceneBinary(const Registry& registry,
+                     BinaryWriter& writer,
+                     SceneSerializationContext& context,
+                     SceneSaveError* error)
 {
     const auto entities = registry.Entities.GetAliveEntities();
 
@@ -325,7 +336,7 @@ bool SaveSceneBinary(const Registry& registry, BinaryWriter& writer, SceneSaveEr
     {
         ChunkWriter chunk;
         if (!chunk.Begin(writer, entry->BinaryChunkId(), SceneVersion)
-            || !SaveComponentChunkBinary(*entry, entities, registry, writer)
+            || !SaveComponentChunkBinary(*entry, entities, registry, writer, context)
             || !chunk.End(writer))
         {
             SetError(error, "Failed to write component chunk.");
@@ -337,6 +348,15 @@ bool SaveSceneBinary(const Registry& registry, BinaryWriter& writer, SceneSaveEr
 }
 
 bool LoadSceneBinary(BinaryReader& reader, Registry& registry, SceneLoadError* error)
+{
+    SceneSerializationContext context;
+    return LoadSceneBinary(reader, registry, context, error);
+}
+
+bool LoadSceneBinary(BinaryReader& reader,
+                     Registry& registry,
+                     SceneSerializationContext& context,
+                     SceneLoadError* error)
 {
     BinaryHeader header;
     if (!ReadBinaryHeader(reader, header)
@@ -374,7 +394,7 @@ bool LoadSceneBinary(BinaryReader& reader, Registry& registry, SceneLoadError* e
         {
             std::uint32_t count = 0;
             ok = Deserialize(reader, count)
-                && LoadComponentChunkBinary(*entry, reader, count, registry, remap);
+                && LoadComponentChunkBinary(*entry, reader, count, registry, remap, context);
         }
 
         if (!ok)
@@ -404,6 +424,12 @@ bool LoadSceneBinary(BinaryReader& reader, Registry& registry, SceneLoadError* e
 
 JsonValue SaveSceneJson(const Registry& registry)
 {
+    SceneSerializationContext context;
+    return SaveSceneJson(registry, context);
+}
+
+JsonValue SaveSceneJson(const Registry& registry, SceneSerializationContext& context)
+{
     JsonValue::Array entitiesJson;
     JsonValue::Array hierarchyJson;
     const auto entities = registry.Entities.GetAliveEntities();
@@ -419,8 +445,8 @@ JsonValue SaveSceneJson(const Registry& registry)
         for (const auto& entry : SerializerEntries())
         {
             JsonWriteArchive archive;
-            if (!entry->Save(archive, entity, registry) || !archive.Ok())
-                continue;
+            if (!entry->Save(archive, entity, registry, context) || !archive.Ok())
+                return {};
 
             JsonValue component = archive.TakeValue();
             if (!component.IsNull())
@@ -460,6 +486,15 @@ JsonValue SaveSceneJson(const Registry& registry)
 }
 
 bool LoadSceneJson(const JsonValue& root, Registry& registry, SceneLoadError* error)
+{
+    SceneSerializationContext context;
+    return LoadSceneJson(root, registry, context, error);
+}
+
+bool LoadSceneJson(const JsonValue& root,
+                   Registry& registry,
+                   SceneSerializationContext& context,
+                   SceneLoadError* error)
 {
     if (!root.IsObject())
     {
@@ -510,7 +545,7 @@ bool LoadSceneJson(const JsonValue& root, Registry& registry, SceneLoadError* er
                 continue;
 
             JsonReadArchive archive(componentData);
-            if (!entry->Load(archive, entity, registry) || !archive.Ok())
+            if (!entry->Load(archive, entity, registry, context) || !archive.Ok())
             {
                 RollbackLoadedEntities(registry, entities);
                 SetError(error, "Failed to load JSON component.");

--- a/example/CubeDemo/CubeDemoScene.cpp
+++ b/example/CubeDemo/CubeDemoScene.cpp
@@ -1,5 +1,6 @@
 #include "CubeDemoScene.h"
 
+#include <core/assets/AssetSystem.h>
 #include <core/json/JsonParser.h>
 #include <render/Camera.h>
 #include <render/MeshRendererComponent.h>
@@ -25,12 +26,36 @@ DemoScene LoadDemoScene(Registry& registry,
 {
     DemoScene scene;
 
-    // Register assets in a fixed order so their handles match the JSON.
-    // Mesh index 1 / Material indices 1-3 are baked into cube_demo_scene.json.
-    scene.CubeMesh  = meshes.CreateFromData("cube_1m", MeshPrimitives::BuildCube(1.0f));
-    scene.Red   = materials.Register("red",   Material{ .Pass = ShaderPassId::ForwardOpaque, .BaseColor = Vec4(1.0f, 0.15f, 0.1f,  1.0f) });
-    scene.Green = materials.Register("green", Material{ .Pass = ShaderPassId::ForwardOpaque, .BaseColor = Vec4(0.1f, 0.85f, 0.45f, 1.0f) });
-    scene.Blue  = materials.Register("blue",  Material{ .Pass = ShaderPassId::ForwardOpaque, .BaseColor = Vec4(0.2f, 0.45f, 1.0f,  1.0f) });
+    AssetRegistry assetRegistry;
+    assetRegistry.Register(AssetRecord{
+        .Type = AssetType::Mesh,
+        .Path = "asset://meshes/dev/cube.smesh",
+    });
+    assetRegistry.Register(AssetRecord{
+        .Type = AssetType::Material,
+        .Path = "asset://materials/dev/red.smat",
+    });
+    assetRegistry.Register(AssetRecord{
+        .Type = AssetType::Material,
+        .Path = "asset://materials/dev/green.smat",
+    });
+    assetRegistry.Register(AssetRecord{
+        .Type = AssetType::Material,
+        .Path = "asset://materials/dev/blue.smat",
+    });
+
+    // Register matching procedural runtime resources under the same paths.
+    scene.CubeMesh = meshes.CreateFromData(
+        "asset://meshes/dev/cube.smesh", MeshPrimitives::BuildCube(1.0f));
+    scene.Red   = materials.Register(
+        "asset://materials/dev/red.smat",
+        Material{ .Pass = ShaderPassId::ForwardOpaque, .BaseColor = Vec4(1.0f, 0.15f, 0.1f,  1.0f) });
+    scene.Green = materials.Register(
+        "asset://materials/dev/green.smat",
+        Material{ .Pass = ShaderPassId::ForwardOpaque, .BaseColor = Vec4(0.1f, 0.85f, 0.45f, 1.0f) });
+    scene.Blue  = materials.Register(
+        "asset://materials/dev/blue.smat",
+        Material{ .Pass = ShaderPassId::ForwardOpaque, .BaseColor = Vec4(0.2f, 0.45f, 1.0f,  1.0f) });
 
     std::ifstream file{std::string(scenePath)};
     if (!file.is_open())
@@ -55,7 +80,13 @@ DemoScene LoadDemoScene(Registry& registry,
     }
 
     SceneLoadError loadError;
-    if (!LoadSceneJson(*json, registry, &loadError))
+    AssetSystem assets(assetRegistry, meshes, materials);
+    SceneSerializationContext sceneContext{
+        .Assets = &assets,
+        .Meshes = &meshes,
+        .Materials = &materials,
+    };
+    if (!LoadSceneJson(*json, registry, sceneContext, &loadError))
     {
         std::fprintf(stderr, "CubeDemo: scene load error: %s\n", loadError.Message.c_str());
         assert(false && "Failed to load demo scene");

--- a/example/CubeDemo/cube_demo_scene.json
+++ b/example/CubeDemo/cube_demo_scene.json
@@ -24,8 +24,8 @@
                     "scale": [1.0, 1.0, 1.0]
                 },
                 "MeshRenderer": {
-                    "mesh": { "index": 1, "generation": 1 },
-                    "material": { "index": 1, "generation": 1 },
+                    "mesh": "asset://meshes/dev/cube.smesh",
+                    "material": "asset://materials/dev/red.smat",
                     "visible": true,
                     "layer_mask": 4294967295,
                     "submesh_mask": 4294967295
@@ -40,8 +40,8 @@
                     "scale": [0.35, 0.35, 0.35]
                 },
                 "MeshRenderer": {
-                    "mesh": { "index": 1, "generation": 1 },
-                    "material": { "index": 3, "generation": 1 },
+                    "mesh": "asset://meshes/dev/cube.smesh",
+                    "material": "asset://materials/dev/blue.smat",
                     "visible": true,
                     "layer_mask": 4294967295,
                     "submesh_mask": 4294967295
@@ -56,8 +56,8 @@
                     "scale": [1.0, 1.0, 1.0]
                 },
                 "MeshRenderer": {
-                    "mesh": { "index": 1, "generation": 1 },
-                    "material": { "index": 2, "generation": 1 },
+                    "mesh": "asset://meshes/dev/cube.smesh",
+                    "material": "asset://materials/dev/green.smat",
                     "visible": true,
                     "layer_mask": 4294967295,
                     "submesh_mask": 4294967295
@@ -72,8 +72,8 @@
                     "scale": [0.75, 1.5, 0.75]
                 },
                 "MeshRenderer": {
-                    "mesh": { "index": 1, "generation": 1 },
-                    "material": { "index": 3, "generation": 1 },
+                    "mesh": "asset://meshes/dev/cube.smesh",
+                    "material": "asset://materials/dev/blue.smat",
                     "visible": true,
                     "layer_mask": 4294967295,
                     "submesh_mask": 4294967295
@@ -88,8 +88,8 @@
                     "scale": [8.0, 0.15, 8.0]
                 },
                 "MeshRenderer": {
-                    "mesh": { "index": 1, "generation": 1 },
-                    "material": { "index": 2, "generation": 1 },
+                    "mesh": "asset://meshes/dev/cube.smesh",
+                    "material": "asset://materials/dev/green.smat",
                     "visible": true,
                     "layer_mask": 4294967295,
                     "submesh_mask": 4294967295

--- a/test/runtime/SceneSerializerTests.cpp
+++ b/test/runtime/SceneSerializerTests.cpp
@@ -1,22 +1,58 @@
 #include <gtest/gtest.h>
 
+#include <core/assets/AssetSystem.h>
 #include <core/json/JsonParser.h>
 #include <core/json/JsonStringify.h>
+#include <core/serialization/JsonArchive.h>
 #include <core/serialization/BinaryFormat.h>
 #include <core/serialization/BinaryReader.h>
 #include <core/serialization/BinaryWriter.h>
 #include <core/serialization/Serialize.h>
 #include <math/geometry/3d/Transform3d.h>
 #include <render/Camera.h>
+#include <render/MaterialCache.h>
 #include <render/MeshRendererComponent.h>
 #include <world/registry/Registry.h>
 #include <world/serialization/SceneFormat.h>
+#include <world/serialization/SceneFieldCodec.h>
 #include <world/serialization/SceneSerializer.h>
 #include <world/transform/TransformHierarchyService.h>
 #include <world/transform/TransformPropagationOrderService.h>
 #include <world/transform/TransformStore.h>
 
 #include <sstream>
+#include <string_view>
+#include <tuple>
+
+struct SceneCodecMaterialComponent
+{
+    MaterialHandle Material;
+};
+
+template <>
+struct TypeSchema<SceneCodecMaterialComponent>
+{
+    static constexpr std::string_view Name = "SceneCodecMaterial";
+
+    static auto Fields()
+    {
+        return std::tuple{
+            MakeField("material", &SceneCodecMaterialComponent::Material),
+        };
+    }
+};
+
+template <>
+struct ComponentStorageTraits<SceneCodecMaterialComponent>
+{
+    using Store = SparseSetStore<SceneCodecMaterialComponent>;
+    static constexpr std::uint32_t BinaryChunkId = MakeFourCC('T', 'M', 'A', 'T');
+
+    static bool Add(Registry& registry, EntityId entity, SceneCodecMaterialComponent component)
+    {
+        return registry.Components.Ensure<Store>().Add(entity, component);
+    }
+};
 
 namespace
 {
@@ -40,6 +76,14 @@ namespace
     {
         ClearComponentSerializers();
         InitSceneSerializer();
+    }
+
+    void RegisterMaterialAsset(AssetRegistry& registry, std::string_view path)
+    {
+        registry.Register(AssetRecord{
+            .Type = AssetType::Material,
+            .Path = std::string(path),
+        });
     }
 
     Transform3f MakeTransform(float x, float y, float z)
@@ -66,15 +110,6 @@ TEST(SceneSerializer, BinaryRoundTripsCleanRegistry)
     hierarchy.Register(parent);
     hierarchy.SetParent(child, parent);
 
-    MeshRendererComponent meshRenderer{
-        .Mesh = MeshHandle{ .Index = 7, .Generation = 2 },
-        .Material = MaterialHandle{ .Index = 9, .Generation = 3 },
-        .Visible = false,
-        .LayerMask = 0x00FF00FFu,
-        .SubmeshMask = 0x0000000Fu,
-    };
-    source.Components.Get<MeshRendererStore>().Add(child, meshRenderer);
-
     CameraComponent camera{
         .Projection = ProjectionKind::Orthographic,
         .FovYRadians = 0.75f,
@@ -98,11 +133,9 @@ TEST(SceneSerializer, BinaryRoundTripsCleanRegistry)
 
     auto& loadedTransforms = loaded.Components.Get<TransformStore<Transform3f>>();
     auto& loadedHierarchy = loaded.Resources.Get<TransformHierarchyService>();
-    auto& loadedMeshes = loaded.Components.Get<MeshRendererStore>();
     auto& loadedCameras = loaded.Components.Get<CameraStore>();
 
     ASSERT_EQ(loadedTransforms.Count(), 2u);
-    ASSERT_EQ(loadedMeshes.Count(), 1u);
     ASSERT_EQ(loadedCameras.Count(), 1u);
 
     const auto owners = loadedTransforms.GetOwnerIds();
@@ -115,14 +148,6 @@ TEST(SceneSerializer, BinaryRoundTripsCleanRegistry)
     EXPECT_EQ(loadedHierarchy.GetParent(loadedChild).Index, loadedParent.Index);
     ASSERT_NE(loadedTransforms.TryGet(loadedParent), nullptr);
     EXPECT_EQ(loadedTransforms.TryGet(loadedParent)->Local.Position, Vec3d(1.0f, 2.0f, 3.0f));
-
-    const MeshRendererComponent* loadedMesh = loadedMeshes.TryGet(loadedChild);
-    ASSERT_NE(loadedMesh, nullptr);
-    EXPECT_EQ(loadedMesh->Mesh, meshRenderer.Mesh);
-    EXPECT_EQ(loadedMesh->Material, meshRenderer.Material);
-    EXPECT_EQ(loadedMesh->Visible, meshRenderer.Visible);
-    EXPECT_EQ(loadedMesh->LayerMask, meshRenderer.LayerMask);
-    EXPECT_EQ(loadedMesh->SubmeshMask, meshRenderer.SubmeshMask);
 
     const CameraComponent* loadedCamera = loadedCameras.TryGet(loadedParent);
     ASSERT_NE(loadedCamera, nullptr);
@@ -199,12 +224,12 @@ TEST(SceneSerializer, LoadsHandAuthoredJson)
                         "rotation": [0, 0, 0, 1],
                         "scale": [1, 1, 1]
                     },
-                    "MeshRenderer": {
-                        "mesh": { "index": 3, "generation": 1 },
-                        "material": { "index": 4, "generation": 2 },
-                        "visible": true,
-                        "layer_mask": 4294967295,
-                        "submesh_mask": 15
+                    "Camera": {
+                        "projection": "orthographic",
+                        "fov_y_radians": 1.0,
+                        "orthographic_height": 8.0,
+                        "near_plane": 0.1,
+                        "far_plane": 100.0
                     }
                 }
             },
@@ -214,12 +239,6 @@ TEST(SceneSerializer, LoadsHandAuthoredJson)
                         "position": [5, 0, 0],
                         "rotation": [0, 0, 0, 1],
                         "scale": [1, 1, 1]
-                    },
-                    "Camera": {
-                        "projection": "perspective",
-                        "fov_y_radians": 1.0,
-                        "near_plane": 0.1,
-                        "far_plane": 1000.0
                     }
                 }
             }
@@ -235,9 +254,171 @@ TEST(SceneSerializer, LoadsHandAuthoredJson)
 
     EXPECT_EQ(loaded.Entities.Count(), 2u);
     EXPECT_EQ(loaded.Components.Get<TransformStore<Transform3f>>().Count(), 2u);
-    EXPECT_EQ(loaded.Components.Get<MeshRendererStore>().Count(), 1u);
     EXPECT_EQ(loaded.Components.Get<CameraStore>().Count(), 1u);
     EXPECT_EQ(loaded.Resources.Get<TransformHierarchyService>().GetRoots().size(), 1u);
+}
+
+TEST(SceneSerializer, RegistersMeshRendererThroughGenericSerializer)
+{
+    ResetSceneSerializers();
+
+    bool found = false;
+    for (const auto& entry : GetComponentSerializerEntries())
+        found = found || entry->JsonKey() == "MeshRenderer";
+
+    EXPECT_TRUE(found);
+}
+
+TEST(SceneSerializer, GenericComponentSerializerWritesTypedMaterialHandleAsPathString)
+{
+    ClearComponentSerializers();
+    RegisterComponent<SceneCodecMaterialComponent>();
+
+    MaterialCache materials;
+    MaterialHandle material = materials.Register(
+        "asset://materials/dev/red.smat",
+        Material{ .Pass = ShaderPassId::ForwardOpaque, .BaseColor = Vec4(1.0f, 0.0f, 0.0f, 1.0f) });
+
+    Registry registry;
+    EntityId entity = registry.Entities.Create();
+    registry.Components.Ensure<SparseSetStore<SceneCodecMaterialComponent>>()
+        .Add(entity, SceneCodecMaterialComponent{ .Material = material });
+
+    SceneSerializationContext context{ .Materials = &materials };
+    JsonValue json = SaveSceneJson(registry, context);
+
+    const JsonValue* entities = json.Find("entities");
+    ASSERT_NE(entities, nullptr);
+    ASSERT_TRUE(entities->IsArray());
+    ASSERT_EQ(entities->AsArray().size(), 1u);
+
+    const JsonValue* components = entities->AsArray()[0].Find("components");
+    ASSERT_NE(components, nullptr);
+    const JsonValue* component = components->Find("SceneCodecMaterial");
+    ASSERT_NE(component, nullptr);
+    const JsonValue* materialJson = component->Find("material");
+    ASSERT_NE(materialJson, nullptr);
+    ASSERT_TRUE(materialJson->IsString());
+    EXPECT_EQ(materialJson->AsString(), "asset://materials/dev/red.smat");
+}
+
+TEST(SceneSerializer, MaterialHandleSceneCodecWritesPathString)
+{
+    MaterialCache materials;
+    MaterialHandle handle = materials.Register(
+        "asset://materials/dev/red.smat",
+        Material{ .Pass = ShaderPassId::ForwardOpaque, .BaseColor = Vec4(1.0f, 0.0f, 0.0f, 1.0f) });
+
+    SceneSerializationContext context{ .Materials = &materials };
+    JsonWriteArchive archive;
+    ASSERT_TRUE(SceneFieldCodec<MaterialHandle>::Save(archive, "material", handle, context));
+
+    JsonValue json = archive.TakeValue();
+    ASSERT_TRUE(json.IsString());
+    EXPECT_EQ(json.AsString(), "asset://materials/dev/red.smat");
+}
+
+TEST(SceneSerializer, MaterialHandleSceneCodecLoadsPathString)
+{
+    AssetRegistry registry;
+    RegisterMaterialAsset(registry, "asset://materials/dev/red.smat");
+    MaterialCache materials;
+    MaterialHandle registered = materials.Register(
+        "asset://materials/dev/red.smat",
+        Material{ .Pass = ShaderPassId::ForwardOpaque, .BaseColor = Vec4(1.0f, 0.0f, 0.0f, 1.0f) });
+    AssetSystem assets(registry, nullptr, &materials);
+
+    auto parsed = JsonParse(R"("asset://materials/dev/red.smat")");
+    ASSERT_TRUE(parsed.has_value());
+
+    SceneSerializationContext context{ .Assets = &assets, .Materials = &materials };
+    JsonReadArchive archive(*parsed);
+    MaterialHandle loaded;
+    ASSERT_TRUE(SceneFieldCodec<MaterialHandle>::Load(archive, "", loaded, context));
+    EXPECT_EQ(loaded, registered);
+}
+
+TEST(SceneSerializer, MaterialHandleSceneCodecLoadsLegacyAssetRefObject)
+{
+    AssetRegistry registry;
+    RegisterMaterialAsset(registry, "asset://materials/dev/red.smat");
+    MaterialCache materials;
+    MaterialHandle registered = materials.Register(
+        "asset://materials/dev/red.smat",
+        Material{ .Pass = ShaderPassId::ForwardOpaque, .BaseColor = Vec4(1.0f, 0.0f, 0.0f, 1.0f) });
+    AssetSystem assets(registry, nullptr, &materials);
+
+    auto parsed = JsonParse(R"({ "type": "Material", "path": "asset://materials/dev/red.smat" })");
+    ASSERT_TRUE(parsed.has_value());
+
+    SceneSerializationContext context{ .Assets = &assets, .Materials = &materials };
+    JsonReadArchive archive(*parsed);
+    MaterialHandle loaded;
+    ASSERT_TRUE(SceneFieldCodec<MaterialHandle>::Load(archive, "", loaded, context));
+    EXPECT_EQ(loaded, registered);
+}
+
+TEST(SceneSerializer, MaterialHandleSceneCodecRejectsWrongTypeEmptyPathAndMissingPath)
+{
+    AssetRegistry registry;
+    MaterialCache materials;
+    AssetSystem assets(registry, nullptr, &materials);
+    SceneSerializationContext context{ .Assets = &assets, .Materials = &materials };
+
+    auto wrongType = JsonParse(R"({ "type": "Mesh", "path": "asset://materials/dev/red.smat" })");
+    ASSERT_TRUE(wrongType.has_value());
+    JsonReadArchive wrongTypeArchive(*wrongType);
+    MaterialHandle loaded;
+    EXPECT_FALSE(SceneFieldCodec<MaterialHandle>::Load(wrongTypeArchive, "", loaded, context));
+    EXPECT_FALSE(wrongTypeArchive.Ok());
+
+    auto emptyPath = JsonParse(R"("")");
+    ASSERT_TRUE(emptyPath.has_value());
+    JsonReadArchive emptyPathArchive(*emptyPath);
+    EXPECT_FALSE(SceneFieldCodec<MaterialHandle>::Load(emptyPathArchive, "", loaded, context));
+    EXPECT_FALSE(emptyPathArchive.Ok());
+
+    auto missingPath = JsonParse(R"("asset://materials/dev/missing.smat")");
+    ASSERT_TRUE(missingPath.has_value());
+    JsonReadArchive missingPathArchive(*missingPath);
+    EXPECT_FALSE(SceneFieldCodec<MaterialHandle>::Load(missingPathArchive, "", loaded, context));
+    EXPECT_FALSE(missingPathArchive.Ok());
+}
+
+TEST(SceneSerializer, MaterialHandleSceneCodecRejectsRegistryTypeMismatch)
+{
+    AssetRegistry registry;
+    registry.Register(AssetRecord{
+        .Type = AssetType::Mesh,
+        .Path = "asset://materials/dev/red.smat",
+    });
+
+    MaterialCache materials;
+    [[maybe_unused]] MaterialHandle material = materials.Register(
+        "asset://materials/dev/red.smat",
+        Material{ .Pass = ShaderPassId::ForwardOpaque, .BaseColor = Vec4(1.0f, 0.0f, 0.0f, 1.0f) });
+    AssetSystem assets(registry, nullptr, &materials);
+
+    auto parsed = JsonParse(R"("asset://materials/dev/red.smat")");
+    ASSERT_TRUE(parsed.has_value());
+
+    SceneSerializationContext context{ .Assets = &assets, .Materials = &materials };
+    JsonReadArchive archive(*parsed);
+    MaterialHandle loaded;
+    EXPECT_FALSE(SceneFieldCodec<MaterialHandle>::Load(archive, "", loaded, context));
+    EXPECT_FALSE(archive.Ok());
+}
+
+TEST(SceneSerializer, MeshHandleSceneCodecRejectsWrongLegacyObjectType)
+{
+    auto wrongType = JsonParse(R"({ "type": "Material", "path": "asset://meshes/dev/cube.smesh" })");
+    ASSERT_TRUE(wrongType.has_value());
+
+    SceneSerializationContext context;
+    JsonReadArchive archive(*wrongType);
+    MeshHandle loaded;
+    EXPECT_FALSE(SceneFieldCodec<MeshHandle>::Load(archive, "", loaded, context));
+    EXPECT_FALSE(archive.Ok());
 }
 
 TEST(SceneSerializer, JsonLoadRollsBackEntitiesAndComponentsOnFailure)


### PR DESCRIPTION
- Updated IComponentSerializer interface to include SceneSerializationContext for Save and Load methods.
- Introduced SceneFieldCodec for generic serialization of various field types, including MeshHandle and MaterialHandle.
- Implemented SceneSerializationContext to manage dependencies for asset resolution during serialization.
- Added AssetRegistry and AssetSystem to manage asset registration and loading.
- Enhanced SceneSerializer to support new serialization context, allowing for better asset management in scene files.
- Updated CubeDemoScene to register assets and utilize the new serialization context for loading scenes.
- Modified tests to validate the new asset handling and serialization logic for materials and meshes.