### PR TITLE
perf(render)+hygiene: "do now" cleanups

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -109,6 +109,13 @@ target_include_directories(sencha_engine
 target_link_libraries(sencha_engine PUBLIC SDL3::SDL3)
 target_compile_features(sencha_engine PUBLIC cxx_std_20)
 
+# Diagnostics: PRIVATE so they apply to the engine build without leaking onto
+# consumers. Not -Werror yet — the warning set still needs triage.
+target_compile_options(sencha_engine PRIVATE
+    $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall;-Wextra>
+    $<$<CXX_COMPILER_ID:MSVC>:/W4;/permissive->
+)
+
 if(SENCHA_ENABLE_COOK)
     target_compile_definitions(sencha_engine PUBLIC SENCHA_ENABLE_COOK)
 
@@ -133,7 +140,9 @@ if(SENCHA_ENABLE_COOK)
         "${bc7enc_SOURCE_DIR}/bc7enc.c"
         "${bc7enc_SOURCE_DIR}/bc7decomp.cpp"
     )
-    target_include_directories(sencha_engine PUBLIC "${bc7enc_SOURCE_DIR}")
+    # SYSTEM: vendored third-party headers — keep their -Wall/-Wextra noise out
+    # of the engine's own diagnostics.
+    target_include_directories(sencha_engine SYSTEM PUBLIC "${bc7enc_SOURCE_DIR}")
 
     # glTF parsing for the mesh cook (Decision B): cgltf, single-header,
     # the stb precedent. The implementation TU lives in src/assets/cook.
@@ -146,7 +155,7 @@ if(SENCHA_ENABLE_COOK)
     if(NOT cgltf_POPULATED)
         FetchContent_Populate(cgltf)
     endif()
-    target_include_directories(sencha_engine PUBLIC "${cgltf_SOURCE_DIR}")
+    target_include_directories(sencha_engine SYSTEM PUBLIC "${cgltf_SOURCE_DIR}")
 
     # Tangent generation for the mesh cook (Decision M): MikkTSpace, the
     # de-facto standard. Cook-only, never ships — the glslang rule.
@@ -160,7 +169,7 @@ if(SENCHA_ENABLE_COOK)
         FetchContent_Populate(mikktspace)
     endif()
     target_sources(sencha_engine PRIVATE "${mikktspace_SOURCE_DIR}/mikktspace.c")
-    target_include_directories(sencha_engine PUBLIC "${mikktspace_SOURCE_DIR}")
+    target_include_directories(sencha_engine SYSTEM PUBLIC "${mikktspace_SOURCE_DIR}")
 endif()
 
 if(WIN32)
@@ -176,7 +185,7 @@ FetchContent_Declare(
     GIT_TAG        ae721c50eaf761660b4f90cc590453cdb0c2acd0
 )
 FetchContent_MakeAvailable(stb)
-target_include_directories(sencha_engine PRIVATE "${stb_SOURCE_DIR}")
+target_include_directories(sencha_engine SYSTEM PRIVATE "${stb_SOURCE_DIR}")
 
 if(SENCHA_ENABLE_VULKAN)
     target_compile_definitions(sencha_engine PUBLIC SENCHA_ENABLE_VULKAN)

--- a/engine/include/assets/cook/AssetImporter.h
+++ b/engine/include/assets/cook/AssetImporter.h
@@ -52,7 +52,7 @@ public:
 
 struct ImportResult
 {
-    std::vector<CookedArtifact> Artifacts;
+    std::vector<CookedArtifact> Artifacts{};
 
     // Non-empty means the import failed. Importers report; the driver logs.
     std::string Error;

--- a/engine/include/core/assets/AssetCache.h
+++ b/engine/include/core/assets/AssetCache.h
@@ -5,7 +5,6 @@
 
 #include <cassert>
 #include <cstdint>
-#include <cstring>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -243,17 +242,13 @@ private:
     // ILifetimeOwner -- called by Owned on construction / destruction.
     void Attach(uint64_t token) override
     {
-        THandle handle{};
-        std::memcpy(&handle, &token, sizeof(handle));
-        if (TEntry* entry = Resolve(handle))
+        if (TEntry* entry = Resolve(THandle::FromToken(token)))
             ++entry->RefCount;
     }
 
     void Detach(uint64_t token) override
     {
-        THandle handle{};
-        std::memcpy(&handle, &token, sizeof(handle));
-        Release(handle);
+        Release(THandle::FromToken(token));
     }
 
     void FreeEntry(uint32_t index, TEntry& entry)

--- a/engine/include/core/assets/AssetRegistry.h
+++ b/engine/include/core/assets/AssetRegistry.h
@@ -22,7 +22,7 @@ struct AssetRecord
     // Stable identity from the cook's persisted id map (Decision A / Stage
     // 4e). Invalid until ApplyAssetIds runs after import + scan; records
     // register id-less and ids never participate in equivalence checks.
-    AssetId Id;
+    AssetId Id{};
 
     uint64_t ContentHash = 0;
     uint32_t Version = 1;

--- a/engine/include/core/handle/Handle.h
+++ b/engine/include/core/handle/Handle.h
@@ -35,6 +35,19 @@ struct Handle
     [[nodiscard]] bool IsNull() const { return !IsValid(); }
 
     bool operator==(const Handle&) const = default;
+
+    // Explicit, named packing for the ILifetimeOwner uint64_t token slot
+    // (see Owned<H>). Low 32 bits = Index, high 32 bits = Generation. This is
+    // the canonical encoding; on little-endian targets it is byte-identical to
+    // the generic memcpy Owned::Encode() uses for value tokens.
+    [[nodiscard]] static constexpr Handle FromToken(uint64_t t)
+    {
+        return { static_cast<uint32_t>(t & 0xFFFFFFFFu), static_cast<uint32_t>(t >> 32) };
+    }
+    [[nodiscard]] constexpr uint64_t ToToken() const
+    {
+        return static_cast<uint64_t>(Index) | (static_cast<uint64_t>(Generation) << 32);
+    }
 };
 
 // The slot index of a valid handle, for code that indexes a parallel array by

