### PR TITLE
Add animation core pieces: pose model, clip sampler, blending, pose store, tests, and suite plan docs

### DIFF
--- a/docs/animation/suite-plan.md
+++ b/docs/animation/suite-plan.md
@@ -1,0 +1,188 @@
+# Sencha Animation Suite Plan
+
+Status: ready for review. Executor: staged, each stage independently landable with the suite green.
+
+This document is the execution spec for the v1.0 animation work called out by the engine roadmap: skinned rendering, the fixed-tick animation runtime, montage integration for AbilityKit, and the `kabuki` animation editor. The current asset substrate already imports skeletons, clips, and skinned meshes, but there is no runtime that samples clips, blends poses, evaluates graphs, or renders skinned meshes.
+
+## Decisions on the record
+
+1. **Scope is the full vertical suite.** Runtime skinning, sampling, graphs, montages, and the editor ship in sequenced stages.
+2. **Launch path is Kettle plus Kyusu handoff.** `kabuki` is a sibling editor executable registered from Kettle, and Kyusu gains an edit action that spawns it with `--project` and `--asset`.
+3. **Product name is `kabuki`.** The name is limited to the executable and window title. Runtime and editor types use mechanical names such as `AnimationGraph...`.
+4. **Graph UI uses hand-rolled ImGui canvas widgets.** The shared canvas and timeline widgets live in `editor_common` and become reusable substrate for later sequencer work.
+
+## Non-goals and revival triggers
+
+- `IPoseModifier` is not built until a second concrete pose modifier such as look-at or foot IK exists. The seam is between finalized local pose and palette build.
+- Additive blend layers wait for reactive hit or stagger overlays and enter through a graph format-version bump.
+- Sub-state-machines wait for a real authored graph that becomes unmanageable when flat.
+- Cross-state sync groups wait for a real cross-state or cross-layer synchronization need. V1 only shares normalized phase within one blend space.
+- Clip compression and uniform-rate sampled storage wait for measured decode or memory pressure on real content.
+- Sequencer and cinematics are v2.0 work, with the timeline widget reused.
+- Chunk-parallel pose evaluation waits until profiling shows the serial pose system exceeds the roughly 1 ms rule.
+- Multi-mesh-one-pose waits for armor-set style content and should enter as a pose-source entity reference on `SkinnedMeshComponent`.
+
+## Runtime architecture
+
+The runtime is one concrete fixed-tick pipeline. Behavior variation enters as data through `AnimationGraph` and `AnimationMontage` cooked assets. Evaluation uses flat arrays and closed-enum switches, not node objects or one-implementation interfaces. Per-entity evaluation is independent so serial and parallel lanes can produce byte-identical pose products.
+
+### Pose data model
+
+Add `engine/include/anim/SkeletonPose.h` and `engine/include/anim/AnimationPoseStore.h` plus matching sources under `engine/src/anim/`.
+
+- `JointTransform` stores translation, rotation, and scale.
+- `AnimationPoseHandle` is a generational slot handle.
+- `AnimationPoseStore` owns local pose spans and skinning palette spans for allocated slots.
+- Model-space transforms are transient scratch. The persistent palette is object-space and is built by multiplying model-space joints with inverse bind matrices.
+- Slot lifecycle follows the `StaticMeshComponentAssets` precedent through component traits and a registry resource that provides animation graph, skeleton, and pose-store services.
+
+### Clip sampling
+
+Add `AnimationClipSampler` as pure free functions:
+
+- `WriteBindPose` fills a local pose from skeleton bind data.
+- `WrapClipTime` handles looping and clamping.
+- `SampleClip` writes tracked channels into a pre-filled pose and leaves untracked channels unchanged.
+
+Sampling rules are fixed in the header: step selects the key where `Times[i] <= t < Times[i + 1]`; linear tracks lerp translation and scale; rotations use nlerp with a hemisphere fix and normalization.
+
+### Blending
+
+Add `AnimationBlend` as pure free functions over spans:
+
+- Binary blend.
+- N-way weighted blend in cooked sample order.
+- Masked override blend using resolved joint weights.
+- 1D blend spaces with sorted samples and clamped bracket selection.
+- 2D blend spaces with cook-time triangulation, cooked-order triangle walk, barycentric weights, and deterministic hull clamp.
+
+Blend-space states advance one normalized phase and evaluate each sample at `phase * sample duration`.
+
+### Animation graph asset and evaluator
+
+Add authored `*.animgraph.json`, cooked `.sanimgraph`, FourCC `SGRF`, and the next free `AssetType`. Follow the new asset-type recipe from `docs/core-systems-map.md`: registry extension, cache, staged loader, owner-thread commit, `AssetSystem` accessors, cook importer, and cooked cache index bump.
+
+The cooked graph contains a string table, parameters, layers, states, transitions, conditions, notifies, blend-space tables, masks, and clip paths. Loader commit acquires the skeleton and clips, validates skeleton consistency and mask lengths, and compiles gameplay tag queries by name.
+
+Evaluation semantics:
+
+- Transition conditions are all-of and transitions are tested in cooked order, first match wins.
+- Trigger bits are consumed after transition evaluation each fixed tick.
+- State and montage notifies fire on playhead crossing within `(t0, t1]`, including loop wrap.
+- `TagWindowBegin` and `TagWindowEnd` grant and release counted gameplay tags.
+- `Event` notifies push `AnimationNotifyEvent` into a per-registry event buffer.
+- All simulation-visible work advances in fixed tick. Pose sampling runs in PostFixed, and zero-tick frames reuse the persistent palette.
+
+### Montages and root motion
+
+Add authored `*.montage.json`, cooked `.smontage`, FourCC `SMTG`, and the next free `AssetType`. A montage is one clip plus named sections, notifies, a target layer, optional mask, blend-in, blend-out, play rate, and optional root motion.
+
+Runtime keeps one active montage slot per graph layer. The state machine continues advancing underneath the montage so blend-out lands on current graph output. Combo branching is modeled as a requested section jump honored at section end.
+
+The montage sink boundary remains isolated: AbilityKit defines an interface in terms of entity id, montage path, and section hash; the animation side owns an `AnimationMontageRequest` event buffer; the composition root adapts one to the other.
+
+Root motion is cooked by bumping `.sanim` to v2 and optionally adding a root motion track. The graph system writes `AnimationRootMotion`, and `RootMotionApplySystem` converts the delta into character-controller movement before physics.
+
+### ECS components and systems
+
+Add these trivially copyable components:
+
+- `AnimationGraphComponent` with graph and pose handles.
+- `AnimationGraphParameters` with float, bool, and trigger storage.
+- `AnimationGraphRuntimeState` with per-layer state and montage slots.
+- `AnimationRootMotion` with delta translation, delta yaw, and active flag.
+- `SkinnedMeshComponent` mirroring `StaticMeshComponent` schema shape.
+
+Add `SkinnedMeshComponent` and `AnimationGraphComponent` to `EngineSceneComponents` so reflection and Kyusu inspector pickup are automatic.
+
+Systems are registered through `EngineSchedule`:
+
+- `AnimationGraphSystem` in FixedLogic after movement.
+- `RootMotionApplySystem` in FixedLogic after the graph system and before physics.
+- `AnimationPoseSystem` in PostFixed.
+- `SkinnedMeshExtractionSystem` in ExtractRender after regular render extraction.
+- `SkinnedMeshForwardPass` in the render feature after static opaque draw.
+
+### GPU skinning
+
+Use vertex-shader matrix-palette skinning. The cooked influence stream is a separate vertex buffer binding, and palettes are copied into a per-frame storage buffer. Push constants carry palette base and joint count. `RenderPacket` gains a skinning palette arena, and `RenderQueue` gains skinned items that merge only when mesh, section, and material match.
+
+Compute pre-skinning stays deferred until multiple geometry-consuming passes make per-pass skinning measurably expensive.
+
+## Editor architecture
+
+`kabuki` is a new executable under `editor/kabuki/` over `editor_common`, following the `chakin` application and service pattern. It registers animation runtime systems so preview uses the same code path as the game.
+
+### Application and launch
+
+- Add `AnimationEditorApp`, `AnimationEditorServices`, and `main.cpp`.
+- Mirror `chakin` CMake and install behavior.
+- Add a Kettle launch action for `kabuki`.
+- Lift `ResolveEditorBinary` into `editor/common/src/project/` so Kettle and Kyusu share it.
+- Add a Kyusu edit action for animation graph assets that spawns `kabuki --project ... --asset ...`.
+
+### Document model
+
+Mirror `MaterialEditSession` with `AnimationGraphEditSession` and `MontageEditSession`. Each open tab owns one session and one `CommandStack`. Every edit is an undoable command, including state, transition, notify, blend-space, parameter, and montage-section edits. Node layout remains editor-only JSON and is stripped by cook.
+
+### Panels
+
+`kabuki` registers these panels:
+
+- Asset browser, grouped by skeleton.
+- Graph canvas.
+- Preview viewport.
+- Inspector.
+- Timeline.
+- Parameter dashboard.
+- Validation panel.
+
+### Canvas and timeline widgets
+
+Shared hand-rolled ImGui widgets live under `editor_common/ui/canvas/`. `CanvasView` handles pan, zoom, transforms, node drawing, edge drawing, arrowheads, and hit tests. `TimelineTrack` handles playhead, range selection, snapping, notify markers, and section blocks.
+
+The graph canvas shows states, transitions, default-state markers, any-state rail, selection, drag-create transitions, delete, box select, and live evaluation overlay from the preview runtime state.
+
+### Preview and parameter dashboard
+
+The preview follows the `MaterialPreviewRenderFeature` pattern and renders a preview entity through the real skinned runtime path. It supports mesh selection, ground grid, root-motion trail, in-place versus traveling root-motion display, turntable, scrub, step, rate, and play controls.
+
+The parameter dashboard exposes graph floats, bools, triggers, a 2D stick widget for two float parameters, simulated gameplay tags, and a montage test bench that writes through the same request buffer used by gameplay.
+
+### Validation and reload
+
+Validation is a pure implementation shared by editor and cook. It reports skeleton mismatches, unreachable states, empty transition conditions, duplicate blend-space coordinates, section range errors, notify range errors, and missing mask joints.
+
+Graph and montage loaders gain `CommitReload`, Kyusu watches the new authored extensions, and `kabuki` continuously applies the working session to the resident preview state without requiring save.
+
+## Phased rollout
+
+1. **Pose math and sampler.** Add pose structs, store, clip sampler, blend functions, composition, palette build, and pure math tests.
+2. **Skinned rendering.** Add component, traits, manifest, queue, packet, extraction, pass, shader, and a temporary fixed-time sampling driver.
+3. **Animation graph asset and evaluator with 1D blend space.** Add asset type, cook, loader, cache, animation components, graph system, pose system, and notifies. Delete the temporary stage-2 driver. Add the permanent determinism hash test.
+4. **Root motion, montages, and montage sink.** Add `.sanim` v2 root track cook, root motion system, montage asset, request buffer, and composition-root sink adapter.
+5. **2D blend spaces and layered masking.** Add cooked triangulation, barycentric evaluation, hull clamp, multi-layer graphs, and masks.
+6. **kabuki foundation.** Add executable, Kettle wiring, sessions, tabs, commands, browser, canvas, graph editing, inspector, tag-query builder, and shared validation.
+7. **Preview and parameter dashboard.** Add preview render feature, preview entity on real systems, live overlay, parameter controls, stick widget, and tag simulation.
+8. **Timeline and montages in editor.** Add timeline widget family, notify editing, montage documents, section branching, windows, blend handles, and montage test bench.
+9. **Loop closure.** Add graph and montage hot reload, Kyusu watcher extensions, Kyusu edit handoff, and template exemplar content.
+
+## Guardrails
+
+- Match named precedents before inventing new shapes.
+- If existing substrate does not fit, extend that substrate rather than adding a parallel workaround.
+- Do not add one-implementation interfaces, future enum values, or half-wired strategy seams.
+- Keep graph evaluation as flat data with one evaluator switch.
+- Treat determinism as a gate. Any unordered-container iteration in evaluation is a defect.
+- Write comments for why, not what, and avoid em dashes in code, comments, commits, and docs.
+- Keep editor code out of the runtime and cook code behind `SENCHA_ENABLE_COOK`.
+- Prefer reuse and deletion over new parallel code.
+- When stage 3 lands, remove stale roadmap Section 3 vocabulary rows converted to code and mark shipped items with dates.
+
+## Verification gates
+
+- Every stage runs `cmake --build build` and `ctest --test-dir build`.
+- Stage 2 and later visually confirm the skinned character through the cooked path and attach a screenshot to the PR.
+- Stage 3 and later keep the serial versus `worker_count == 4` pose digest test as permanent ctest coverage.
+- Stage 6 and later launch Kettle, launch `kabuki`, author the reference graph, cook, and run the template game. Headless tests cover sessions, commands, validation, and canvas hit-test math.
+- Stage 9 demonstrates the full `kabuki` save to Kyusu PIE hot-reload loop, with editor layering and isolation fitness tests green.

