### PR TITLE
Add editor tests, layering guards, and interaction safety

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,12 @@ include(GNUInstallDirs)
 add_test(NAME framework_isolation
     COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/cmake/CheckFrameworkIsolation.cmake")
 
+# Physics backend firewall: Jolt must stay behind engine/src/physics/ (plus the
+# dev-only collision cook). Same standalone-script form as the framework guard so
+# it runs under ctest without building the engine or Jolt.
+add_test(NAME physics_isolation
+    COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/cmake/CheckPhysicsIsolation.cmake")
+
 # All SENCHA_ENABLE_* feature flags are declared here, before any subdirectory
 # consumes them.
 include("${CMAKE_SOURCE_DIR}/cmake/SenchaOptions.cmake")

--- a/cmake/CheckFrameworkIsolation.cmake
+++ b/cmake/CheckFrameworkIsolation.cmake
@@ -1,30 +1,44 @@
 # Enforces the D-J dependency rule for the gameplay framework:
-#   - framework code must NOT include the renderer, graphics, audio, or the
-#     render/audio-pulling scene codecs (gameplay is decoupled from render/scene)
+#   - framework code may depend ONLY on core/, ecs/, math/, other framework/, the
+#     standard library, and the one serializer seam it needs
+#     (world/serialization/IComponentSerializer.h). Anything else (render/,
+#     graphics/, audio/, world/ internals, scene codecs, physics/, editor/,
+#     assets/, app/, runtime/, zone/, ...) is forbidden: gameplay stays decoupled
+#     from render/scene/backend, and reaches the world only through the thin sinks
+#     the framework itself owns (D-G).
 #   - engine code outside framework/ must NOT include framework/ (engine never
-#     depends on gameplay)
+#     depends on gameplay).
+#
+# Direction 1 is a strict allowlist (default-deny), not a list of banned names.
+# A blocklist only catches the leaks you thought to name; the moment a framework
+# file reaches for world/ internals or physics/ the way to find out should be a
+# red test, not a code review. Adding a new allowed dependency is a conscious edit
+# to ALLOWED_PREFIXES below, on the record.
 #
 # Run standalone (no build/Vulkan needed):
 #   cmake -P cmake/CheckFrameworkIsolation.cmake
-# Or via the check_framework_isolation target once configured.
 
 cmake_minimum_required(VERSION 3.20)
 
 get_filename_component(REPO "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
 
-# Includes a framework/ file may never pull (substrings matched after "#include <").
-set(FRAMEWORK_FORBIDDEN
-    "render/"
-    "graphics/"
-    "audio/"
-    "world/serialization/SceneFieldCodec.h"
-    "world/serialization/ComponentSerializer.h"
-    "world/serialization/SceneSerializer.h"
+# Include-path prefixes a framework/ file may pull. A bare stdlib header (no '/')
+# is always allowed. Everything else is a violation.
+set(ALLOWED_PREFIXES
+    "core/"
+    "ecs/"
+    "math/"
+    "framework/"
+)
+# Specific non-prefix headers a framework file may include. Kept exact so the
+# framework gets the serializer interface without the render/audio-pulling codecs.
+set(ALLOWED_EXACT
+    "world/serialization/IComponentSerializer.h"
 )
 
 set(VIOLATIONS "")
 
-# 1. framework/ must not reach into render/scene.
+# 1. framework/ may depend only on the allowlist.
 file(GLOB_RECURSE FRAMEWORK_FILES
     "${REPO}/engine/include/framework/*"
     "${REPO}/engine/src/framework/*"
@@ -32,10 +46,29 @@ file(GLOB_RECURSE FRAMEWORK_FILES
 foreach(file ${FRAMEWORK_FILES})
     file(READ "${file}" content)
     file(RELATIVE_PATH rel "${REPO}" "${file}")
-    foreach(bad ${FRAMEWORK_FORBIDDEN})
-        string(REGEX MATCH "#[ \t]*include[ \t]*[<\"]${bad}" hit "${content}")
-        if(hit)
-            list(APPEND VIOLATIONS "${rel} includes '${bad}' (framework must not depend on render/scene)")
+    string(REGEX MATCHALL "#[ \t]*include[ \t]*[<\"][^>\"]+[>\"]" includes "${content}")
+    foreach(directive ${includes})
+        string(REGEX REPLACE "#[ \t]*include[ \t]*[<\"]([^>\"]+)[>\"]" "\\1" path "${directive}")
+        if(NOT path MATCHES "/")
+            continue() # stdlib header
+        endif()
+        set(ok FALSE)
+        foreach(prefix ${ALLOWED_PREFIXES})
+            if(path MATCHES "^${prefix}")
+                set(ok TRUE)
+                break()
+            endif()
+        endforeach()
+        if(NOT ok)
+            foreach(exact ${ALLOWED_EXACT})
+                if(path STREQUAL "${exact}")
+                    set(ok TRUE)
+                    break()
+                endif()
+            endforeach()
+        endif()
+        if(NOT ok)
+            list(APPEND VIOLATIONS "${rel} includes '${path}' (framework may depend only on core/, ecs/, math/, framework/, and the serializer seam)")
         endif()
     endforeach()
 endforeach()

--- a/cmake/CheckPhysicsIsolation.cmake
+++ b/cmake/CheckPhysicsIsolation.cmake
@@ -1,0 +1,73 @@
+# Enforces the physics backend firewall: Jolt is an implementation detail of the
+# physics module and must not leak anywhere else.
+#
+#   - No engine file outside engine/src/physics/ may include a Jolt header
+#     (<Jolt/...>) or name a Jolt type (JPH::). Public physics headers
+#     (engine/include/physics/) are held to this too: the whole point of the
+#     PIMPL firewall is that they expose mechanism-named types, never JPH.
+#   - The one sanctioned exception is the collision-shape cook, which bakes Jolt
+#     shapes. It is dev/cook-only (SENCHA_ENABLE_COOK), excluded from the runtime
+#     build, so it cannot drag Jolt into a shipped runtime.
+#
+# Matches JPH:: (not JPH_) on purpose: JPH_* are Jolt config macros that appear
+# legitimately in the allowed files; JPH:: is a type/namespace use, which is the
+# leak we care about. A file that uses JPH:: types pulled in transitively through
+# a non-Jolt-named header is exactly the re-exposure this catches.
+#
+# Run standalone (no build/Jolt needed):
+#   cmake -P cmake/CheckPhysicsIsolation.cmake
+
+cmake_minimum_required(VERSION 3.20)
+
+get_filename_component(REPO "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+
+# Files/dirs allowed to touch Jolt. Anything matching one of these path
+# fragments is skipped. Adding a new Jolt dependency site is a conscious decision
+# that belongs here, on the record.
+set(PHYSICS_ALLOWED
+    "/engine/src/physics/"
+    "/engine/src/assets/cook/CollisionShapeCook.cpp"
+)
+
+set(VIOLATIONS "")
+
+file(GLOB_RECURSE ENGINE_FILES
+    "${REPO}/engine/include/*"
+    "${REPO}/engine/src/*"
+)
+foreach(file ${ENGINE_FILES})
+    set(allowed FALSE)
+    foreach(ok ${PHYSICS_ALLOWED})
+        if(file MATCHES "${ok}")
+            set(allowed TRUE)
+            break()
+        endif()
+    endforeach()
+    if(allowed)
+        continue()
+    endif()
+
+    file(READ "${file}" content)
+    file(RELATIVE_PATH rel "${REPO}" "${file}")
+
+    string(REGEX MATCH "#[ \t]*include[ \t]*[<\"]Jolt/" inc_hit "${content}")
+    if(inc_hit)
+        list(APPEND VIOLATIONS "${rel} includes a <Jolt/...> header (Jolt must stay behind engine/src/physics/)")
+    endif()
+
+    string(REGEX MATCH "JPH::" jph_hit "${content}")
+    if(jph_hit)
+        list(APPEND VIOLATIONS "${rel} names a JPH:: type (Jolt must not leak past the physics PIMPL)")
+    endif()
+endforeach()
+
+if(VIOLATIONS)
+    foreach(v ${VIOLATIONS})
+        message(WARNING "physics isolation: ${v}")
+    endforeach()
+    list(LENGTH VIOLATIONS n)
+    message(FATAL_ERROR "physics isolation check failed: ${n} violation(s)")
+endif()
+
+list(LENGTH ENGINE_FILES engine_count)
+message(STATUS "physics isolation OK (Jolt confined to engine/src/physics/ + the cook)")

--- a/editor/src/editmodes/BoundsManipulator.cpp
+++ b/editor/src/editmodes/BoundsManipulator.cpp
@@ -164,12 +164,16 @@ private:
         if (!s.has_value())
             return std::nullopt;
 
-        double coord = AxisGet(H.Center, H.Axis) + *s;
+        const double pivot = AxisGet(H.Center, H.Axis);
+        double coord = pivot + *s;
         const GridPlane grid = viewport.GetGrid(ctx.Grid);
         if (grid.SnapEnabled && grid.Spacing > 0.0f)
         {
             const double origin = AxisGet(grid.Origin, H.Axis);
-            coord = origin + std::round((coord - origin) / grid.Spacing) * grid.Spacing;
+            // Absolute snap through the shared kernel. This was an inline copy of
+            // the same formula; routing it through GizmoMath::SnapAxisOffset means
+            // the one snap implementation (and its test) covers bounds too.
+            coord = pivot + GizmoMath::SnapAxisOffset(*s, pivot, origin, grid.Spacing);
         }
 
         Vec3d newMin = OldMin;

--- a/editor/src/interaction/InteractionHost.cpp
+++ b/editor/src/interaction/InteractionHost.cpp
@@ -39,6 +39,16 @@ InputConsumed InteractionHost::OnPointerUp(ToolContext& ctx, EditorViewport& vie
         return InputConsumed::No;
 
     auto interaction = std::move(Active);
-    interaction->OnPointerUp(ctx, viewport, pointer);
+    try
+    {
+        interaction->OnPointerUp(ctx, viewport, pointer); // commit
+    }
+    catch (...)
+    {
+        // Commit threw: revert the live preview so an interrupted commit can't
+        // strand uncommitted scene state, then propagate.
+        interaction->OnCancel(ctx);
+        throw;
+    }
     return InputConsumed::Yes;
 }

--- a/editor/src/ui/InspectorPanel.cpp
+++ b/editor/src/ui/InspectorPanel.cpp
@@ -107,7 +107,18 @@ std::string_view InspectorPanel::GetTitle() const
 
 void InspectorPanel::ResetEditState()
 {
+    // An edit interrupted before its commit (selection change, panel switch) has
+    // already written this frame's preview bytes into the live component. Restore
+    // the pre-edit snapshot so an abandoned edit cannot strand an un-undoable
+    // mutation.
+    if (EditActive && EditingComponent != InvalidComponentId && !EditBefore.empty())
+    {
+        World& world = Scene.GetRegistry().Components;
+        if (void* live = world.GetComponentRaw(EditingEntity, EditingComponent))
+            std::memcpy(live, EditBefore.data(), EditBefore.size());
+    }
     EditActive = false;
+    EditingEntity = {};
     EditingComponent = InvalidComponentId;
     EditBefore.clear();
 }
@@ -193,6 +204,7 @@ void InspectorPanel::DrawComponent(IComponentSerializer& serializer, EntityId en
     if (activated)
     {
         EditActive = true;
+        EditingEntity = entity;
         EditingComponent = id;
         EditBefore = frameStart;
     }

--- a/editor/src/ui/InspectorPanel.h
+++ b/editor/src/ui/InspectorPanel.h
@@ -49,7 +49,9 @@ private:
 
     // A single in-flight edit (only one widget drags at a time). Captured on
     // widget activation (pre-edit bytes), committed to a RawComponentEditCommand
-    // when the drag finishes.
+    // when the drag finishes. EditingEntity is the entity those bytes belong to,
+    // so an interrupted edit can be reverted to them (see ResetEditState).
+    EntityId               EditingEntity = {};
     ComponentId            EditingComponent = InvalidComponentId;
     std::vector<std::byte> EditBefore;
     bool                   EditActive = false;

--- a/scripts/check_editor_layering.sh
+++ b/scripts/check_editor_layering.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Editor layering guards (editor/ARCHITECTURE.md "Dependency rules"), enforced as
+# a source scan so the layering cannot silently regress. Companion to
+# check_meshedit_deps.sh; same form (a ctest that fails on a violation).
+#
+# Two rules, both green when introduced:
+#
+#   A. Core abstractions (commands/ selection/ tools/ interaction/ brush/) must
+#      not depend on the authoring/domain subsystems (document/ viewport/ render/
+#      ui/ editmodes/ meshedit/ workspace/). They are the editor's reusable
+#      leaves; domain code depends on them, not the reverse. The shared
+#      pointer-event header (input/InputEvent.h) is the one allowed crossing, so
+#      input/ is not in the forbidden set.
+#
+#   B. Only app/ (the composition root) may reach UP into workspace/ (the
+#      aggregator). Cross-subsystem composition lives in workspace/; the
+#      subsystems below it stay independent of it.
+#
+# Usage: check_editor_layering.sh <source-root>
+
+set -uo pipefail
+
+ROOT="${1:-.}"
+EDITOR="$ROOT/editor/src"
+status=0
+
+# Greps for a pattern but drops comment-only lines, so prose mentioning a
+# forbidden name is not flagged.
+check() {
+    local desc="$1" pattern="$2"
+    shift 2
+    local hits
+    hits="$(grep -rnE "$pattern" "$@" 2>/dev/null \
+            | grep -vE ':[0-9]+:[[:space:]]*(//|\*|/\*)')"
+    if [ -n "$hits" ]; then
+        echo "VIOLATION: $desc"
+        echo "$hits"
+        echo
+        status=1
+    fi
+}
+
+# A. Core abstractions must not include a domain/authoring subsystem. The
+# optional path prefix makes this catch relative includes ("../document/...").
+check "core abstraction depends on a domain subsystem (only input/InputEvent.h may cross)" \
+      '#include[[:space:]]*["<]([^">]*/)?(document|viewport|render|ui|editmodes|meshedit|workspace)/' \
+      "$EDITOR/commands" "$EDITOR/selection" "$EDITOR/tools" "$EDITOR/interaction" "$EDITOR/brush"
+
+# B. Only app/ may include workspace/. Filter on the including FILE's path (not
+# the line text, which contains "workspace/" by construction), so a real
+# violation in content is not masked.
+ws_includers="$(grep -rlE '#include[[:space:]]*["<]([^">]*/)?workspace/' "$EDITOR" 2>/dev/null \
+                | grep -vE '^'"$EDITOR"'/(app|workspace)/')"
+if [ -n "$ws_includers" ]; then
+    echo "VIOLATION: a subsystem below the aggregator reaches up into workspace/ (compose in app/ instead)"
+    echo "$ws_includers"
+    echo
+    status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+    echo "editor layering directions: OK"
+fi
+exit "$status"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,10 @@ file(GLOB_RECURSE FRAMEWORK_TEST_SOURCES CONFIGURE_DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/framework/*.cpp
 )
 
+file(GLOB_RECURSE EDITOR_TEST_SOURCES CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/editor/*.cpp
+)
+
 add_executable(core_tests ${CORE_TEST_SOURCES})
 target_link_libraries(core_tests PRIVATE sencha_engine GTest::gtest_main)
 
@@ -180,6 +184,17 @@ if(FRAMEWORK_TEST_SOURCES)
     list(APPEND SENCHA_TEST_TARGETS framework_tests)
 endif()
 
+# Editor headless tests. Editor code that is GUI/Vulkan-free (the pure gizmo and
+# selection math) is compiled and tested directly, linking only the engine for
+# its math headers -- the brush_tests discipline. GUI-coupled editor code (ImGui,
+# render passes) is out of scope for headless tests by construction.
+if(EDITOR_TEST_SOURCES)
+    add_executable(editor_tests ${EDITOR_TEST_SOURCES})
+    target_include_directories(editor_tests PRIVATE ${CMAKE_SOURCE_DIR}/editor/src)
+    target_link_libraries(editor_tests PRIVATE sencha_engine GTest::gtest_main)
+    list(APPEND SENCHA_TEST_TARGETS editor_tests)
+endif()
+
 add_custom_target(engine_tests DEPENDS ${SENCHA_TEST_TARGETS})
 
 include(GoogleTest)
@@ -227,6 +242,12 @@ if(TARGET brush_tests)
     )
 endif()
 
+if(TARGET editor_tests)
+    gtest_discover_tests(editor_tests
+        DISCOVERY_TIMEOUT 30
+    )
+endif()
+
 if(TARGET level_cook_tests)
     gtest_discover_tests(level_cook_tests
         DISCOVERY_TIMEOUT 30
@@ -253,5 +274,9 @@ if(NOT WIN32)
     add_test(
         NAME ui_color_discipline
         COMMAND bash ${CMAKE_SOURCE_DIR}/scripts/check_ui_colors.sh ${CMAKE_SOURCE_DIR}
+    )
+    add_test(
+        NAME editor_layering_directions
+        COMMAND bash ${CMAKE_SOURCE_DIR}/scripts/check_editor_layering.sh ${CMAKE_SOURCE_DIR}
     )
 endif()

--- a/test/editor/GizmoMathTests.cpp
+++ b/test/editor/GizmoMathTests.cpp
@@ -1,0 +1,95 @@
+// Headless tests for the gizmo-drag math (editor/src/editmodes/GizmoMath.h).
+//
+// These guard two historical editor bug families: reversed gizmo drag (the
+// closest-point-on-axis sign) and relative-vs-absolute grid snap.
+// The kernel is pure and header-only, so it is tested directly without driving
+// the viewport or ImGui. ViewportMathTests already covers the X-axis sign and
+// one snap case; this extends to Y/Z and to the absolute-snap-with-origin and
+// rawOffset==0 cases a relative implementation would get wrong.
+
+#include <editmodes/GizmoMath.h>
+
+#include <gtest/gtest.h>
+
+#include <math/Vec.h>
+#include <math/geometry/3d/Ray3d.h>
+
+namespace
+{
+// Build a ray without the out-of-line Ray3d ctor so the kernel can be tested
+// against headers alone.
+Ray3d MakeRay(Vec3d origin, Vec3d direction)
+{
+    Ray3d ray;
+    ray.Origin = origin;
+    ray.Direction = direction;
+    return ray;
+}
+} // namespace
+
+// A drag toward the +axis side must yield a positive parameter, on every axis.
+// The opposite convention is the backwards-drag bug.
+TEST(GizmoMath, ClosestAxisParamCarriesSignOnX)
+{
+    const auto s = GizmoMath::ClosestAxisParam(
+        Vec3d(0, 0, 0), Vec3d(1, 0, 0), MakeRay(Vec3d(2, 1, 0), Vec3d(0, -1, 0)));
+    ASSERT_TRUE(s.has_value());
+    EXPECT_NEAR(*s, 2.0, 1e-9);
+}
+
+TEST(GizmoMath, ClosestAxisParamNegativeOnX)
+{
+    const auto s = GizmoMath::ClosestAxisParam(
+        Vec3d(0, 0, 0), Vec3d(1, 0, 0), MakeRay(Vec3d(-3, 1, 0), Vec3d(0, -1, 0)));
+    ASSERT_TRUE(s.has_value());
+    EXPECT_NEAR(*s, -3.0, 1e-9);
+}
+
+TEST(GizmoMath, ClosestAxisParamCarriesSignOnY)
+{
+    const auto s = GizmoMath::ClosestAxisParam(
+        Vec3d(0, 0, 0), Vec3d(0, 1, 0), MakeRay(Vec3d(1, 2, 0), Vec3d(-1, 0, 0)));
+    ASSERT_TRUE(s.has_value());
+    EXPECT_NEAR(*s, 2.0, 1e-9);
+}
+
+TEST(GizmoMath, ClosestAxisParamCarriesSignOnZ)
+{
+    const auto s = GizmoMath::ClosestAxisParam(
+        Vec3d(0, 0, 0), Vec3d(0, 0, 1), MakeRay(Vec3d(0, 1, 4), Vec3d(0, -1, 0)));
+    ASSERT_TRUE(s.has_value());
+    EXPECT_NEAR(*s, 4.0, 1e-9);
+}
+
+// A ray parallel to the axis is ill-conditioned: no usable parameter.
+TEST(GizmoMath, ClosestAxisParamRejectsParallelRay)
+{
+    const auto s = GizmoMath::ClosestAxisParam(
+        Vec3d(0, 0, 0), Vec3d(1, 0, 0), MakeRay(Vec3d(0, 1, 0), Vec3d(1, 0, 0)));
+    EXPECT_FALSE(s.has_value());
+}
+
+// Snapping is absolute (to grid lines), not relative (to grid-sized steps): even
+// a zero drag pulls an off-grid pivot onto the nearest line.
+TEST(GizmoMath, SnapAxisOffsetIsAbsoluteAtZeroDrag)
+{
+    EXPECT_NEAR(GizmoMath::SnapAxisOffset(0.0, 0.3, 0.0, 1.0f), -0.3, 1e-9);
+}
+
+TEST(GizmoMath, SnapAxisOffsetLandsOnGridLine)
+{
+    // pivot 0.3 + drag 0.9 == 1.2, nearest line is 1.0, so the offset is 0.7.
+    EXPECT_NEAR(GizmoMath::SnapAxisOffset(0.9, 0.3, 0.0, 1.0f), 0.7, 1e-9);
+}
+
+// The grid origin shifts the lines: with origin 0.25 a pivot at 0 snaps to 0.25.
+TEST(GizmoMath, SnapAxisOffsetRespectsGridOrigin)
+{
+    EXPECT_NEAR(GizmoMath::SnapAxisOffset(0.0, 0.0, 0.25, 1.0f), 0.25, 1e-9);
+}
+
+// Non-positive spacing disables snapping: the raw offset passes through.
+TEST(GizmoMath, SnapAxisOffsetDisabledPassesThrough)
+{
+    EXPECT_NEAR(GizmoMath::SnapAxisOffset(0.7, 5.0, 0.0, 0.0f), 0.7, 1e-12);
+}


### PR DESCRIPTION
## Summary

This change adds three complementary safety mechanisms to the editor and engine:

1. **Headless editor tests** for pure gizmo math (sign handling and grid snapping)
2. **Layering enforcement** to prevent architectural regressions in the editor and physics subsystems
3. **Interaction safety** to revert live preview state when an edit is interrupted or commit fails

## Key Changes

- **test/editor/GizmoMathTests.cpp** (new): Headless unit tests for `GizmoMath::ClosestAxisParam` and `GizmoMath::SnapAxisOffset`. These guard against two historical bugs: reversed gizmo drag (sign of closest-point-on-axis) and relative-vs-absolute grid snap. Tests cover all three axes and edge cases (parallel rays, zero drag, grid origin).

- **cmake/CheckPhysicsIsolation.cmake** (new): Standalone CMake script that enforces the physics backend firewall—Jolt headers and types must not leak outside `engine/src/physics/` (except the dev-only collision cook). Runs as a ctest without building Jolt.

- **scripts/check_editor_layering.sh** (new): Bash script enforcing two editor dependency rules:
  - Core abstractions (commands/, selection/, tools/, interaction/, brush/) must not depend on domain subsystems (document/, viewport/, render/, ui/, editmodes/, meshedit/, workspace/)
  - Only app/ may reach up into workspace/ (the aggregator)

- **cmake/CheckFrameworkIsolation.cmake** (modified): Converted from a blocklist (forbidden includes) to a strict allowlist (allowed prefixes + exact headers). Framework code may now depend only on core/, ecs/, math/, framework/, and the serializer seam (`world/serialization/IComponentSerializer.h`). This is more maintainable and catches leaks the moment they occur.

- **editor/src/interaction/InteractionHost.cpp** (modified): Added exception safety to `OnPointerUp`. If commit throws, the interaction's `OnCancel` is called to revert the live preview before the exception propagates. This prevents an interrupted commit from stranding uncommitted scene state.

- **editor/src/ui/InspectorPanel.h** and **.cpp** (modified): Added `EditingEntity` field to track which entity an in-flight edit belongs to. `ResetEditState` now restores the pre-edit snapshot if an edit is interrupted (selection change, panel switch) before commit, preventing abandoned edits from leaving un-undoable mutations.

- **editor/src/editmodes/BoundsManipulator.cpp** (modified): Refactored bounds snapping to use the shared `GizmoMath::SnapAxisOffset` kernel instead of an inline copy. This ensures the one snap implementation (and its test) covers both gizmo and bounds manipulation.

- **test/CMakeLists.txt** (modified): Added editor_tests target for headless tests and editor_layering_directions ctest.

- **CMakeLists.txt** (modified): Added physics_isolation ctest.

## Implementation Notes

- The gizmo math tests are pure and header-only, testing the kernel directly without viewport or ImGui.
- The layering checks run as standalone CMake/Bash scripts under ctest, so they validate the source tree without requiring a full build.
- Interaction safety uses try-catch at the commit boundary to ensure preview state is reverted on failure, maintaining invariant that live component state matches the undo stack.
- The framework isolation allowlist is explicit and maintainable; adding a new allowed dependency is a conscious edit to `ALLOWED_PREFIXES`, on the record.

https://claude.ai/code/session_01QUyMfRSf4YpaEeUw7fQdTW