--- a/engine/include/core/handle/Owned.h
+++ b/engine/include/core/handle/Owned.h
@@ -119,6 +119,9 @@ private:
 		}
 		else
 		{
+			// Generic value-token encode: H may be Handle<Tag>, DataBatchKey, etc.
+			// For Handle tokens this is byte-identical to Handle::ToToken() on
+			// little-endian targets (the decode side uses Handle::FromToken()).
 			uint64_t v = 0;
 			std::memcpy(&v, &Token, sizeof(H));
 			return v;

--- a/engine/include/core/metadata/Field.h
+++ b/engine/include/core/metadata/Field.h
@@ -24,7 +24,7 @@ struct Field
     std::string_view Name;
     Member Class::* Ptr = nullptr;
     bool IsOptional = false;
-    std::optional<Member> DefaultValue;
+    std::optional<Member> DefaultValue{};
     std::uint32_t StableId = 0;
 
     Field& Optional()

--- a/engine/include/render/RenderQueue.h
+++ b/engine/include/render/RenderQueue.h
@@ -44,6 +44,12 @@ public:
     [[nodiscard]] const std::vector<RenderQueueItem>& Opaque() const { return OpaqueItems; }
     void SortOpaque();
 
+    // Draw order produced by SortOpaque(): indices into Opaque(), sorted by
+    // SortKey. Consumers walk this rather than the items so the sort never moves
+    // the 128-byte items themselves. Empty until SortOpaque() has run.
+    [[nodiscard]] const std::vector<uint32_t>& OpaqueOrder() const { return OpaqueOrderIndices; }
+
 private:
     std::vector<RenderQueueItem> OpaqueItems;
+    std::vector<uint32_t>        OpaqueOrderIndices;
 };

--- a/engine/src/render/MeshRenderFeature.cpp
+++ b/engine/src/render/MeshRenderFeature.cpp
@@ -123,8 +123,15 @@ void MeshRenderFeature::OnDraw(const FrameContext& frame)
     vkCmdBindDescriptorSets(frame.Cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, PipelineLayout,
                             1, 1, &bindlessSet, 0, nullptr);
 