--- a/docs/plans/engine-roadmap.md
+++ b/docs/plans/engine-roadmap.md
@@ -4,7 +4,7 @@ Status: standing master plan (2026-07-02). Supersedes `docs/plans/real-engine-ro
 that plan's phase spine (0 through 4) is absorbed here. Its Phase 0 (the SDK boundary)
 and most of Phase 1 (the editor product loop) are recorded as shipped; Phases 2 through 4
 map into the v1.0 tracks below. Companion execution docs remain authoritative for their
-own detail (see Section 12).
+own detail (see Section 12). The animation suite companion is `docs/animation/suite-plan.md`.
 
 Audience: whoever implements any item here (human or agent), and reviewers. This document
 owns versions, gates, and sequencing for the whole engine. Execution detail lives in the

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -32,6 +32,9 @@ test/       GoogleTest-based engine tests.
   streaming and traversal track (roadmap Track C).
 - `docs/gameplay/abilitykit.md` is the execution spec for the gameplay
   framework items in roadmap Track A.
+- `docs/animation/suite-plan.md` is the execution spec for skinned
+  rendering, the animation runtime, montage integration, and the `kabuki`
+  animation editor.
 - `docs/architecture/hardening-and-consolidation.md` is the execution spec
   for the editor hardening and module ABI items (roadmap Tracks D and F).
 - `docs/plans/sencha-level-editor/` is the shipped-branch record and the

--- a/engine/include/anim/AnimationBlend.h
+++ b/engine/include/anim/AnimationBlend.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <anim/SkeletonPose.h>
+
+#include <span>
+
+void BlendPoses(std::span<const JointTransform> a,
+                std::span<const JointTransform> b,
+                float alpha,
+                std::span<JointTransform> out);
+void BlendPosesWeighted(std::span<const std::span<const JointTransform>> poses,
+                        std::span<const float> weights,
+                        std::span<JointTransform> out);
+void BlendPosesMasked(std::span<const JointTransform> base,
+                      std::span<const JointTransform> layer,
+                      float alpha,
+                      std::span<const float> jointWeights,
+                      std::span<JointTransform> out);

--- a/engine/include/anim/AnimationClipSampler.h
+++ b/engine/include/anim/AnimationClipSampler.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <anim/AnimationClip.h>
+#include <anim/Skeleton.h>
+#include <anim/SkeletonPose.h>
+
+#include <span>
+
+// Deterministic sampler rules: step selects key i where Times[i] <= t < Times[i + 1].
+// Linear interpolation lerps translation and scale, and nlerps rotation after a
+// hemisphere fix. Callers pre-fill pose from bind if untracked channels should bind.
+[[nodiscard]] float WrapClipTime(float timeSeconds, float durationSeconds, bool looping);
+void WriteBindPose(const SkeletonData& skeleton, std::span<JointTransform> pose);
+void SampleClip(const AnimationClipData& clip,
+                float timeSeconds,
+                std::span<JointTransform> pose);

--- a/engine/include/anim/AnimationPoseStore.h
+++ b/engine/include/anim/AnimationPoseStore.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <anim/Skeleton.h>
+#include <anim/SkeletonPose.h>
+#include <math/Mat.h>
+
+#include <array>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+struct AnimationPoseHandle
+{
+    uint32_t Index = UINT32_MAX;
+    uint32_t Generation = 0;
+
+    [[nodiscard]] bool IsValid() const { return Index != UINT32_MAX; }
+};
+
+class AnimationPoseStore
+{
+public:
+    [[nodiscard]] AnimationPoseHandle Allocate(uint32_t jointCount);
+    void Free(AnimationPoseHandle handle);
+
+    [[nodiscard]] std::span<JointTransform> LocalPose(AnimationPoseHandle handle);
+    [[nodiscard]] std::span<const JointTransform> LocalPose(AnimationPoseHandle handle) const;
+    [[nodiscard]] std::span<Mat4> SkinningPalette(AnimationPoseHandle handle);
+    [[nodiscard]] std::span<const Mat4> SkinningPalette(AnimationPoseHandle handle) const;
+    [[nodiscard]] uint32_t JointCount(AnimationPoseHandle handle) const;
+    [[nodiscard]] bool Contains(AnimationPoseHandle handle) const;
+
+private:
+    struct Slot
+    {
+        uint32_t Generation = 1;
+        uint32_t JointCount = 0;
+        bool Occupied = false;
+        std::vector<JointTransform> LocalPose;
+        std::vector<Mat4> SkinningPalette;
+    };
+
+    [[nodiscard]] Slot& CheckedSlot(AnimationPoseHandle handle);
+    [[nodiscard]] const Slot& CheckedSlot(AnimationPoseHandle handle) const;
+
+    std::vector<Slot> m_slots;
+    std::array<std::vector<uint32_t>, kMaxSkeletonJoints + 1> m_freeListsByJointCount;
+};

--- a/engine/include/anim/SkeletonPose.h
+++ b/engine/include/anim/SkeletonPose.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <anim/Skeleton.h>
+#include <math/Mat.h>
+#include <math/Quat.h>
+#include <math/Vec.h>
+
+#include <span>
+
+struct JointTransform
+{
+    Vec3d Translation{};
+    Quat<float> Rotation{};
+    Vec3d Scale = Vec3d(1.0f, 1.0f, 1.0f);
+};
+
+[[nodiscard]] Mat4 JointTransformToMatrix(const JointTransform& transform);
+void BuildModelSpacePose(const SkeletonData& skeleton,
+                         std::span<const JointTransform> localPose,
+                         std::span<Mat4> modelPose);
+void BuildSkinningPalette(const SkeletonData& skeleton,
+                          std::span<const JointTransform> localPose,
+                          std::span<Mat4> scratchModelPose,
+                          std::span<Mat4> skinningPalette);

--- a/engine/include/math/Quat.h
+++ b/engine/include/math/Quat.h
@@ -215,6 +215,19 @@ struct Quat
 		return Quat{};
 	}
 
+	static Quat Nlerp(Quat a, Quat b, T t)
+		requires std::floating_point<T>
+	{
+		if (a.Dot(b) < T{0})
+			b = -b;
+		return Quat{
+			a.X + t * (b.X - a.X),
+			a.Y + t * (b.Y - a.Y),
+			a.Z + t * (b.Z - a.Z),
+			a.W + t * (b.W - a.W)
+		}.Normalized();
+	}
+
 	static Quat FromAxisAngle(const Vec<3, T>& axis, T angleRadians)
 		requires std::floating_point<T>
 	{

--- a/engine/src/anim/AnimationBlend.cpp
+++ b/engine/src/anim/AnimationBlend.cpp
@@ -1,0 +1,96 @@
+#include <anim/AnimationBlend.h>
+
+#include <algorithm>
+#include <cassert>
+
+namespace
+{
+    [[nodiscard]] JointTransform BlendJoint(const JointTransform& a,
+                                            const JointTransform& b,
+                                            float alpha)
+    {
+        const float clamped = std::clamp(alpha, 0.0f, 1.0f);
+        return JointTransform{
+            .Translation = Vec3d::Lerp(a.Translation, b.Translation, clamped),
+            .Rotation = Quat<float>::Nlerp(a.Rotation, b.Rotation, clamped),
+            .Scale = Vec3d::Lerp(a.Scale, b.Scale, clamped)
+        };
+    }
+} // namespace
+
+void BlendPoses(std::span<const JointTransform> a,
+                std::span<const JointTransform> b,
+                float alpha,
+                std::span<JointTransform> out)
+{
+    assert(a.size() == b.size());
+    assert(out.size() >= a.size());
+
+    for (size_t jointIndex = 0; jointIndex < a.size(); ++jointIndex)
+        out[jointIndex] = BlendJoint(a[jointIndex], b[jointIndex], alpha);
+}
+
+void BlendPosesWeighted(std::span<const std::span<const JointTransform>> poses,
+                        std::span<const float> weights,
+                        std::span<JointTransform> out)
+{
+    assert(poses.size() == weights.size());
+    assert(!poses.empty());
+
+    const size_t jointCount = poses[0].size();
+    assert(out.size() >= jointCount);
+    for (std::span<const JointTransform> pose : poses)
+        assert(pose.size() == jointCount);
+
+    for (size_t jointIndex = 0; jointIndex < jointCount; ++jointIndex)
+    {
+        Vec3d translation{};
+        Vec3d scale{};
+        Quat<float> rotation(0.0f, 0.0f, 0.0f, 0.0f);
+        float totalWeight = 0.0f;
+
+        for (size_t poseIndex = 0; poseIndex < poses.size(); ++poseIndex)
+        {
+            const float weight = std::max(weights[poseIndex], 0.0f);
+            if (weight == 0.0f)
+                continue;
+
+            const JointTransform& joint = poses[poseIndex][jointIndex];
+            Quat<float> sampleRotation = joint.Rotation;
+            if (totalWeight > 0.0f && rotation.Dot(sampleRotation) < 0.0f)
+                sampleRotation = -sampleRotation;
+
+            translation += joint.Translation * weight;
+            scale += joint.Scale * weight;
+            rotation.X += sampleRotation.X * weight;
+            rotation.Y += sampleRotation.Y * weight;
+            rotation.Z += sampleRotation.Z * weight;
+            rotation.W += sampleRotation.W * weight;
+            totalWeight += weight;
+        }
+
+        assert(totalWeight > 0.0f);
+        const float invWeight = 1.0f / totalWeight;
+        out[jointIndex].Translation = translation * invWeight;
+        out[jointIndex].Scale = scale * invWeight;
+        out[jointIndex].Rotation = (rotation * invWeight).Normalized();
+    }
+}
+
+void BlendPosesMasked(std::span<const JointTransform> base,
+                      std::span<const JointTransform> layer,
+                      float alpha,
+                      std::span<const float> jointWeights,
+                      std::span<JointTransform> out)
+{
+    assert(base.size() == layer.size());
+    assert(jointWeights.size() >= base.size());
+    assert(out.size() >= base.size());
+
+    const float clampedAlpha = std::clamp(alpha, 0.0f, 1.0f);
+    for (size_t jointIndex = 0; jointIndex < base.size(); ++jointIndex)
+    {
+        const float jointAlpha = clampedAlpha * std::clamp(jointWeights[jointIndex], 0.0f, 1.0f);
+        out[jointIndex] = BlendJoint(base[jointIndex], layer[jointIndex], jointAlpha);
+    }
+}

--- a/engine/src/anim/AnimationClipSampler.cpp
+++ b/engine/src/anim/AnimationClipSampler.cpp
@@ -1,0 +1,97 @@
+#include <anim/AnimationClipSampler.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+
+namespace
+{
+    [[nodiscard]] size_t FindKeyIndex(std::span<const float> times, float timeSeconds)
+    {
+        auto upper = std::upper_bound(times.begin(), times.end(), timeSeconds);
+        if (upper == times.begin())
+            return 0;
+        return static_cast<size_t>((upper - times.begin()) - 1);
+    }
+
+    [[nodiscard]] Vec3d ReadVec3(const std::vector<float>& values, size_t key)
+    {
+        const float* v = values.data() + key * 3;
+        return Vec3d(v[0], v[1], v[2]);
+    }
+
+    [[nodiscard]] Quat<float> ReadQuat(const std::vector<float>& values, size_t key)
+    {
+        const float* q = values.data() + key * 4;
+        return Quat<float>(q[0], q[1], q[2], q[3]);
+    }
+
+    [[nodiscard]] float SegmentAlpha(const AnimationJointTrack& track, size_t key, float timeSeconds)
+    {
+        if (key + 1 >= track.TimesSeconds.size())
+            return 0.0f;
+        const float t0 = track.TimesSeconds[key];
+        const float t1 = track.TimesSeconds[key + 1];
+        return std::clamp((timeSeconds - t0) / (t1 - t0), 0.0f, 1.0f);
+    }
+} // namespace
+
+float WrapClipTime(float timeSeconds, float durationSeconds, bool looping)
+{
+    if (durationSeconds <= 0.0f || !std::isfinite(durationSeconds) || !std::isfinite(timeSeconds))
+        return 0.0f;
+
+    if (!looping)
+        return std::clamp(timeSeconds, 0.0f, durationSeconds);
+
+    float wrapped = std::fmod(timeSeconds, durationSeconds);
+    if (wrapped < 0.0f)
+        wrapped += durationSeconds;
+    return wrapped;
+}
+
+void WriteBindPose(const SkeletonData& skeleton, std::span<JointTransform> pose)
+{
+    assert(pose.size() >= skeleton.Joints.size());
+    for (size_t jointIndex = 0; jointIndex < skeleton.Joints.size(); ++jointIndex)
+    {
+        const SkeletonJoint& joint = skeleton.Joints[jointIndex];
+        pose[jointIndex].Translation = joint.BindTranslation;
+        pose[jointIndex].Rotation = joint.BindRotation;
+        pose[jointIndex].Scale = joint.BindScale;
+    }
+}
+
+void SampleClip(const AnimationClipData& clip,
+                float timeSeconds,
+                std::span<JointTransform> pose)
+{
+    for (const AnimationJointTrack& track : clip.Tracks)
+    {
+        assert(track.JointIndex < pose.size());
+        if (track.TimesSeconds.empty())
+            continue;
+
+        const size_t key = FindKeyIndex(track.TimesSeconds, timeSeconds);
+        JointTransform& joint = pose[track.JointIndex];
+
+        if (track.Interpolation == AnimationInterpolation::Step || key + 1 >= track.TimesSeconds.size())
+        {
+            if (track.Path == AnimationChannelPath::Translation)
+                joint.Translation = ReadVec3(track.Values, key);
+            else if (track.Path == AnimationChannelPath::Scale)
+                joint.Scale = ReadVec3(track.Values, key);
+            else
+                joint.Rotation = ReadQuat(track.Values, key);
+            continue;
+        }
+
+        const float alpha = SegmentAlpha(track, key, timeSeconds);
+        if (track.Path == AnimationChannelPath::Translation)
+            joint.Translation = Vec3d::Lerp(ReadVec3(track.Values, key), ReadVec3(track.Values, key + 1), alpha);
+        else if (track.Path == AnimationChannelPath::Scale)
+            joint.Scale = Vec3d::Lerp(ReadVec3(track.Values, key), ReadVec3(track.Values, key + 1), alpha);
+        else
+            joint.Rotation = Quat<float>::Nlerp(ReadQuat(track.Values, key), ReadQuat(track.Values, key + 1), alpha);
+    }
+}

--- a/engine/src/anim/AnimationPoseStore.cpp
+++ b/engine/src/anim/AnimationPoseStore.cpp
@@ -1,0 +1,93 @@
+#include <anim/AnimationPoseStore.h>
+
+#include <cassert>
+
+AnimationPoseHandle AnimationPoseStore::Allocate(uint32_t jointCount)
+{
+    assert(jointCount > 0 && jointCount <= kMaxSkeletonJoints);
+
+    uint32_t index = UINT32_MAX;
+    auto& freeList = m_freeListsByJointCount[jointCount];
+    if (!freeList.empty())
+    {
+        index = freeList.back();
+        freeList.pop_back();
+    }
+    else
+    {
+        index = static_cast<uint32_t>(m_slots.size());
+        m_slots.emplace_back();
+    }
+
+    Slot& slot = m_slots[index];
+    slot.Occupied = true;
+    slot.JointCount = jointCount;
+    slot.LocalPose.assign(jointCount, JointTransform{});
+    slot.SkinningPalette.assign(jointCount, Mat4::Identity());
+    return AnimationPoseHandle{ index, slot.Generation };
+}
+
+void AnimationPoseStore::Free(AnimationPoseHandle handle)
+{
+    if (!Contains(handle))
+        return;
+
+    Slot& slot = m_slots[handle.Index];
+    const uint32_t jointCount = slot.JointCount;
+    slot.Occupied = false;
+    slot.JointCount = 0;
+    slot.LocalPose.clear();
+    slot.SkinningPalette.clear();
+    ++slot.Generation;
+    if (slot.Generation == 0)
+        ++slot.Generation;
+    m_freeListsByJointCount[jointCount].push_back(handle.Index);
+}
+
+std::span<JointTransform> AnimationPoseStore::LocalPose(AnimationPoseHandle handle)
+{
+    Slot& slot = CheckedSlot(handle);
+    return slot.LocalPose;
+}
+
+std::span<const JointTransform> AnimationPoseStore::LocalPose(AnimationPoseHandle handle) const
+{
+    const Slot& slot = CheckedSlot(handle);
+    return slot.LocalPose;
+}
+
+std::span<Mat4> AnimationPoseStore::SkinningPalette(AnimationPoseHandle handle)
+{
+    Slot& slot = CheckedSlot(handle);
+    return slot.SkinningPalette;
+}
+
+std::span<const Mat4> AnimationPoseStore::SkinningPalette(AnimationPoseHandle handle) const
+{
+    const Slot& slot = CheckedSlot(handle);
+    return slot.SkinningPalette;
+}
+
+uint32_t AnimationPoseStore::JointCount(AnimationPoseHandle handle) const
+{
+    return CheckedSlot(handle).JointCount;
+}
+
+bool AnimationPoseStore::Contains(AnimationPoseHandle handle) const
+{
+    return handle.Index < m_slots.size()
+        && m_slots[handle.Index].Occupied
+        && m_slots[handle.Index].Generation == handle.Generation;
+}
+
+AnimationPoseStore::Slot& AnimationPoseStore::CheckedSlot(AnimationPoseHandle handle)
+{
+    assert(Contains(handle) && "invalid animation pose handle");
+    return m_slots[handle.Index];
+}
+
+const AnimationPoseStore::Slot& AnimationPoseStore::CheckedSlot(AnimationPoseHandle handle) const
+{
+    assert(Contains(handle) && "invalid animation pose handle");
+    return m_slots[handle.Index];
+}

--- a/engine/src/anim/SkeletonPose.cpp
+++ b/engine/src/anim/SkeletonPose.cpp
@@ -1,0 +1,37 @@
+#include <anim/SkeletonPose.h>
+
+#include <cassert>
+
+Mat4 JointTransformToMatrix(const JointTransform& transform)
+{
+    return Mat4::MakeTranslation(transform.Translation)
+        * transform.Rotation.ToMat4()
+        * Mat4::MakeScale(transform.Scale);
+}
+
+void BuildModelSpacePose(const SkeletonData& skeleton,
+                         std::span<const JointTransform> localPose,
+                         std::span<Mat4> modelPose)
+{
+    assert(localPose.size() == skeleton.Joints.size());
+    assert(modelPose.size() >= skeleton.Joints.size());
+
+    for (size_t jointIndex = 0; jointIndex < skeleton.Joints.size(); ++jointIndex)
+    {
+        const Mat4 local = JointTransformToMatrix(localPose[jointIndex]);
+        const int32_t parent = skeleton.Joints[jointIndex].ParentIndex;
+        modelPose[jointIndex] = parent >= 0 ? modelPose[static_cast<size_t>(parent)] * local : local;
+    }
+}
+
+void BuildSkinningPalette(const SkeletonData& skeleton,
+                          std::span<const JointTransform> localPose,
+                          std::span<Mat4> scratchModelPose,
+                          std::span<Mat4> skinningPalette)
+{
+    assert(skinningPalette.size() >= skeleton.Joints.size());
+    BuildModelSpacePose(skeleton, localPose, scratchModelPose);
+
+    for (size_t jointIndex = 0; jointIndex < skeleton.Joints.size(); ++jointIndex)
+        skinningPalette[jointIndex] = scratchModelPose[jointIndex] * skeleton.Joints[jointIndex].InverseBind;
+}

--- a/test/core/AnimationPoseTests.cpp
+++ b/test/core/AnimationPoseTests.cpp
@@ -1,0 +1,183 @@
+#include <anim/AnimationBlend.h>
+#include <anim/AnimationClipSampler.h>
+#include <anim/AnimationPoseStore.h>
+#include <anim/SkeletonPose.h>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace
+{
+    void ExpectVecNear(const Vec3d& actual, const Vec3d& expected, float epsilon = 1e-5f)
+    {
+        EXPECT_NEAR(actual.X, expected.X, epsilon);
+        EXPECT_NEAR(actual.Y, expected.Y, epsilon);
+        EXPECT_NEAR(actual.Z, expected.Z, epsilon);
+    }
+
+    void ExpectQuatNear(const Quat<float>& actual, const Quat<float>& expected, float epsilon = 1e-5f)
+    {
+        EXPECT_NEAR(actual.X, expected.X, epsilon);
+        EXPECT_NEAR(actual.Y, expected.Y, epsilon);
+        EXPECT_NEAR(actual.Z, expected.Z, epsilon);
+        EXPECT_NEAR(actual.W, expected.W, epsilon);
+    }
+
+    SkeletonData MakeTwoJointSkeleton()
+    {
+        SkeletonData skeleton;
+        SkeletonJoint root;
+        root.BindTranslation = Vec3d(1.0f, 0.0f, 0.0f);
+        root.BindRotation = Quat<float>::Identity();
+        root.BindScale = Vec3d(1.0f, 1.0f, 1.0f);
+        root.InverseBind = Mat4::MakeTranslation(-1.0f, 0.0f, 0.0f);
+        skeleton.Joints.push_back(root);
+
+        SkeletonJoint child;
+        child.ParentIndex = 0;
+        child.BindTranslation = Vec3d(0.0f, 2.0f, 0.0f);
+        child.BindRotation = Quat<float>::Identity();
+        child.BindScale = Vec3d(1.0f, 1.0f, 1.0f);
+        child.InverseBind = Mat4::MakeTranslation(-1.0f, -2.0f, 0.0f);
+        skeleton.Joints.push_back(child);
+        return skeleton;
+    }
+} // namespace
+
+TEST(AnimationPoseStore, ReusesFreedSlotsByJointCountInLifoOrder)
+{
+    AnimationPoseStore store;
+    const AnimationPoseHandle a = store.Allocate(2);
+    const AnimationPoseHandle b = store.Allocate(3);
+    const AnimationPoseHandle c = store.Allocate(2);
+
+    store.Free(a);
+    store.Free(b);
+    store.Free(c);
+
+    const AnimationPoseHandle reusedTwo = store.Allocate(2);
+    EXPECT_EQ(reusedTwo.Index, c.Index);
+    EXPECT_NE(reusedTwo.Generation, c.Generation);
+
+    const AnimationPoseHandle reusedThree = store.Allocate(3);
+    EXPECT_EQ(reusedThree.Index, b.Index);
+    EXPECT_NE(reusedThree.Generation, b.Generation);
+}
+
+TEST(AnimationClipSampler, WritesBindPoseAndLeavesUntrackedChannels)
+{
+    SkeletonData skeleton = MakeTwoJointSkeleton();
+    std::vector<JointTransform> pose(skeleton.Joints.size());
+    WriteBindPose(skeleton, pose);
+
+    ExpectVecNear(pose[0].Translation, Vec3d(1.0f, 0.0f, 0.0f));
+    ExpectVecNear(pose[1].Translation, Vec3d(0.0f, 2.0f, 0.0f));
+
+    AnimationClipData clip;
+    clip.DurationSeconds = 1.0f;
+    AnimationJointTrack track;
+    track.JointIndex = 0;
+    track.Path = AnimationChannelPath::Translation;
+    track.Interpolation = AnimationInterpolation::Linear;
+    track.TimesSeconds = { 0.0f, 1.0f };
+    track.Values = { 0.0f, 0.0f, 0.0f, 10.0f, 0.0f, 0.0f };
+    clip.Tracks.push_back(track);
+
+    SampleClip(clip, 0.25f, pose);
+    ExpectVecNear(pose[0].Translation, Vec3d(2.5f, 0.0f, 0.0f));
+    ExpectVecNear(pose[1].Translation, Vec3d(0.0f, 2.0f, 0.0f));
+}
+
+TEST(AnimationClipSampler, StepSamplingUsesPreviousKeyAtBoundary)
+{
+    std::vector<JointTransform> pose(1);
+    AnimationClipData clip;
+    clip.DurationSeconds = 2.0f;
+    AnimationJointTrack track;
+    track.JointIndex = 0;
+    track.Path = AnimationChannelPath::Translation;
+    track.Interpolation = AnimationInterpolation::Step;
+    track.TimesSeconds = { 0.0f, 1.0f, 2.0f };
+    track.Values = { 0.0f, 0.0f, 0.0f, 5.0f, 0.0f, 0.0f, 9.0f, 0.0f, 0.0f };
+    clip.Tracks.push_back(track);
+
+    SampleClip(clip, 0.999f, pose);
+    ExpectVecNear(pose[0].Translation, Vec3d(0.0f, 0.0f, 0.0f));
+    SampleClip(clip, 1.0f, pose);
+    ExpectVecNear(pose[0].Translation, Vec3d(5.0f, 0.0f, 0.0f));
+}
+
+TEST(AnimationClipSampler, NlerpUsesShortestQuaternionHemisphere)
+{
+    std::vector<JointTransform> pose(1);
+    AnimationClipData clip;
+    clip.DurationSeconds = 1.0f;
+    AnimationJointTrack track;
+    track.JointIndex = 0;
+    track.Path = AnimationChannelPath::Rotation;
+    track.Interpolation = AnimationInterpolation::Linear;
+    track.TimesSeconds = { 0.0f, 1.0f };
+    track.Values = { 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, -1.0f };
+    clip.Tracks.push_back(track);
+
+    SampleClip(clip, 0.5f, pose);
+    ExpectQuatNear(pose[0].Rotation, Quat<float>::Identity());
+}
+
+TEST(AnimationClipSampler, WrapClipTimeHandlesLoopingAndClamping)
+{
+    EXPECT_FLOAT_EQ(WrapClipTime(2.5f, 2.0f, true), 0.5f);
+    EXPECT_FLOAT_EQ(WrapClipTime(-0.25f, 2.0f, true), 1.75f);
+    EXPECT_FLOAT_EQ(WrapClipTime(3.0f, 2.0f, false), 2.0f);
+    EXPECT_FLOAT_EQ(WrapClipTime(-1.0f, 2.0f, false), 0.0f);
+}
+
+TEST(AnimationBlend, BlendsAndMasksPoses)
+{
+    std::vector<JointTransform> a(2);
+    std::vector<JointTransform> b(2);
+    std::vector<JointTransform> out(2);
+    a[0].Translation = Vec3d(0.0f, 0.0f, 0.0f);
+    b[0].Translation = Vec3d(10.0f, 0.0f, 0.0f);
+    a[1].Translation = Vec3d(0.0f, 0.0f, 0.0f);
+    b[1].Translation = Vec3d(0.0f, 10.0f, 0.0f);
+
+    BlendPoses(a, b, 0.5f, out);
+    ExpectVecNear(out[0].Translation, Vec3d(5.0f, 0.0f, 0.0f));
+    ExpectVecNear(out[1].Translation, Vec3d(0.0f, 5.0f, 0.0f));
+
+    const float weights[] = { 1.0f, 0.25f };
+    BlendPosesMasked(a, b, 0.5f, weights, out);
+    ExpectVecNear(out[0].Translation, Vec3d(5.0f, 0.0f, 0.0f));
+    ExpectVecNear(out[1].Translation, Vec3d(0.0f, 1.25f, 0.0f));
+}
+
+TEST(AnimationBlend, WeightedBlendUsesCookedOrder)
+{
+    std::vector<JointTransform> a(1);
+    std::vector<JointTransform> b(1);
+    std::vector<JointTransform> out(1);
+    a[0].Translation = Vec3d(0.0f, 0.0f, 0.0f);
+    b[0].Translation = Vec3d(10.0f, 0.0f, 0.0f);
+
+    const std::span<const JointTransform> poseSpans[] = { a, b };
+    const float weights[] = { 0.25f, 0.75f };
+    BlendPosesWeighted(poseSpans, weights, out);
+
+    ExpectVecNear(out[0].Translation, Vec3d(7.5f, 0.0f, 0.0f));
+}
+
+TEST(SkeletonPose, BuildsIdentityPaletteForBindPose)
+{
+    SkeletonData skeleton = MakeTwoJointSkeleton();
+    std::vector<JointTransform> pose(skeleton.Joints.size());
+    std::vector<Mat4> scratch(skeleton.Joints.size());
+    std::vector<Mat4> palette(skeleton.Joints.size());
+
+    WriteBindPose(skeleton, pose);
+    BuildSkinningPalette(skeleton, pose, scratch, palette);
+
+    EXPECT_TRUE(palette[0].NearlyEquals(Mat4::Identity()));
+    EXPECT_TRUE(palette[1].NearlyEquals(Mat4::Identity()));
+}

--- a/test/math_geometry/QuatTests.cpp
+++ b/test/math_geometry/QuatTests.cpp
@@ -178,6 +178,23 @@ TEST(Quat, Equality)
 
 // --- Axis-Angle and Vector Rotation ---
 
+TEST(Quat, NlerpInterpolatesAndNormalizes)
+{
+	Quatf a = Quatf::Identity();
+	Quatf b = Quatf::FromAxisAngle(Vec3d(0.0f, 0.0f, 1.0f), Pi);
+	Quatf result = Quatf::Nlerp(a, b, 0.5f);
+
+	EXPECT_NEAR(result.Length(), 1.0f, 1e-6f);
+	ExpectVecNear(result.RotateVector(Vec3d(1.0f, 0.0f, 0.0f)), Vec3d(0.0f, 1.0f, 0.0f));
+}
+
+TEST(Quat, NlerpUsesShortestHemisphere)
+{
+	Quatf result = Quatf::Nlerp(Quatf::Identity(), -Quatf::Identity(), 0.5f);
+
+	EXPECT_TRUE(result.NearlyEquals(Quatf::Identity()));
+}
+
 TEST(Quat, FromAxisAngleCreatesExpectedRotation)
 {
 	Quatf q = Quatf::FromAxisAngle(Vec3d(0.0f, 0.0f, 1.0f), Pi / 2.0f);


### PR DESCRIPTION
### Motivation

- Provide foundational animation runtime primitives (poses, sampling, blending, pose storage) needed by the engine roadmap and the animation suite execution plan.
- Record the execution plan for the full animation suite and wire the roadmap to the new animation companion doc.
- Add deterministic sampler and blend semantics to enable later graph, montage, and skinned-rendering work.

### Description

- Add the animation suite execution spec document `docs/animation/suite-plan.md` and reference it from `docs/plans/engine-roadmap.md` and `docs/readme.md`.
- Introduce pose and skinning primitives with `engine/include/anim/SkeletonPose.h` and `engine/src/anim/SkeletonPose.cpp` implementing `JointTransform`, `JointTransformToMatrix`, `BuildModelSpacePose`, and `BuildSkinningPalette`.
- Add clip sampling utilities `engine/include/anim/AnimationClipSampler.h` and `engine/src/anim/AnimationClipSampler.cpp` with `WrapClipTime`, `WriteBindPose`, and `SampleClip` implementing deterministic step/linear rules and quaternion nlerp with hemisphere fix.
- Add blending APIs `engine/include/anim/AnimationBlend.h` and `engine/src/anim/AnimationBlend.cpp` implementing binary, weighted, and masked blends over spans.
- Add an allocation-backed pose storage `engine/include/anim/AnimationPoseStore.h` and `engine/src/anim/AnimationPoseStore.cpp` with generational `AnimationPoseHandle` and LIFO free-listing by joint count.
- Extend quaternion utilities with `Quat::Nlerp` in `engine/include/math/Quat.h` to support normalized linear interpolation used by the sampler and blends.
- Add unit tests in `test/core/AnimationPoseTests.cpp` covering pose store reuse, bind pose sampling, step sampling, nlerp behavior, wrap-time, blending, and palette build, and extend `test/math_geometry/QuatTests.cpp` with `Nlerp` tests.

### Testing

- Performed a full build and test run via `cmake --build build` and `ctest --test-dir build` which executed the added unit tests and the existing quaternion tests.
- New tests in `AnimationPoseTests` (storage, sampler, blend, palette) were run and passed.
- Added `Quat` tests for `Nlerp` were run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bb711ebe8832194efa3fc35ff59ea)