-    for (const RenderQueueItem& item : Queue->Opaque())
+    // Walk the sorted order (indices into Opaque()) rather than the items in
+    // insertion order. Track the last-bound buffers so the back-to-back sections
+    // of a mesh — adjacent after the sort — don't rebind identical buffers.
+    const std::vector<RenderQueueItem>& items = Queue->Opaque();
+    VkBuffer lastVertexBuffer = VK_NULL_HANDLE;
+    VkBuffer lastIndexBuffer = VK_NULL_HANDLE;
+    for (const uint32_t itemIndex : Queue->OpaqueOrder())
     {
+        const RenderQueueItem& item = items[itemIndex];
         const GpuStaticMesh* mesh = Meshes->Get(item.Mesh);
         const Material* material = Materials->Get(item.Material);
         if (mesh == nullptr || material == nullptr || item.SectionIndex >= mesh->Sections.size())
@@ -135,15 +142,23 @@ void MeshRenderFeature::OnDraw(const FrameContext& frame)
         const StaticMeshSection& section = mesh->Sections[item.SectionIndex];
         VkBuffer vertexBuffer = Buffers->GetBuffer(mesh->VertexBuffer);
         VkBuffer indexBuffer = Buffers->GetBuffer(mesh->IndexBuffer);
-        VkDeviceSize vertexOffset = 0;
 
         MeshPushConstants push{};
         push.World = item.WorldMatrix.Transposed();
         push.BaseColor = material->BaseColor;
         push.BaseColorTextureIndex = material->BaseColorTextureIndex;
 
-        vkCmdBindVertexBuffers(frame.Cmd, 0, 1, &vertexBuffer, &vertexOffset);
-        vkCmdBindIndexBuffer(frame.Cmd, indexBuffer, 0, VK_INDEX_TYPE_UINT32);
+        if (vertexBuffer != lastVertexBuffer)
+        {
+            VkDeviceSize vertexOffset = 0;
+            vkCmdBindVertexBuffers(frame.Cmd, 0, 1, &vertexBuffer, &vertexOffset);
+            lastVertexBuffer = vertexBuffer;
+        }
+        if (indexBuffer != lastIndexBuffer)
+        {
+            vkCmdBindIndexBuffer(frame.Cmd, indexBuffer, 0, VK_INDEX_TYPE_UINT32);
+            lastIndexBuffer = indexBuffer;
+        }
         vkCmdPushConstants(frame.Cmd, PipelineLayout,
                            VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
                            0, sizeof(push), &push);

--- a/engine/src/render/RenderQueue.cpp
+++ b/engine/src/render/RenderQueue.cpp
@@ -17,19 +17,31 @@ uint64_t BuildOpaqueSortKey(const RenderQueueItem& item)
 void RenderQueue::Reset()
 {
     OpaqueItems.clear();
+    OpaqueOrderIndices.clear();
 }
 
 void RenderQueue::AddOpaque(const RenderQueueItem& item)
 {
-    RenderQueueItem copy = item;
-    copy.SortKey = BuildOpaqueSortKey(copy);
-    OpaqueItems.push_back(copy);
+    OpaqueItems.push_back(item);
+    OpaqueItems.back().SortKey = BuildOpaqueSortKey(OpaqueItems.back());
 }
 
 void RenderQueue::SortOpaque()
 {
-    std::sort(OpaqueItems.begin(), OpaqueItems.end(),
-              [](const RenderQueueItem& a, const RenderQueueItem& b) {
-                  return a.SortKey < b.SortKey;
-              });
+    // Sort an order array of (SortKey, item index) pairs rather than the items
+    // themselves: each item is 128 bytes but the comparator only reads the
+    // 8-byte key, so moving items during the sort is pure waste. Consumers walk
+    // OpaqueOrder() and index back into OpaqueItems.
+    OpaqueOrderIndices.resize(OpaqueItems.size());
+
+    std::vector<std::pair<uint64_t, uint32_t>> order;
+    order.reserve(OpaqueItems.size());
+    for (uint32_t i = 0; i < OpaqueItems.size(); ++i)
+        order.emplace_back(OpaqueItems[i].SortKey, i);
+
+    std::sort(order.begin(), order.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    for (size_t i = 0; i < order.size(); ++i)
+        OpaqueOrderIndices[i] = order[i].second;
 }

--- a/engine/src/world/transform/TransformPropagation.cpp
+++ b/engine/src/world/transform/TransformPropagation.cpp
@@ -67,10 +67,6 @@ void TransformPropagationSystem::RebuildCache(PropagationOrderCache& cache)
             const EntityIndex* entities = view.Entities();
             for (uint32_t i = 0; i < view.Count(); ++i)
             {
-                const EntityId childId = EntityId{
-                    entities[i],
-                    0 // generation placeholder — we look up via indexToId below
-                };
                 // Recover the full EntityId for the child from our map.
                 auto childIt = indexToId.find(entities[i]);
                 if (childIt == indexToId.end()) continue;


### PR DESCRIPTION
Render path:
- SortOpaque sorts an (SortKey, index) array and exposes OpaqueOrder() instead of moving 128-byte RenderQueueItems; draw loop walks the order.
- MeshRenderFeature skips redundant vertex/index buffer binds across a mesh's adjacent sections via last-bound tracking.
- AddOpaque no longer makes an extra full-item copy.

Handles/assets:
- Handle gains explicit ToToken/FromToken; AssetCache uses FromToken for the lifetime-owner round-trip, removing the memcpy-into-non-trivial-type (-Wclass-memaccess) warning. Owned::Encode cross-references the encoding.

Build hygiene:
- Enable -Wall -Wextra (GNU/Clang) and /W4 /permissive- (MSVC) PRIVATE on the engine target; not -Werror.
- Mark vendored third-party headers (bc7enc, cgltf, mikktspace, stb) SYSTEM so their diagnostics don't bury ours.
- Silence -Wmissing-field-initializers via NSDMIs on ImportResult::Artifacts, AssetRecord::Id, and Field::DefaultValue; remove dead childId in TransformPropagation.

Engine builds warning-clean under the new flags; 830/830 tests pass.