### PR TITLE
Complete backend residency and driven-pose foundations

### DIFF
--- a/docs/architecture/backend-residency.md
+++ b/docs/architecture/backend-residency.md
@@ -1,0 +1,19 @@
+# Backend residency contract
+
+A registry-local binding is justified when it owns retained objects in a shared backend that are derived from one registry's entities, reconciled against entity lifetime, and released with registry residency. Stateless queries, transient commands, gameplay interpretation, and one-shot interactions do not receive bindings.
+
+Frame participation controls iteration. Registry residency transitions control retained backend state.
+
+Every binding must state and test these edges:
+
+- **Enter domain participation:** materialize or restore backend objects before the new frame view exposes the registry to that domain.
+- **Participating:** reconcile entity topology and synchronize state through the domain's normal passes.
+- **Leave domain participation:** remove backend presence while preserving component-authoritative state. A dormant registry has no contacts, query hits, solver work, voices, or other backend effect in the domain it left.
+- **Detaching:** perform an unconditional final visit while the registry and sibling resources remain alive. Normal teardown empties the binding before registry destruction; destructors remain defensive fallback.
+- **Return:** restore deterministically from authoritative component state.
+
+Lifecycle mutations are recorded at their mutation sites and processed once per rendered frame before frame-view construction. The processing batch is stable: mutations raised during residency processing accumulate for the next frame.
+
+Cross-registry relationships that must survive routine streaming use game-held, generational participation leases. Independent leases compose by union and release independently. Forced teardown may override a lease; the relationship reports its own terminal result.
+
+Concrete bindings remain separate resources, named for their backend object family. Shared lifecycle shape does not justify a common base class or aggregate manager. After multiple implementations exist, only proven duplicated mechanics may be extracted.

--- a/docs/architecture/backend-residency.md
+++ b/docs/architecture/backend-residency.md
@@ -12,8 +12,8 @@ Every binding must state and test these edges:
 - **Detaching:** perform an unconditional final visit while the registry and sibling resources remain alive. Normal teardown empties the binding before registry destruction; destructors remain defensive fallback.
 - **Return:** restore deterministically from authoritative component state.
 
-Lifecycle mutations are recorded at their mutation sites and processed once per rendered frame before frame-view construction. The processing batch is stable: mutations raised during residency processing accumulate for the next frame.
+Lifecycle mutations are recorded at their mutation sites and processed once per rendered frame before frame-view construction. The processing batch is stable and read-only. Registry attachment, participation changes, and detachment are forbidden while residency handlers run; resulting lifecycle work must be queued for a later drain point. This preserves the invariant that backend state is corrected before a new frame view can observe the corresponding registry state.
 
-Cross-registry relationships that must survive routine streaming use game-held, generational participation leases. Independent leases compose by union and release independently. Forced teardown may override a lease; the relationship reports its own terminal result.
+Cross-registry relationships that must survive routine streaming use game-held, generational participation leases owned by `WorldPartitionRuntime`. Independent leases compose by union and release independently. Forced teardown may override leases, but the teardown owner must first call `InvalidateParticipationLeases(zone)` so every token becomes stale before the registry is destroyed and the relationship reports its terminal result.
 
 Concrete bindings remain separate resources, named for their backend object family. Shared lifecycle shape does not justify a common base class or aggregate manager. After multiple implementations exist, only proven duplicated mechanics may be extracted.

--- a/docs/ecs/component-traits.md
+++ b/docs/ecs/component-traits.md
@@ -84,12 +84,23 @@ static void OnRemove(const T& component, World& world, EntityId entity);
 |-----------------------------------------|--------------------|----------------------------------|
 | `world.AddComponent<T>(entity, value)`  | `OnAdd` for non-empty T | Immediately, inline              |
 | `world.RemoveComponent<T>(entity)`      | `OnRemove` for non-empty T | Before the entity moves archetype|
+| `world.DestroyEntity(entity)`           | `OnRemove` for every non-empty hooked component | Before the row is removed |
 | `cmds.AddComponent<T>(entity, value)`   | `OnAdd` for non-empty T | During `CommandBuffer::Flush`    |
 | `cmds.RemoveComponent<T>(entity)`       | `OnRemove` for non-empty T | During `CommandBuffer::Flush`    |
+| `cmds.DestroyEntity(entity)`            | `OnRemove` for every non-empty hooked component | During `CommandBuffer::Flush` |
+| `World` destruction / move-assignment   | `OnRemove` for every live non-empty hooked component | Before resources are destroyed |
 
 Hooks run **synchronously** at the call site (for direct mutations) or during flush (for
 command buffer operations). They execute in the order commands were recorded for
 command-buffer flushes.
+
+Destruction fires an entity's hooked components in column (registration) order,
+deterministically, and observes the destroyed entity's own values — hooks run
+before the swap-remove that backfills the row. World teardown drains every live
+hooked component the same way **before** destroying resources, so a hook that
+releases against a `World` resource (the retain/release pattern above) can always
+reach its service. There is no path on which a hooked component leaves the world
+without its `OnRemove` firing.
 
 ---
 

--- a/docs/plans/physics-driven-pose-constraints.md
+++ b/docs/plans/physics-driven-pose-constraints.md
@@ -40,13 +40,25 @@ the mechanism through components and events.
    world-partition features, not hidden constraint behavior.
 7. **Terminal events are published into one engine-owned buffer** on
    `PhysicsStepSystem`, which outlives every registry, so unload-path events cannot
-   die with the registry that produced them.
-8. **`PhysicsConstraintId` is generational.** Constraint handles live in ECS link
+   die with the registry that produced them. Teardown events raised between steps
+   land in a pending staging list that the next step folds into the published
+   buffer before clearing, so the per-step clear cannot destroy them unread.
+8. **Terminal completion consumes the definition.** Ending a constraint for any
+   reason removes `DrivenPoseConstraint` from the follower along with the runtime
+   components. The component is a transient runtime request; rearming is
+   structural — the game adds a new component. Persistent authored constraints
+   arrive in P7 as an authoring component that instantiates transient requests.
+9. **`PhysicsConstraintId` is generational.** Constraint handles live in ECS link
    components and survive churn; slot reuse without a generation is an ABA defect
    waiting to happen. `RemoveConstraint` on a dead handle is a safe no-op.
-9. **Three update categories, three mechanisms**: topology through structural-version
-   gating, configuration edits through `Changed<DrivenPoseConstraint>`, per-tick
-   target state unconditionally.
+10. **Three update categories, three mechanisms**: topology through
+    structural-version gating, configuration edits through
+    `Changed<DrivenPoseConstraint>`, per-tick target state unconditionally.
+    `Changed` never doubles as a rearm signal — decision 8 makes that impossible,
+    because a terminal constraint no longer has a component to be marked changed.
+11. **The binding owns frame and velocity composition.** The backend receives an
+    already-resolved world-space driven frame with velocities evaluated at the
+    attachment point; it never sees the target's ECS-side local attachment frame.
 
 Rejected shapes, argued where cited:
 
@@ -172,8 +184,8 @@ struct DrivenPoseConstraint
     Transform3f FollowerLocalFrame;
     Transform3f TargetLocalFrame;
 
-    PoseDriveSettings LinearDrive;
-    PoseDriveSettings AngularDrive;
+    LinearPoseDriveSettings LinearDrive;
+    AngularPoseDriveSettings AngularDrive;
     ConstraintBreakSettings Break;
 };
 ```
@@ -255,10 +267,16 @@ handle that makes steady-state work a contiguous column walk with no hashing.
 (Section 8) are canonical for all constraint state; the component never feeds back
 into the binding. Games read it with const access.
 
-No backend or Jolt type enters ECS storage. All three components (plus
-`DrivenPoseConstraint`) register in `RegisterPhysicsComponents`
-(`engine/src/physics/PhysicsRegistration.cpp`) before any entity creation, per ECS
-rules.
+Because terminal completion removes all three components in the same flush
+(Section 10), `Broken` and `Invalid` are never observable through
+`DrivenPoseTelemetry` — the component only ever shows `Pending` or `Active`, and
+terminal outcomes reach the game exclusively through the `DrivenPoseEnded` event.
+The enum's terminal values exist for the binding's records and diagnostics.
+
+No backend or Jolt type enters ECS storage. All three components —
+`DrivenPoseConstraint`, `DrivenPoseLink`, `DrivenPoseTelemetry` — register in
+`RegisterPhysicsComponents` (`engine/src/physics/PhysicsRegistration.cpp`) before
+any entity creation, per ECS rules.
 
 ---
 
@@ -271,15 +289,28 @@ enum class PoseDriveResponse : uint8_t
     Spring,
 };
 
-struct PoseDriveSettings
+struct LinearPoseDriveSettings
 {
     PoseDriveResponse Response = PoseDriveResponse::Locked;
 
     float FrequencyHz = 0.0f;
     float DampingRatio = 1.0f;
-    float MaxForce = std::numeric_limits<float>::infinity(); // MaxTorque angular
+    float MaxForce = std::numeric_limits<float>::infinity();
+};
+
+struct AngularPoseDriveSettings
+{
+    PoseDriveResponse Response = PoseDriveResponse::Locked;
+
+    float FrequencyHz = 0.0f;
+    float DampingRatio = 1.0f;
+    float MaxTorque = std::numeric_limits<float>::infinity();
 };
 ```
+
+Two structs rather than one reused struct with a context-dependent limit field: a
+member named `MaxForce` must not mean torque when the struct sits in the angular
+slot.
 
 `Locked` requests rigid relative-pose preservation. `Spring` uses frequency and
 damping and may lag under collision or acceleration. These are the two response
@@ -325,10 +356,9 @@ struct DrivenPoseConstraintDesc
 {
     PhysicsBodyId Follower;
     Transform3f FollowerLocalFrame;
-    Transform3f TargetLocalFrame;
 
-    PoseDriveSettings LinearDrive;
-    PoseDriveSettings AngularDrive;
+    LinearPoseDriveSettings LinearDrive;
+    AngularPoseDriveSettings AngularDrive;
 
     uint64_t OwnerTag = 0;  // opaque; the binding packs its RegistryId
     uint64_t UserData = 0;  // opaque; the binding packs the follower EntityId
@@ -336,9 +366,8 @@ struct DrivenPoseConstraintDesc
 
 struct DrivenPoseTarget
 {
-    Vec3d Position;
-    Quatf Rotation;
-    Vec3d LinearVelocity;
+    Transform3f WorldFrame;  // already composed: targetWorld * TargetLocalFrame
+    Vec3d LinearVelocity;    // evaluated at the frame origin, not the target origin
     Vec3d AngularVelocity;
     bool Teleported = false;
 };
@@ -370,10 +399,14 @@ std::span<const ExpiredConstraint> TakeExpiredConstraints(); // drained post-ste
 
 Contract:
 
-- The target is a driven frame, not necessarily a body: dynamic, kinematic,
-  animated, scripted, or any entity with a valid world transform. The backend owns
-  whatever hidden representation realizes the frame (kinematic anchor, mass
-  scaling, or another Jolt-side mechanism); the choice never leaks.
+- The backend's whole contract is: drive this follower-local frame toward this
+  world-space frame. It never sees the target entity or its local attachment
+  frame; frame and velocity composition belong to the binding (Section 12), which
+  keeps `TargetLocalFrame` single-owner on the ECS side. The target is a driven
+  frame, not necessarily a body: dynamic, kinematic, animated, scripted, or any
+  entity with a valid world transform. The backend owns whatever hidden
+  representation realizes the frame (kinematic anchor, mass scaling, or another
+  Jolt-side mechanism); the choice never leaks.
 - One-way: the follower receives constraint forces, the target receives no solver
   feedback, and the follower continues colliding normally.
 - **Refresh-or-expire.** `SetDrivenPoseTarget` must be called between steps for
@@ -437,8 +470,10 @@ Three update categories, three mechanisms:
 - **Configuration** (an existing `DrivenPoseConstraint` edited: retuned spring,
   changed frames, changed thresholds): detected with
   `Changed<DrivenPoseConstraint>` and pushed to the backend. Chunk-conservative is
-  acceptable — re-pushing a chunk's settings occasionally is cheap. All read paths
-  use const access so reads never mark the column.
+  acceptable — re-pushing a chunk's settings occasionally is cheap, and a spurious
+  neighbor-write mark can never resurrect a terminal constraint because
+  termination removes the component itself (Section 10). All read paths use const
+  access so reads never mark the column.
 - **Per-tick target state**: resolved and refreshed unconditionally for every
   active constraint. This is not reconciliation; the steady-state test in
   Section 16 is worded against topology passes only.
@@ -453,13 +488,20 @@ Structural changes the binding itself needs (adding `DrivenPoseLink` and
   (the registry's body pass has already run — Section 9), remove backend
   constraints whose definition vanished, sweep records for dead followers.
 - PrepareStep: resolve each record's `Target` ref against the physics span, read
-  target pose and velocities, classify teleports, call `SetDrivenPoseTarget`.
-  Resolution failure or target death is recorded for terminal handling in
-  CollectResults; the constraint is not refreshed, so the backend also disables it
-  for the step.
+  the target pose, compose the driven world frame
+  (`targetWorld * TargetLocalFrame`) and its velocities at the frame origin —
+  for an off-center frame on a rotating target the linear velocity is
+  `v + ω × r`, not the target origin's velocity — classify teleports, and call
+  `SetDrivenPoseTarget`. Composition is pure transform math with focused
+  table-driven tests. Resolution failure or target death is recorded for terminal
+  handling in CollectResults; the constraint is not refreshed, so the backend
+  also disables it for the step.
 - CollectResults: pull telemetry, evaluate break thresholds with hysteresis and
-  `RequiredDuration`, publish terminal events, remove broken backend constraints,
-  strip runtime components, update `DrivenPoseTelemetry` copies.
+  `RequiredDuration`, publish terminal events, remove terminal backend
+  constraints, and remove the terminal followers' `DrivenPoseConstraint`,
+  `DrivenPoseLink`, and `DrivenPoseTelemetry` in one command-buffer flush
+  (Section 10). Surviving constraints get their `DrivenPoseTelemetry` copies
+  updated in place.
 - Destructor: remove all owned backend constraints and publish `OwnerUnloaded`
   events through the sink pointer, which outlives every registry (Section 11).
 
@@ -512,8 +554,17 @@ pass 6). Telemetry is collected before any backend constraint is destroyed.
 
 ## 10. Lifecycle and termination
 
-States: `Pending -> Active -> Broken | Invalid`. A terminal constraint never
-recreates itself; rearming requires the game to replace the component.
+States: `Pending -> Active -> Broken | Invalid`. Terminal completion consumes the
+request: in one command-buffer flush the binding publishes `DrivenPoseEnded`,
+removes the backend constraint, and removes `DrivenPoseConstraint`,
+`DrivenPoseLink`, and `DrivenPoseTelemetry` from the follower. This is what makes
+"broken constraints do not recreate" structurally true — after the flush there is
+no definition left for topology reconciliation to rediscover, and no component
+left for a chunk-conservative `Changed` mark to touch. Rearming is unambiguous:
+the game adds a fresh `DrivenPoseConstraint`. The `Invalid` path consumes the
+request the same way, with a loud debug diagnostic. When P7 introduces authored
+persistent constraints, the authoring component instantiates transient requests;
+the runtime contract here does not change.
 
 - **Pending**: definition exists, follower body link not yet bound. Because the
   registry's body pass precedes its constraint pass, the common case binds in the
@@ -589,17 +640,38 @@ struct DrivenPoseEnded
 };
 ```
 
-`PhysicsStepSystem` owns an `EventBuffer<DrivenPoseEnded>` (the existing primitive
-at `engine/include/core/event/EventBuffer.h`; domain services own their buffers by
+`PhysicsStepSystem` owns the event sink (built on the existing primitive at
+`engine/include/core/event/EventBuffer.h`; domain services own their buffers by
 design). Bindings hold a non-owning sink pointer with the same lifetime argument
 `RigidBodyBinding` already uses for its raw `PhysicsWorld*`: `EngineSchedule`
 outlives `ZoneRuntime`, so registry teardown can still publish.
 
-Buffer discipline: cleared at the start of each physics step. Consumers in the same
-fixed tick's `PostFixed` phase see that tick's events. Frame-lane (`Update`)
-consumers must not assume one tick per frame — a frame runs zero or several fixed
-ticks, and only the last tick's events survive to `Update`. Systems that must not
-miss events consume them in `PostFixed`.
+The sink is two containers, because teardown publishes outside the step. Zone
+lifecycle mutates at drain points before `ScheduleTicks` builds the frame view, so
+an `OwnerUnloaded` raised by a binding destructor exists before the next physics
+step begins — a single buffer cleared at step entry would destroy it unread.
+
+```text
+published : EventBuffer<DrivenPoseEnded>   read by consumers
+pending   : append-only staging            written by teardown, between steps
+
+at physics-step entry:
+    published.Clear()
+    move pending into published
+during the step:
+    bindings and the expiry drain append to published
+```
+
+Everything runs on the simulation thread (teardown at drain points, publication
+inside the step), so no synchronization is involved.
+
+Visibility: consumers in the same fixed tick's `PostFixed` phase see that tick's
+events, including any teardown events staged since the previous step. Frame-lane
+(`Update`) consumers must not assume one tick per frame — a frame runs zero or
+several fixed ticks, and only the last tick's events survive to `Update`. Systems
+that must not miss events consume them in `PostFixed`. A frame that runs zero
+ticks leaves staged teardown events pending; they surface in the next tick that
+actually runs, which is the next moment physics state is coherent to act on.
 
 The engine reports the physical result only. It does not drop objects, end
 abilities, restore input, play cues, destroy game entities, or apply cooldowns;
@@ -626,6 +698,13 @@ Velocity: if the target carries a `RigidBody` component, use its linear and angu
 velocity values (component reads — the target's backend body, if any, is never
 touched). Otherwise derive from fixed-step transform deltas; angular velocity from
 the quaternion delta. The binding's record keeps the previous target transform.
+
+The binding then evaluates velocity at the driven frame's origin before refreshing
+the backend: for an attachment offset `r` from the target origin, the frame's
+linear velocity is `v + ω × r`. Skipping this hands the backend the target
+origin's velocity and makes off-center attachments on rotating targets drag
+behind their true path; the frame-composition helper owns this math and its
+table-driven tests.
 Discontinuities beyond the per-step translation and rotation bounds classify as
 teleports before velocity derivation, so a teleport never manufactures an enormous
 synthetic velocity — it either breaks the constraint (per break settings) or is
@@ -719,11 +798,12 @@ tunable validation, deterministic fixed-step tests. Exit: the same mechanism
 expresses rigid following and forgiving pickup-style following.
 
 **P4 — ECS binding and orchestration.**
-Components and registration; `DrivenPoseBinding`; global pass restructure in
-`PhysicsStepSystem`; span-scoped target resolution; engine-owned event buffer and
-sink wiring; owner teardown publishing; expired-list draining. Exit: constraints
-bind and unbind across registries without leaking backend objects or scanning
-topology on steady frames.
+Components and registration; `DrivenPoseBinding` with the frame- and
+velocity-composition helper; global pass restructure in `PhysicsStepSystem`;
+span-scoped target resolution; engine-owned event sink with pending staging;
+owner teardown publishing; expired-list draining. Exit: constraints bind and
+unbind across registries without leaking backend objects or scanning topology on
+steady frames, and teardown events survive to the next executed tick.
 
 **P5 — breaking and events.**
 Threshold accumulation, hysteresis, teleport classification, `RequiredDuration`,
@@ -763,8 +843,15 @@ ECS integration:
 
 - constraint binds in the same step its follower body binds; stays pending before
 - component removal, follower destruction, target destruction, and target-registry
-  unload each end the constraint with the correct reason
-- owner-registry unload removes backend constraints and publishes `OwnerUnloaded`
+  unload each end the constraint with the correct reason and remove all three
+  components from a surviving follower in the same flush
+- after a break, a write to a different entity's `DrivenPoseConstraint` in the
+  same chunk does not resurrect or rebind the broken follower
+- an off-center frame on a rotating target receives attachment-point velocity
+  (`v + ω × r`), verified against the analytic path
+- owner-registry unload removes backend constraints and publishes `OwnerUnloaded`;
+  the event survives to the next executed tick's `PostFixed` consumer even when
+  the unload happens on a frame that runs zero fixed ticks
 - owner-registry dormancy expires constraints and publishes `OwnerInactive`;
   the returning registry cleans up without publishing a second event
 - target-registry dormancy ends with `TargetUnavailable`
@@ -788,13 +875,17 @@ passing under the new names and storage.
 
 ## 17. Performance expectations
 
-Steady-state complexity: `O(active constraints + active bodies)`. No entity scans,
-no per-constraint registry scans, no repeated registration lookups, no backend
-creation during steady following, no schema interpretation or string lookup in the
-step. Topology work is structural-version gated; target refresh and telemetry are
-contiguous walks over dense records; span resolution is a bounded scan over a
-handful of registries. Any bounded behavior (expiry, pending diagnostics) logs what
-it dropped rather than truncating silently.
+Steady-state complexity, stated honestly:
+`O(active bodies + active constraints × physics registries)` — each active
+constraint's target resolution scans the physics span. The span is deliberately
+small (global plus a handful of streamed zones), so this is acceptable and is not
+disguised as `O(B + C)`; if profiling ever shows the resolution term, the fix is
+an indexed lookup, not a redesign. Beyond that: no entity scans, no repeated
+registration lookups, no backend creation during steady following, no schema
+interpretation or string lookup in the step. Topology work is structural-version
+gated; target refresh and telemetry are contiguous walks over dense records. Any
+bounded behavior (expiry, pending diagnostics) logs what it dropped rather than
+truncating silently.
 
 ---
 

--- a/docs/plans/physics-driven-pose-constraints.md
+++ b/docs/plans/physics-driven-pose-constraints.md
@@ -1,22 +1,32 @@
 # Driven Pose Constraints and Backend Residency
 
-Status: approved plan (2026-07-20), third revision. The first revision modeled
-constraints as free-standing entities; the second corrected ownership but patched
-around three substrate gaps with local mechanisms. This revision closes the gaps at
-the layer that owns each one, because the same gaps were generating defects and
-design conundrums independently of this feature. Scope is deliberately larger than
-the feature: the goal is boundaries that are still correct a year from now.
+Status: approved plan (2026-07-20), fourth revision. Revision one modeled
+constraints as free-standing entities. Revision two corrected ownership but
+patched around substrate gaps locally. Revision three closed the gaps but
+derived registry lifecycle by diffing frame views, which forced carry-over
+machinery and an orchestrator-only lookup. This revision records lifecycle
+transitions at their mutation sites and processes them in a drain-time
+residency phase, which deletes that machinery; it also adds composable
+participation leases, whose justification is a verified defect in the current
+pin mechanism. Scope is deliberately larger than the feature: the goal is
+boundaries that are still correct a year from now.
 
-Audience: whoever implements any track here (human or agent), and reviewers. Every
-claim about the current tree in Section 2 was verified against source at the time
-of writing; re-verify before relying on one, per the repository rule that plans are
-not proof.
+Audience: whoever implements any track here (human or agent), and reviewers.
+Every claim about the current tree in Section 2 was verified against source at
+the time of writing; re-verify before relying on one, per the repository rule
+that plans are not proof.
 
-Scope: ECS lifecycle contract, registry lifecycle observability, event-channel
-primitive, physics binding ownership, the shared-simulation residency contract, the
-driven-pose constraint mechanism, diagnostics, and tests. Game integration
-(abilities, input, cameras, pickup rules) stays out of scope; games consume the
-mechanism through components and events.
+Scope: ECS lifecycle contract, registry residency transitions and phase,
+participation leases, event-channel primitive, physics binding ownership, the
+shared-simulation residency contract, the driven-pose constraint mechanism,
+diagnostics, and tests. Game integration (abilities, input, cameras, pickup
+rules) stays out of scope; games consume the mechanism through components,
+events, and leases.
+
+The contract in one sentence: **frame participation controls iteration;
+residency transitions control retained backend state; active cross-registry
+relationships retain the participation they require through leases; destruction
+performs an explicit detach before RAII cleanup.**
 
 ---
 
@@ -25,84 +35,114 @@ mechanism through components and events.
 Substrate (Track A):
 
 1. **`DestroyEntity` fires `OnRemove` hooks.** The `ComponentTraits` contract is
-   completed: a component leaving the world fires its hook on every path — remove,
-   destroy, command buffer, and world teardown. Today destruction fires nothing,
-   which makes the documented retain/release pattern leak (Section 2.1).
+   completed: a component leaving the world fires its hook on every path —
+   remove, destroy, command buffer, and world teardown. Today destruction fires
+   nothing, which makes the documented retain/release pattern leak
+   (Section 2.1).
 2. **`World` teardown drains entity hooks before resources die.** Hooks reach
    their release targets through `World` resources; the current teardown order
    destroys resources first, so unload-path releases are unreachable.
-3. **Registry lifecycle becomes observable as frame data.** `BuildFrameView`
-   additionally computes transitions — per-domain entered and left spans, plus
-   destroyed registry ids — from drain-point-stable state. No observer callbacks,
-   no bus: transitions are data delivered at one phase point.
-4. **`FrameRegistryView` owns cross-registry resolution.** `Find(RegistryId)`
-   resolves participating registries for simulation code; `FindAttached` resolves
-   any attached registry for engine orchestrators handling lifecycle edges;
-   `IsAlive(EntityRef)` composes resolution with the generational check.
-   `ZoneRuntime::FindRegistry` remains the tools-and-lifecycle lookup.
-5. **`TickEventChannel<T>` is a named primitive.** Two-phase publication over
-   `EventBuffer<T>`: stage from outside the step, fold-and-clear at tick entry,
-   publish during the step. Events that must outlive their publishing registry get
-   one mechanism instead of per-subsystem staging.
+3. **Registry lifecycle transitions are recorded where they happen.**
+   `AttachZone`, `SetParticipation`, and `DestroyZone` produce explicit
+   residency-change records (attached, participation changed, detaching)
+   instead of forcing consumers to reverse-engineer deltas from frame views.
+   All three already run only at drain points, so the seam exists; this makes
+   it explicit.
+4. **A `RegistryResidency` phase processes the change batch once per rendered
+   frame**, after async commits and before the frame view is built — even on
+   frames whose fixed-step accumulator produces zero ticks. Backend state is
+   corrected before any frame span can observe it. Destruction is two-step:
+   `Detaching` registries get a final visit while fully alive, then are
+   destroyed.
+5. **Destructors become verified fallback, not the teardown path.** Ordinary
+   teardown happens in the `Detaching` visit with the registry readable and
+   sibling resources alive, eliminating dependence on unspecified
+   resource-destruction order and events-from-dying-state. Destructors still
+   clean up anything left (abnormal shutdown, direct-test usage) and a
+   diagnostics counter records fallback cleanups; the conformance harness — not
+   a destructor assert — proves the detach path leaves zero residue.
+6. **`FrameRegistryView` stays an iteration view** and gains only resolution:
+   `Find(RegistryId)` over participating registries and `IsAlive(EntityRef)`.
+   Residency changes carry live registry pointers, so no attached-scope lookup
+   is needed by transition consumers; `ZoneRuntime::FindRegistry` remains the
+   tools-and-lifecycle lookup.
+7. **`TickEventChannel<T>` is a named primitive.** Two-phase publication over
+   `EventBuffer<T>`: stage from outside the step (residency phase, teardown),
+   fold-and-clear at tick entry, publish during the step.
 
-Residency (Track B):
+Residency and streaming (Track B):
 
-6. **Dormant means absent from the shared simulation.** `ZoneParticipation`
+8. **Dormant means absent from the shared simulation.** `ZoneParticipation`
    already promises it ("cannot affect simulation or presentation"); physics
-   currently violates it — a dormant zone's bodies keep simulating and colliding.
-   On leaving the physics span a registry's bindings evict their backend objects
-   (records and links retained); on re-entry they restore from
-   component-authoritative state; destruction still cleans up via destructors.
-7. **Bindings live in `Registry::Resources` and are named for their mechanism.**
-   `PhysicsScene` becomes `RigidBodyBinding`; `CharacterMoverPool` moves beside
-   it; `DrivenPoseBinding` joins them. The binding criterion: retained backend
-   objects derived from this registry's entities, reconciled against entity
-   lifecycle, destroyed with the registry. Nothing else earns a binding.
-8. **A shared residency-conformance harness tests every binding** through the
-   same gauntlet: populate, go dormant, return, destroy — asserting zero backend
-   residue at each edge. The reconcile protocol shared by the three bindings is
-   extracted only after all three exist in code, and only the genuinely shared
-   part; storage semantics stay per-binding.
+   currently violates it. Leaving the physics domain evicts backend objects
+   (records and links retained); returning restores from
+   component-authoritative state; detaching removes everything with full refs
+   in hand.
+9. **Bindings live in `Registry::Resources`, named for their mechanism, one per
+   backend object family.** `PhysicsScene` becomes `RigidBodyBinding`;
+   `CharacterMoverPool` moves beside it; `DrivenPoseBinding` joins them. The
+   binding criterion: retained backend objects derived from this registry's
+   entities, reconciled against entity lifecycle, removed at detach. Nothing
+   else earns a binding. No shared interface: `PhysicsStepSystem` knows the
+   finite set of physics families and calls them in explicit order; they share
+   a contract, not a base class.
+10. **Participation leases replace reliance on the non-composable pin.**
+    `PinZone` is last-writer-wins per zone and `UnpinZone` erases
+    unconditionally (verified, Section 2.1), so independent holders cannot
+    coexist. Leases are generational participation floors owned by
+    `ZoneRuntime`; streaming demand, authored pins, and leases union into
+    effective participation, and unload selection honors floors. Leases are
+    **game-held**: the engine never acquires them implicitly — a physics
+    component silently pinning zones against the streaming budget is a hidden
+    side effect, and a layering violation besides. Forced teardown overrides
+    leases; holders learn through terminal events.
+11. **A shared residency-conformance harness gates every binding** through the
+    same gauntlet. The reconcile protocol shared by the three bindings is
+    extracted only after all three exist, and only the genuinely shared part.
 
 Feature (Track C):
 
-9. **The solver is global, bindings are registry-local, and a driven constraint
-   belongs to the follower.** The definition is a component on the driven body's
-   entity; the follower's registry owns the backend constraint.
-10. **Terminal completion consumes the definition.** Ending a constraint removes
-    `DrivenPoseConstraint` and its runtime components in one flush. Rearming is
-    structural; chunk-conservative `Changed` marks cannot resurrect anything.
-11. **The binding owns frame and velocity composition.** The backend receives a
-    resolved world-space driven frame with velocities evaluated at the attachment
-    point; it never sees the target's local attachment frame.
-12. **An endpoint registry leaving the physics view is terminal.** With
-    transitions observable, the departing side's binding is visited and publishes
-    full-fidelity events. The backend's refresh-or-expire check demotes from
-    load-bearing mechanism to debug invariant. Residency pins and cross-registry
-    entity migration are future world-partition features, not constraint behavior.
-13. **`PhysicsConstraintId` is generational**, and `RemoveConstraint` on a dead
-    handle is a safe no-op — required by unspecified sibling-resource destruction
-    order, and by eviction and teardown paths crossing.
-14. **Three update categories, three mechanisms**: topology through
+12. **The solver is global, bindings are registry-local, and a driven
+    constraint belongs to the follower.** The definition is a component on the
+    driven body's entity; the follower's registry owns the backend constraint.
+13. **Terminal completion consumes the definition.** Ending a constraint
+    removes `DrivenPoseConstraint` and its runtime components in one flush.
+    Rearming is structural; chunk-conservative `Changed` marks cannot resurrect
+    anything.
+14. **The binding owns frame and velocity composition.** The backend receives a
+    resolved world-space driven frame with velocities evaluated at the
+    attachment point; it never sees the target's local attachment frame.
+15. **An endpoint registry leaving the physics domain is terminal.** Leases are
+    the mechanism that prevents routine streaming from causing it; when it
+    happens anyway, the departing side is visited during the residency phase
+    and publishes full-fidelity events. The backend's refresh check demotes to
+    a debug invariant.
+16. **`PhysicsConstraintId` is generational**, and `RemoveConstraint` on a dead
+    handle is a safe no-op — defense in depth for crossing cleanup paths.
+17. **Three update categories, three mechanisms**: topology through
     structural-version gating, configuration edits through
     `Changed<DrivenPoseConstraint>`, per-tick target state unconditionally.
 
 Rejected regardless of budget, because they are wrong rather than expensive:
 
-- Registry lifecycle observer callbacks or an event bus. Ordering becomes
-  implicit, ownership becomes spooky; transitions-as-frame-data delivers the same
-  information at a defined phase point.
-- Per-zone physics worlds. Cross-zone collision is a requirement; piecewise
-  ownership of one shared solver is the correct price.
-- A binding base-class framework. The three bindings share a protocol, not
-  storage semantics (dense swap-remove vs stable-slot pool). Extract the protocol
-  after the third instance exists; never force the storage.
+- Registry lifecycle observer callbacks or an event bus. The residency phase
+  delivers the same information as batched data at one deterministic phase
+  point, with explicit consumer ordering.
+- Deriving transitions by diffing frame views (revision three's design).
+  Mutation sites already know previous and current state; diffing forced
+  carry-over lists across zero-tick frames and an orchestrator-only lookup,
+  all deleted by recording at the source.
+- Per-zone physics worlds. Cross-zone collision is a requirement.
+- A binding base-class framework. Storage semantics genuinely differ
+  (stable-slot pool vs dense swap-remove); extract the shared protocol after
+  the third instance exists, never the storage.
+- Engine-acquired participation leases. Residency retention is streaming
+  policy; it belongs to the game, with the terminal event naming the remedy.
 - Suspending and resuming constraints across dormancy. A relationship with an
-  absent endpoint is a ghost no system owns. Endpoint departure is terminal; a
-  game that wants the relationship to survive pins the zone.
+  absent endpoint is a ghost no system owns; leases keep endpoints present,
+  departure is terminal.
 - Constraint entities with an arbitrary owning registry, and a
-  `PhysicsConstraintScene` with global authority (rejected in revision two;
-  arguments preserved in Section 5).
+  `PhysicsConstraintScene` with global authority (rejected in revision two).
 
 ---
 
@@ -112,9 +152,9 @@ Add a reusable physics mechanism that drives one physics body toward a pose
 defined relative to another entity while preserving collision response.
 
 The invariant: a follower body attempts to maintain a configured position and
-orientation relative to a moving target frame. The solver resolves the follower
-against the world, and the constraint reports when the relationship can no longer
-be maintained within configured limits.
+orientation relative to a moving target frame. The physics solver resolves the
+follower against the world, and the constraint reports when the relationship
+can no longer be maintained within configured limits.
 
 This supports suspended actors, physics-object pickups, grabs, moving machinery
 attachments, magnetic and tractor mechanics, breakable carries, and rigid or
@@ -134,23 +174,29 @@ arrives on rails instead of re-litigating ownership.
   `Physics(PhysicsContext&)` already iterates the physics participation span
   (`EngineFramePhases.cpp` sets `ActiveRegistries = ctx.Registries.Physics`).
 - `PhysicsScene` is the per-registry ECS-to-body bridge: dense owned records,
-  structural-version-gated reconciliation, `PhysicsBodyLink` for hash-free sync,
-  destructor removes the registry's bodies. `CharacterMoverPool` repeats the
-  pattern for character movers. Both self-describe as registry-local but live in
-  the ECS `World`'s resource bag, while `Registry` carries a dedicated
-  `ResourceRegistry Resources` member whose comment names "physics worlds" among
-  intended tenants. `ActiveCameraService` already lives there.
-- `EntityRef` exists with zero consumers. `RegistryId` allocation is monotonic
-  (`ZoneRuntime::AllocateRegistryId`), generation currently fixed at 1.
-- `FrameRegistryView` is spans only. The global registry participates in every
-  span, ordered first. Zone lifecycle mutates only at drain points outside a live
-  frame view (asserted), so registry pointers are frame-stable.
-- Dormancy is routine: `WorldPartitionRuntime` demotes the previous focus zone as
-  normal streaming behavior. `ZoneParticipation`'s comment defines dormant as
-  unable to affect simulation or presentation.
+  structural-version-gated reconciliation, `PhysicsBodyLink` for hash-free
+  sync, destructor removes the registry's bodies. `CharacterMoverPool` repeats
+  the pattern for character movers. Both self-describe as registry-local but
+  live in the ECS `World`'s resource bag, while `Registry` carries a dedicated
+  `ResourceRegistry Resources` member whose comment names "physics worlds"
+  among intended tenants. `ActiveCameraService` already lives there.
+- Zone lifecycle mutates only at drain points outside a live frame view
+  (asserted in `ZoneRuntime`): `DestroyZone` runs from async-task completion
+  (`AsyncZoneLoader.cpp`), `SetParticipation` from `WorldPartitionRuntime`
+  updates and zone builders. `SetParticipation` is a direct field assignment
+  and `DestroyZone` erases the owning pointer immediately — the two places the
+  transition seam goes. The same zone's participation can change more than once
+  in one drain window, so the change batch coalesces.
+- `FramePhase` is a runtime-only enum (`DrainAsyncTasks = 3`,
+  `ScheduleTicks = 4`); inserting a phase renumbers nothing persisted.
+- `EntityRef` exists with zero consumers. `RegistryId` allocation is monotonic,
+  generation currently fixed at 1. `FrameRegistryView` is spans only; the
+  global registry participates in every span, ordered first.
+- Dormancy is routine: `WorldPartitionRuntime` demotes the previous focus zone
+  as normal streaming behavior.
 - Transform propagation runs after physics inside Simulate;
-  `CharacterControllerSystem` runs after `PhysicsStepSystem`. Both mean poses
-  read during physics can be one tick stale (Section 13).
+  `CharacterControllerSystem` runs after `PhysicsStepSystem`. Poses read during
+  physics can be one tick stale (Section 5.7).
 - Resource destruction order is unspecified in both resource stores.
 - `RigidBody` is linear-only with an unsynchronized `GravityScale` field.
   `PhysicsBodyId` is non-generational, safe for bodies only because records and
@@ -158,21 +204,27 @@ arrives on rails instead of re-litigating ownership.
 
 ### 2.1 Live defects this revision fixes
 
-- **Hook contract incomplete.** `World::DestroyEntity` removes the row and fires
-  no `OnRemove` (`World.h`), and the traits documentation's fire table
+- **Hook contract incomplete.** `World::DestroyEntity` removes the row and
+  fires no `OnRemove` (`World.h`), and the traits documentation's fire table
   (`docs/ecs/component-traits.md`) lists add/remove paths only — destruction is
   absent. Yet the documented flagship use is refcounted handles, and
   `StaticMeshComponent` and `AudioSourceComponent` ship live `OnAdd` retains.
   Destroying such an entity leaks its retains. Implementation must first write
-  the failing regression (destroy leaks a retain; unload leaks all retains) and
-  confirm no compensating sweep exists elsewhere.
+  the failing regression (destroy leaks a retain; unload leaks all retains)
+  and confirm no compensating sweep exists elsewhere.
 - **`World` teardown order.** The destructor clears resources before component
-  storage, so even with destruction hooks, unload-path releases could not reach
-  their targets. Teardown must drain hooks first.
+  storage, so even with destruction hooks, unload-path releases could not
+  reach their targets.
 - **Dormant zones keep physical presence.** Bodies of a registry that left the
   physics span remain active in the shared `PhysicsWorld`: they simulate,
-  collide, and answer queries, violating the documented participation contract.
-  No code path removes or parks them today.
+  collide, and answer queries, violating the documented participation
+  contract. No code path removes or parks them today.
+- **`PinZone` is not composable.** One `ZonePin` per zone: a second
+  `PinZone` call overwrites the existing minimum
+  (`WorldPartitionRuntime.cpp:100-110`) and `UnpinZone` erases every pin for
+  the zone (`:112-115`). Two independent holders cannot coexist and the first
+  release destroys the other's hold. Any system built on pins for relationship
+  retention inherits this defect.
 
 ---
 
@@ -187,10 +239,10 @@ covers reentrancy. The `CommandBuffer` destroy path fires the same hooks at
 flush. Archetypes precompute their hooked-column list at creation, so hook-free
 archetypes pay one branch.
 
-`World` teardown (destructor and move-assignment) drains `OnRemove` for all live
-hooked components before destroying component storage, and destroys resources
-last, so hooks can reach release targets. Zone unload thereby releases every
-retained handle.
+`World` teardown (destructor and move-assignment) drains `OnRemove` for all
+live hooked components before destroying component storage, and destroys
+resources last, so hooks can reach release targets. Zone unload thereby
+releases every retained handle.
 
 The batching rule in `docs/ecs/decisions.md` D1.5 extends naturally: bulk
 destroys of hooked archetypes run per-entity in record order; hook-free
@@ -199,58 +251,85 @@ archetypes keep the bulk path.
 Division of labor, stated once and written into the traits doc: **hooks own
 per-component resource correctness** (refcounts, external retains);
 **binding records own per-mechanism backend residency** (backend objects that
-need reconciliation, iteration, and eviction). Hooks do not replace records:
-records are also the hot-path iteration structure and the destroy-detection
-mechanism for state that is not a refcount.
+need reconciliation, iteration, and eviction). Hooks do not replace records,
+and generic ECS destruction is never taught to remove Jolt objects or audio
+voices — each binding owns its projection.
 
-Exit: the previously-failing leak regressions pass; hook order is deterministic
-and tested; `ctest` ECS suite green; the traits doc's fire table includes
-destruction and teardown rows.
+Exit: the previously-failing leak regressions pass; hook order is
+deterministic and tested; ECS suite green; the traits doc's fire table
+includes destruction and teardown rows.
 
-### A2 — Registry lifecycle transitions and resolution
+### A2 — Residency transitions and the RegistryResidency phase
 
-`ZoneRuntime::BuildFrameView` computes, against the previous frame's membership:
+`ZoneRuntime` records a change at each mutation site instead of mutating
+silently:
 
 ```cpp
-struct RegistryTransitions
+enum class RegistryResidencyChangeKind : uint8_t
 {
-    // Newly participating this frame, per domain. Pointers frame-stable.
-    std::span<Registry* const> EnteredPhysics;   // (and per other domains as needed)
+    Attached,
+    ParticipationChanged,
+    Detaching,
+};
 
-    // Left the domain this frame but still attached (dormant). Pointers
-    // frame-stable: lifecycle mutates only at drain points.
-    std::span<Registry* const> LeftPhysics;
+struct RegistryResidencyChange
+{
+    RegistryResidencyChangeKind Kind;
 
-    // Detached or destroyed since the last frame view. Ids only; teardown
-    // already ran via destructors.
-    std::span<const RegistryId> Destroyed;
+    RegistryId Registry;
+    Registry* Instance;          // valid while the batch is processed
+
+    ZoneParticipation Previous;
+    ZoneParticipation Current;
 };
 ```
 
-carried on `FrameRegistryView` beside the spans. Scratch-vector storage,
-allocation-free steady state, same pattern as the existing span scratch. Only the
-physics domain's transitions are consumed in this plan; other domains are
-computed when a consumer exists (the audio sweep in `AudioSystem` is the known
-candidate and can migrate later — noted, not required here).
+- `AttachZone` / `CreateZone` produce `Attached` (with the initial
+  participation as `Current`).
+- `SetParticipation` produces `ParticipationChanged`. Multiple changes to one
+  registry within a drain window coalesce to first-observed `Previous` and
+  final `Current`; intermediate states were never observable to any frame. An
+  attach followed by participation changes coalesces into one `Attached` with
+  the final participation.
+- `DestroyZone` marks the zone `Detaching` and produces the change; the owning
+  pointer is erased only after the batch is processed. The registry and all of
+  its resources are alive and readable during the visit.
 
-Resolution moves onto the view:
+A new frame phase processes the batch:
 
-```cpp
-Registry* Find(RegistryId id) const;          // participating this frame
-Registry* FindAttached(RegistryId id) const;  // any attached, incl. dormant
-bool IsAlive(EntityRef ref) const;            // Find + generational check
+```text
+DrainAsyncTasks       async commits land; attach / participation / destroy
+                      requests apply; ZoneRuntime coalesces the change batch
+RegistryResidency     systems process the batch (new phase)
+                      ZoneRuntime destroys registries marked Detaching
+ScheduleTicks         BuildFrameView (never sees unprocessed residency state)
+Simulate ...          unchanged
 ```
 
-`Find` is the simulation-facing default: a registry outside the frame is
-unresolvable, which is the correct default semantics for gameplay systems.
-`FindAttached` exists for engine orchestrators processing lifecycle edges
-(Section 4.2's carried-over farewell case) and is documented as such.
-Implementation starts as a linear scan; registry counts are a handful. The
-indexed variant is a drop-in if profiling ever cares.
+The phase runs once per rendered frame, including frames with zero fixed
+ticks, which is what deletes revision three's carry-over machinery: there is
+no "transition waiting for a physics tick" state. Systems opt in via
+`RegistryResidency(RegistryResidencyContext&)` on the engine schedule, ordered
+explicitly like every other phase. Backend mutation here is legal and safe:
+same owner thread, between steps, deterministic batch order (request order
+after coalescing).
 
-Exit: transition and resolution coverage in zone runtime tests, including
-enter/leave/destroy across drain points, dormant-vs-destroyed distinction, and
-pointer stability within a frame.
+`FrameRegistryView` stays an iteration view and gains resolution only:
+
+```cpp
+Registry* Find(RegistryId id) const;   // participating this frame
+bool IsAlive(EntityRef ref) const;     // Find + generational check
+```
+
+Simulation code resolves through the view — outside the frame means
+unresolvable, the correct default. Residency consumers use the live pointer in
+the change record. Tools and lifecycle orchestration keep
+`ZoneRuntime::FindRegistry`.
+
+Exit: transition coverage in zone runtime tests — attach, participation
+changes (including coalescing), destroy, batch ordering, pointer validity
+through the visit, destruction deferred until after processing; view
+resolution coverage; a zero-tick frame still processes residency.
 
 ### A3 — TickEventChannel
 
@@ -259,36 +338,36 @@ template <typename T>
 class TickEventChannel
 {
 public:
-    void Stage(const T& event);      // outside the step (teardown, drain points)
+    void Stage(const T& event);      // outside the step: residency phase, teardown
     void Publish(const T& event);    // during the step
     void BeginTick();                // fold staged into published, clear old
     std::span<const T> Items() const;
 };
 ```
 
-Built on `EventBuffer<T>`, placed beside it in `core/event`. Single-threaded by
-contract (teardown at drain points and publication in the step share the
-simulation thread). Visibility rules are the channel's documentation, not each
-subsystem's: same-tick `PostFixed` consumers see the tick's events plus staged
-events since the last executed tick; frame-lane consumers see only the last
-executed tick; a zero-tick frame leaves staged events pending until the next
-tick that runs.
+Built on `EventBuffer<T>`, placed beside it in `core/event`. Single-threaded
+by contract. Visibility rules are the channel's documentation, not each
+subsystem's: same-tick `PostFixed` consumers see the tick's events plus
+anything staged since the last executed tick; frame-lane consumers see only
+the last executed tick; a zero-tick frame leaves staged events pending until
+the next tick that runs.
 
-Exit: focused tests including the zero-tick frame, stage-then-destroy, and
-multi-tick frames.
+Exit: focused tests including zero-tick frames, stage-from-residency-phase,
+and multi-tick frames.
 
 ---
 
-## 4. Track B: physics residency
+## 4. Track B: physics residency and leases
 
 ### B1 — Binding ownership refactor
 
-Move `PhysicsScene` and `CharacterMoverPool` into `Registry::Resources`; rename
-`PhysicsScene` to `RigidBodyBinding`:
+Move `PhysicsScene` and `CharacterMoverPool` into `Registry::Resources`;
+rename `PhysicsScene` to `RigidBodyBinding`:
 
 ```text
 PhysicsStepSystem            owns PhysicsWorld, CollisionShapeCache,
-                             step orchestration, TickEventChannel instances
+                             step orchestration, TickEventChannel instances,
+                             physics residency processing
 
 Registry::Resources          RigidBodyBinding
                              CharacterMoverPool
@@ -298,80 +377,130 @@ Registry::Components (World) authored components, runtime link components
 ```
 
 Behavior-preserving; direct tests keep constructing bare `World`s and hold
-bindings as locals. Every backend removal path is order-independent (decision
-13), because sibling-resource destruction order is unspecified.
+bindings as locals. Every backend removal path is order-independent
+(decision 16).
 
 Exit: full suite green; a regression asserts bindings are reachable in
 `Registry::Resources` and absent from the `World` bag.
 
 ### B2 — Shared reconcile protocol
 
-`RigidBodyBinding`, `CharacterMoverPool`, and `DrivenPoseBinding` each carry the
-same skeleton: dense records, `LastStructuralVersion` gate, create-and-sweep
-reconcile, reconcile-count diagnostics, destructor teardown. After all three
-exist in code (i.e., after C's P4), extract the genuinely shared part — the
-version gate, the sweep protocol shape, the counters — as a small composition
-utility. Storage stays per-binding: the pool's stable-slot free list and the
-dense swap-remove vector are real semantic differences, not duplication. If the
-diff shows the shared part is smaller than the ceremony of extracting it, record
-that finding and keep the pattern; the conformance harness (B4), not code
-sharing, is what actually protects future bindings.
+After all three bindings exist in code (post C/P4), extract the genuinely
+shared part of the skeleton — the version gate, the sweep protocol shape, the
+counters — as a small composition utility. Storage stays per-binding: the
+pool's stable-slot free list and the dense swap-remove vector are semantic
+differences, not duplication. If the diff shows the shared part is smaller
+than the ceremony of extracting it, record that finding and keep the pattern;
+the conformance harness, not code sharing, is what protects future bindings.
 
-### B3 — The dormancy contract: evict and restore
+### B3 — The residency contract: evict, restore, detach
 
-The governing sentence: **dormant means absent from the shared simulation.**
+The governing rule, per binding lifecycle method, driven by
+`PhysicsStepSystem`'s `RegistryResidency` handler consuming the change batch:
 
-`PhysicsStepSystem`, at the start of its physics work each frame, consumes the
-transition data:
+```text
+Participating          backend objects exist and are synchronized (normal passes)
+Leaving physics        LeavePhysics: evict — no contacts, no default query hits,
+                       no solver cost; records and links retained
+Dormant                zero backend presence; binding idle
+Returning              EnterPhysics: restore from component-authoritative state,
+                       before the frame's normal reconcile
+Detaching              Detach: remove backend objects and relationships with the
+                       registry fully readable; stage terminal events
+Destroyed              destructor is verified fallback: cleans anything left,
+                       increments a diagnostics counter when it had to
+```
 
-- For each registry in `LeftPhysics` (and any carried-over leaver): a **farewell
-  visit** — each binding evicts its backend objects. `RigidBodyBinding` parks or
-  removes its bodies (mechanism is an implementation choice behind the binding
-  and `PhysicsWorld`; the contract is: no contacts, no default query hits, no
-  solver cost). `CharacterMoverPool` parks its movers under the same contract.
-  `DrivenPoseBinding` terminates its constraints with full-fidelity events
-  (decision 12). Records and link components are retained — eviction is not
-  teardown.
-- For each registry in `EnteredPhysics`: a **restore visit** — bindings
-  reinstate backend state from component-authoritative data (the last active
-  step synced transforms and velocities back to components, so restoration is
-  faithful). Restore precedes the frame's normal reconcile pass.
-- Farewell visits that cannot run because the frame executed zero physics ticks
-  carry over by `RegistryId`; on the next executed tick, ids found in
-  `Destroyed` are dropped (their destructors already tore down), the rest
-  resolve via `FindAttached`.
+Concretely, no shared interface (decision 9):
 
-This corrects the standing contract violation (Section 2.1) and is a behavior
-change: dormant zone geometry stops being collidable and stops answering default
-queries. That is what the participation contract always claimed; any content
-relying on the violation was relying on a bug. Called out loudly in the change
+```cpp
+class RigidBodyBinding
+{
+    void EnterPhysics(World&, PhysicsWorld&);
+    void LeavePhysics(World&, PhysicsWorld&);
+    void Detach(World&, PhysicsWorld&);
+    // + existing sync passes
+};
+// CharacterMoverPool and DrivenPoseBinding: same shape, own semantics.
+```
+
+For rigid bodies, leave captures body state, removes or parks the body
+(implementation choice behind the binding and `PhysicsWorld`; the observable
+contract is zero simulation presence), and keeps the record; enter
+reconstructs or reinserts and restores transform and velocity before normal
+reconciliation resumes. Movers park under the same contract. Driven
+constraints terminate on leave and detach (Section 5.6) — relationships end
+when an endpoint leaves the simulation.
+
+This corrects the standing contract violation and is a behavior change:
+dormant zone geometry stops being collidable and stops answering default
+queries. That is what the participation contract always claimed; content
+relying on the violation was relying on a bug. Called out loudly in change
 notes.
 
-Restoration cost is bounded by zone size (room-scale by the engine's stated
-capacity assumptions); shapes stay in the cooked cache. If profiling shows
-restore spikes, the park-don't-remove mechanism absorbs them; the contract does
-not change either way.
+Exit: fitness tests prove a dormant zone's simulation presence is zero, a
+returning zone restores component-faithful state, detach leaves zero backend
+residue with full-fidelity events, repeated cycles allocate nothing in steady
+state, and the fallback counter stays at zero through the whole suite.
 
-Exit: fitness tests prove a dormant zone's simulation presence is zero (no
-contacts against its geometry, no query hits, body/mover/constraint accounting
-correct), a returning zone restores bit-faithful component state, and repeated
-dormancy cycles allocate nothing in steady state.
+### B4 — Conformance harness and the contract document
 
-### B4 — Residency conformance harness
+A parameterized gauntlet any binding runs; the harness supplies the sequence
+and assertions, each binding supplies adapter operations and backend counts:
 
-A parameterized test gauntlet any binding can run: register components, populate
-entities, tick; leave the span (evict), assert zero simulation presence; return
-(restore), assert equivalence; destroy the registry, assert zero backend residue;
-repeat under churn. `RigidBodyBinding`, `CharacterMoverPool`, and
-`DrivenPoseBinding` all pass it in this ticket. The harness — not review vigilance
-— is what holds the line when the fourth binding arrives.
+```text
+Populate -> Participate -> Leave (verify zero presence) -> Return (verify
+deterministic restoration) -> Destroy entities (verify reconciliation) ->
+Detach registry (verify zero residue, events) -> churn and repeat
+```
 
-The residency contract itself is written down in
-`docs/architecture/backend-residency.md`: the binding criterion (decision 7),
-the lifecycle table (participating / leaving / dormant / returning / destroyed —
-who acts, through which mechanism), the hooks-vs-records division (A1), and the
-two resolvers' semantics (A2). `ZoneParticipation`'s comment and the traits doc
-are updated to point at it.
+All three bindings pass it in this ticket; the fourth binding a year from now
+gets a merge gate instead of an architecture argument.
+
+`docs/architecture/backend-residency.md` lands with this phase and states: the
+binding criterion, the lifecycle table above, the hooks-vs-records division,
+lease semantics, the resolution split (view / change record / `FindRegistry`),
+and the one-sentence contract from this plan's header. `ZoneParticipation`'s
+comment and the traits doc are updated to point at it.
+
+### B5 — Participation leases
+
+Generational floors owned by `ZoneRuntime`:
+
+```cpp
+struct ParticipationLeaseId
+{
+    uint32_t Index;
+    uint32_t Generation;
+};
+
+ParticipationLeaseId AcquireParticipationLease(ZoneId zone,
+                                               ZoneParticipation minimum);
+void ReleaseParticipationLease(ParticipationLeaseId lease);
+```
+
+- Effective participation is the union of streaming demand, authored pins, and
+  active lease floors. `ZoneDemand` already unions pin minimums; leases join
+  that computation, and unload selection skips zones with active floors the
+  way it skips pinned zones today.
+- Leases are acquired and released by game code (and future engine features
+  that own a policy decision, e.g. save snapshots). The engine's constraint
+  mechanism never acquires them implicitly (decision 10). The documented
+  pickup recipe: acquire physics leases on both endpoint zones when creating
+  the constraint, release them on `DrivenPoseEnded`.
+- Leases prevent routine demotion, not immortality: forced teardown (world
+  shutdown, explicit destruction) overrides floors, and holders observe the
+  outcome through terminal events plus lease invalidation
+  (`IsLeaseValid` answers false after override).
+- The global registry needs no lease (never dormant); acquiring against it
+  succeeds as a no-op. Acquiring against a detaching zone fails visibly.
+- `PinZone`/`UnpinZone` remain for authored single-owner pins; their
+  non-composability is documented at the declaration. Whether they migrate
+  onto leases later is a world-partition decision outside this ticket.
+
+Exit: lease tests — independent holders compose, release order is irrelevant,
+floors hold participation and block unload selection, forced teardown
+overrides and invalidates, generational ids reject stale releases.
 
 ---
 
@@ -379,14 +508,14 @@ are updated to point at it.
 
 The mechanism as corrected through prior revisions, on top of Tracks A and B.
 Ownership argument, preserved: the follower is the one unambiguous owner. A
-constraint entity would need an arbitrary owning registry, third-party lifecycle,
-and placement guidance; a component on the follower makes discovery and body
-binding own-registry concerns where structural-version gating works, and shrinks
-cross-registry coupling to const reads of the target. Accepted limitation, still
-deliberate: one pose driver per follower (one component per type per entity).
-Competing drives are the recorded trigger for a future relationship-entity
-mechanism; the backend API below is component-model-agnostic, so that migration
-would not touch it.
+constraint entity would need an arbitrary owning registry, third-party
+lifecycle, and placement guidance; a component on the follower makes discovery
+and body binding own-registry concerns where structural-version gating works,
+and shrinks cross-registry coupling to const reads of the target. Accepted
+limitation, still deliberate: one pose driver per follower (one component per
+type per entity). Competing drives are the recorded trigger for a future
+relationship-entity mechanism; the backend API is component-model-agnostic, so
+that migration would not touch it.
 
 ### 5.1 Components
 
@@ -426,8 +555,8 @@ All three register in `RegisterPhysicsComponents` before entity creation.
 `DrivenPoseLink` mirrors `PhysicsBodyLink`: hash-free steady state.
 `DrivenPoseTelemetry` is a published copy, records are canonical; because
 terminal completion removes all three components in one flush, the component
-only ever shows `Pending` or `Active` — terminal outcomes arrive exclusively via
-the event.
+only ever shows `Pending` or `Active` — terminal outcomes arrive exclusively
+via the event.
 
 ### 5.2 Drive and break settings
 
@@ -465,10 +594,9 @@ struct ConstraintBreakSettings
 
 Split linear/angular types so no field means force in one slot and torque in
 another. `Locked` is rigid preservation; `Spring` lags and recovers under
-frequency and damping. Error thresholds carry reset hysteresis so hovering
-values do not accumulate-and-clear on alternating ticks; `RequiredDuration`
-gives forgiving pickups without game policy in the engine. Break evaluation
-lives in the binding.
+frequency and damping. Error thresholds carry reset hysteresis; break
+evaluation lives in the binding; `RequiredDuration` gives forgiving pickups
+without game policy in the engine.
 
 ### 5.3 PhysicsWorld constraint API
 
@@ -515,60 +643,62 @@ PhysicsConstraintTelemetry GetConstraintTelemetry(PhysicsConstraintId id) const;
 ```
 
 The backend's whole contract: drive this follower-local frame toward this
-world-space frame, one-way, while the follower collides normally. It never sees
-the target entity or its attachment frame. The hidden realization (kinematic
-anchor, mass scaling, or another Jolt-side mechanism) never leaks.
+world-space frame, one-way, while the follower collides normally. It never
+sees the target entity or its attachment frame. The hidden realization
+(kinematic anchor, mass scaling, or another Jolt-side mechanism) never leaks.
 
-Targets are refreshed every step by the binding. With Track A's transitions, the
-orchestrator can always reach the binding that owes cleanup, so an unrefreshed
-live constraint is no longer a semantic state — it is an orchestration bug.
-Debug builds assert it (the former refresh-or-expire mechanism, demoted to
-invariant); release builds skip driving the stale constraint and count it in
-diagnostics.
+Targets are refreshed every step by the binding. With residency transitions
+explicit, an unrefreshed live constraint is an orchestration bug, not a
+semantic state: debug builds assert it; release builds skip driving the stale
+constraint and count it in diagnostics.
 
 `RemoveBody` invalidates dependent constraints before removing the body, on
-every path including teardown, in either destruction order.
+every path, in either cleanup order.
 
 ### 5.4 DrivenPoseBinding
 
-Per-registry resource beside the other two bindings. Dense records are canonical:
-follower id, handle, resolved target, previous target transform, failure
-accumulation, state.
+Per-registry resource beside the other two bindings. Dense records are
+canonical: follower id, handle, resolved target, previous target transform,
+failure accumulation, state.
 
 - **Reconcile** (structural-version gated): create backend constraints for
-  followers whose body link exists — the registry's body pass has run first —
+  followers whose body link exists — the registry's body pass runs first —
   remove constraints whose definition vanished, sweep dead followers.
-  Statically invalid configurations (target ref equals follower, invalid ref, no
-  dynamic `RigidBody`, nonfinite frames or drive values) consume the request
-  immediately with a loud debug diagnostic. Pending (body not yet bound) is
-  re-checked per step, surfaced by diagnostics, never silently timed out.
+  Statically invalid configurations (target ref equals follower, invalid ref,
+  no dynamic `RigidBody`, nonfinite frames or drive values) consume the
+  request immediately with a loud debug diagnostic. Pending (body not yet
+  bound) is re-checked per step, surfaced by diagnostics, never silently
+  timed out.
 - **Configuration** (`Changed<DrivenPoseConstraint>`): push edits to the
   backend. Chunk-conservative re-pushes are cheap; resurrection is impossible
   because terminal constraints have no component left to mark.
-- **PrepareStep** (every tick): resolve `Target` against the physics span,
+- **PrepareStep** (every tick): resolve `Target` through the frame view,
   compose the driven world frame (`targetWorld * TargetLocalFrame`) and its
-  velocities at the frame origin — `v + w x r` for off-center frames on rotating
-  targets, not the target origin's velocity — classify teleports, refresh the
-  backend. Composition is pure math with table-driven tests. Foreign-registry
-  reads are const-only. Resolution failure is recorded for terminal handling.
+  velocities at the frame origin — `v + w x r` for off-center frames on
+  rotating targets, not the target origin's velocity — classify teleports,
+  refresh the backend. Composition is pure math with table-driven tests.
+  Foreign-registry reads are const-only. Resolution failure is recorded for
+  terminal handling.
 - **CollectResults** (every tick): pull telemetry, evaluate breaks with
-  hysteresis, publish `DrivenPoseEnded`, and for each terminal constraint remove
-  the backend object plus all three components in one command-buffer flush.
-- **Farewell visit** (B3): terminate all constraints with full refs and reason
-  `OwnerInactive`; evict nothing else — constraints are relationships, and
-  relationships end when an endpoint leaves the simulation.
-- **Destructor**: remove backend constraints and stage `OwnerUnloaded` events
-  into the channel.
+  hysteresis, publish `DrivenPoseEnded`, and for each terminal constraint
+  remove the backend object plus all three components in one command-buffer
+  flush.
+- **LeavePhysics / Detach** (residency phase): terminate all constraints with
+  full refs — reasons `OwnerInactive` and `OwnerUnloaded` respectively —
+  staging events into the channel. Detach runs with the registry fully
+  readable; the destructor is fallback only.
 
-Target velocity source: the target's `RigidBody` component values when present
-(component reads only), otherwise fixed-step transform deltas with quaternion
-delta for angular; teleports classify before derivation so a teleport never
-manufactures a synthetic velocity.
+Target velocity source: the target's `RigidBody` component values when
+present (component reads only), otherwise fixed-step transform deltas with
+quaternion delta for angular; teleports classify before derivation so a
+teleport never manufactures a synthetic velocity.
 
 ### 5.5 Step orchestration
 
+Residency processing happens in the `RegistryResidency` phase before the frame
+view exists, so the fixed-step sequence needs no transition handling:
+
 ```text
-0. Process transitions: farewell visits (leavers), restore visits (returners)
 1. For each registry: rigid-body reconcile + kinematic push   (RigidBodyBinding)
 2. For each registry: driven-pose reconcile                   (DrivenPoseBinding)
 3. For each registry: resolve targets, refresh driven frames  (DrivenPoseBinding)
@@ -581,14 +711,15 @@ manufactures a synthetic velocity.
 `TickEventChannel<DrivenPoseEnded>::BeginTick` runs at step entry. Passes are
 serial on the simulation thread in span order (global first, zones in attach
 order): deterministic event and reconcile ordering. The pass-1/pass-2 barrier
-guarantees every registry's bodies exist before any registry binds constraints.
-Constraint passes are permanently excluded from any per-registry parallel axis —
-they read foreign registries; the exclusion is by construction, not convention.
+guarantees every registry's bodies exist before any registry binds
+constraints. Constraint passes are permanently excluded from any per-registry
+parallel axis — they read foreign registries; the exclusion is by
+construction, not convention.
 
 ### 5.6 Lifecycle, termination, events
 
 States: `Pending -> Active -> Broken | Invalid`. Terminal completion consumes
-the request (decision 10); rearming is a fresh component.
+the request (decision 13); rearming is a fresh component.
 
 ```cpp
 enum class DrivenPoseEndReason : uint8_t
@@ -602,8 +733,8 @@ enum class DrivenPoseEndReason : uint8_t
     TargetTeleported,
     TargetDestroyed,    // target entity dead in a resolvable registry
     TargetUnavailable,  // target registry unloaded or outside the physics view
-    OwnerUnloaded,      // follower's registry destroyed
-    OwnerInactive,      // follower's registry left the physics view
+    OwnerUnloaded,      // follower's registry detached
+    OwnerInactive,      // follower's registry left the physics domain
     InvalidConfiguration,
 };
 
@@ -621,30 +752,32 @@ struct DrivenPoseEnded
 };
 ```
 
-All events carry full refs — the farewell visit and the destructor both run with
-records intact, which the transitions work exists to guarantee. Events ride the
-engine-owned `TickEventChannel<DrivenPoseEnded>` on `PhysicsStepSystem`;
-bindings hold a non-owning channel pointer (same lifetime argument as their
-`PhysicsWorld*`: `EngineSchedule` outlives `ZoneRuntime`).
+All events carry full refs — leave and detach both run with records intact,
+which the residency phase exists to guarantee. Events ride the engine-owned
+`TickEventChannel<DrivenPoseEnded>` on `PhysicsStepSystem`; bindings hold a
+non-owning channel pointer (`EngineSchedule` outlives `ZoneRuntime`).
 
 The engine reports the physical result only; games decide what it means. The
-integrator-facing consequence stays documented loudly: streaming demotes zones
-routinely, so a constraint whose endpoint's zone demotes ends by design; the
-remedies (pins, migration) are world-partition features.
+integrator-facing guidance is now concrete instead of aspirational: streaming
+demotes zones routinely, so a game that wants a cross-zone relationship to
+survive acquires participation leases on both endpoint zones when creating the
+constraint and releases them on `DrivenPoseEnded` (B5). A game that does not
+lease gets a deterministic terminal event naming the reason.
 
 ### 5.7 Target pose staleness (documented v1 contract)
 
-Pose source: `WorldTransform` when present, else `LocalTransform`. Propagation
-runs after physics, so a parented target's world pose is one tick old — sockets
-on moving parents lag one fixed step; v1 recommends top-level or physics-driven
-targets, and on-demand parent-chain propagation is the recorded future option.
-Character-driven targets are likewise one tick stale (`CharacterControllerSystem`
-runs after the step); spring response masks it, locked response will trail.
+Pose source: `WorldTransform` when present, else `LocalTransform`.
+Propagation runs after physics, so a parented target's world pose is one tick
+old — sockets on moving parents lag one fixed step; v1 recommends top-level or
+physics-driven targets, and on-demand parent-chain propagation is the recorded
+future option. Character-driven targets are likewise one tick stale
+(`CharacterControllerSystem` runs after the step); spring response masks it,
+locked response will trail.
 
 ### 5.8 Collision and diagnostics
 
-The follower collides normally per collision filtering; the driven frame carries
-no collision shape; follower-versus-source filtering is ordinary layer
+The follower collides normally per collision filtering; the driven frame
+carries no collision shape; follower-versus-source filtering is ordinary layer
 configuration. Debug drawing: frame axes, desired frame, error vector and arc,
 force and torque magnitudes, state coloring, thresholds. Console:
 
@@ -656,8 +789,8 @@ physics.constraints.warn_pending_steps   (0 = off)
 ```
 
 Counters: active, pending, created and removed per step, breaks by reason,
-stale-refresh invariant hits, reconcile passes, resolution failures. No Jolt
-type outside the physics implementation.
+stale-refresh invariant hits, fallback-destructor cleanups, reconcile passes,
+resolution failures. No Jolt type outside the physics implementation.
 
 ---
 
@@ -665,10 +798,11 @@ type outside the physics implementation.
 
 ```text
 Track A (substrate)      A1 destroy hooks + teardown order
-                         A2 view transitions + resolution
+                         A2 residency transitions + RegistryResidency phase
                          A3 TickEventChannel
 Track B (residency)      B1 binding move + rename            (independent of A)
-                         B3 evict/restore                     (needs A2)
+                         B3 evict / restore / detach          (needs A2)
+                         B5 participation leases              (needs A2)
                          B4 conformance harness + contract doc
                          B2 protocol extraction               (after C/P4)
 Track C (feature)        P1 body completion                   (independent)
@@ -681,18 +815,10 @@ Track C (feature)        P1 body completion                   (independent)
 ```
 
 A1, A2, A3, B1, P1, and P2 are mutually independent and can proceed in
-parallel. Each lands as its own commit series with its own tests; no phase
-waits on the whole.
+parallel. Each lands as its own commit series with its own tests.
 
-Phase exit conditions:
+Phase exit conditions are stated inline in Tracks A and B. For Track C:
 
-- **A1/A2/A3**: as stated in Track A. A1's leak regressions must fail before the
-  fix, for the intended reason.
-- **B1**: suite green, bindings in `Registry::Resources`.
-- **B3**: dormant zone has zero simulation presence; returning zone restores
-  faithfully; cycles allocate nothing.
-- **B4**: all three bindings pass the gauntlet; `backend-residency.md` merged;
-  traits doc and participation comments updated.
 - **P1**: dynamic bodies preserve and report full linear and angular state
   through ECS sync (including the currently-dead `GravityScale`).
 - **P2**: a body follows a translating and rotating driven frame while
@@ -701,8 +827,8 @@ Phase exit conditions:
 - **P3**: rigid and forgiving following from one mechanism; limits enforced;
   deterministic repeated runs.
 - **P4**: constraints bind and unbind across registries with no leaks and no
-  steady-state topology scans; events flow through the channel; farewell and
-  restore paths exercised.
+  steady-state topology scans; events flow through the channel; leave,
+  detach, and restore paths exercised through the residency phase.
 - **P5**: obstruction, overload, teleports, and participation loss produce
   deterministic, inspectable terminal events; no auto-recreation.
 - **P6**: tunable and inspectable without game code.
@@ -713,19 +839,24 @@ Phase exit conditions:
 
 Substrate:
 
-- destroy fires `OnRemove` (direct and command buffer), in deterministic order;
-  world teardown drains hooks before resources; the mesh/audio retain leaks
-  regress before the fix and pass after
-- transition spans across enter/leave/destroy at drain points; dormant vs
-  destroyed distinguished; pointer stability within a frame
-- channel: zero-tick frames, stage-then-destroy, multi-tick frames
+- destroy fires `OnRemove` (direct and command buffer) in deterministic
+  order; world teardown drains hooks before resources; the mesh/audio retain
+  leaks regress before the fix and pass after
+- residency: attach / participation / detach change records, coalescing,
+  batch order, pointer validity through the visit, deferred destruction,
+  zero-tick frames still process residency
+- view resolution: participating-only `Find`, generational `IsAlive`
+- channel: zero-tick frames, stage-from-residency, multi-tick frames
 
-Residency:
+Residency and leases:
 
-- conformance gauntlet for all three bindings (populate / dormant / return /
-  destroy / churn), zero backend residue at each edge
+- conformance gauntlet for all three bindings, zero backend residue at each
+  edge, fallback counter zero throughout
 - dormant zone: no contacts, no default query hits, zero solver cost; restore
   is component-faithful
+- leases: independent holders compose, release order irrelevant, floors hold
+  participation and block unload selection, forced teardown overrides and
+  invalidates, stale lease ids rejected
 
 PhysicsWorld (direct, headless, fixed stepping):
 
@@ -733,40 +864,45 @@ PhysicsWorld (direct, headless, fixed stepping):
 - zero-gravity suspension; collision preserved; one-way isolation
 - force and torque limits; teleport flag semantics
 - generational handles: stale handle never resolves after slot reuse
-- `RemoveBody` invalidates dependents in both destruction orders; dead-handle
+- `RemoveBody` invalidates dependents in both cleanup orders; dead-handle
   removal is a no-op; stale-refresh asserts in debug
 - identical runs produce identical results
 
 ECS integration:
 
 - binds the step the follower's body binds; pending before
-- every terminal reason reachable and correct, components consumed in one flush
+- every terminal reason reachable and correct, components consumed in one
+  flush
 - neighbor-chunk `Changed` marks cannot resurrect a broken follower
 - off-center rotating target receives `v + w x r`, verified analytically
-- `OwnerUnloaded` staged at teardown survives to the next executed tick's
+- `OwnerUnloaded` staged at detach survives to the next executed tick's
   `PostFixed`, including across zero-tick frames
+- a leased endpoint zone is not demoted by streaming while the lease is held;
+  releasing the lease permits demotion and the constraint then ends with
+  `TargetUnavailable` or `OwnerInactive` as appropriate
 - global-registry follower against zone-registry target
 - steady-state ticks: no topology reconciliation (per-tick refresh expected)
 
 Stress and fitness:
 
-- cost scales with active constraints; inactive entities free; no steady-state
-  allocation; create/destroy churn leaks nothing; counts reach zero after
-  registry destruction; invalid data loud in debug, safe in release
+- cost scales with active constraints; inactive entities free; no
+  steady-state allocation; create/destroy churn leaks nothing; counts reach
+  zero after registry detach; invalid data loud in debug, safe in release
 
 ---
 
 ## 8. Performance expectations
 
 Steady state: `O(active bodies + active constraints x physics registries)` —
-the resolution term is a scan over a deliberately small span, stated honestly
-rather than disguised; an indexed lookup is the recorded fix if it ever shows in
-a profile. Topology work is version-gated; refresh and telemetry are contiguous
-record walks. Transition processing is proportional to transitions, which are
-rare. Eviction and restore are proportional to the leaving or returning zone's
-contents and occur at streaming frequency, not tick frequency. Hook completion
-adds cost only to hooked archetypes on structural paths. Anything bounded logs
-what it dropped.
+the resolution term is a scan over a deliberately small span, stated honestly;
+an indexed lookup is the recorded fix if it ever profiles. Topology work is
+version-gated; refresh and telemetry are contiguous record walks. Residency
+processing is proportional to the change batch, which is empty on almost every
+frame and bounded by streaming activity otherwise. Eviction and restore are
+proportional to the transitioning zone's contents at streaming frequency, not
+tick frequency. Lease bookkeeping is O(active leases) at demand-computation
+time. Hook completion adds cost only to hooked archetypes on structural paths.
+Anything bounded logs what it dropped.
 
 ---
 
@@ -778,17 +914,21 @@ what it dropped.
 2. Locked and spring responses are one mechanism; breaks report error, force,
    torque, and terminal reason; endpoints work across registries via
    `EntityRef`.
-3. Component lifecycle is complete: no path exists on which a hooked component
-   leaves the world without its hook firing, including zone unload.
-4. A dormant registry has zero presence in the shared simulation, and returning
-   restores it faithfully.
-5. Every unload, dormancy, and destruction path ends deterministically with the
-   documented reason, full refs, and no dangling backend object — proven by the
+3. Component lifecycle is complete: no path exists on which a hooked
+   component leaves the world without its hook firing, including zone unload.
+4. A dormant registry has zero presence in the shared simulation; returning
+   restores it faithfully; detaching removes everything with full-fidelity
+   events while the registry is still readable; destructors are verified
+   fallback with a zero counter across the suite.
+5. Independent systems can hold participation concurrently through leases,
+   and a leased cross-zone relationship survives routine streaming.
+6. Every unload, dormancy, and destruction path ends deterministically with
+   the documented reason and no dangling backend object — proven by the
    conformance harness for all three bindings.
-6. Bindings live in `Registry::Resources`; the residency contract is a merged
+7. Bindings live in `Registry::Resources`; the residency contract is a merged
    document; no game, genre, or project term in the engine API; no Jolt type
    across the firewall.
-7. No steady-state structural scan or allocation; a game implements suspended
+8. No steady-state structural scan or allocation; a game implements suspended
    actors and forgiving pickups without touching the backend.
 
 ---
@@ -797,9 +937,10 @@ what it dropped.
 
 Bilateral joints, distance and rope limits, hinges, cone and twist limits,
 ragdolls, breakable assemblies, networked prediction, persistent saved
-constraints, editor-authored mechanical assemblies, residency pins,
-cross-registry entity migration, on-demand target-chain propagation, camera
-spring arms, audio-sweep migration onto A2 transitions, indexed registry
-resolution, non-physics domain transition consumers. Each now has a substrate to
-land on; none expands this ticket further. Competing multi-driver poses remain
-the recorded trigger for a relationship-entity mechanism.
+constraints, editor-authored mechanical assemblies, cross-registry entity
+migration, on-demand target-chain propagation, camera spring arms, migrating
+the audio sweep onto residency transitions, migrating authored pins onto
+leases, indexed registry resolution, non-physics residency consumers. Each now
+has a substrate to land on; none expands this ticket further. Competing
+multi-driver poses remain the recorded trigger for a relationship-entity
+mechanism.

--- a/docs/plans/physics-driven-pose-constraints.md
+++ b/docs/plans/physics-driven-pose-constraints.md
@@ -1,0 +1,827 @@
+# Driven Pose Constraints and Physics Binding Ownership
+
+Status: approved plan (2026-07-20). Supersedes the earlier driven-pose-constraint
+draft that modeled constraints as free-standing entities and introduced a
+`PhysicsConstraintScene`; the sections below record why that shape was rejected.
+
+Audience: whoever implements any phase here (human or agent), and reviewers. Every
+claim about the current tree in Section 2 was verified against source at the time of
+writing; re-verify against the tree before relying on one, per the repository rule
+that plans are not proof.
+
+Scope: physics backend, per-registry physics bindings, fixed-step orchestration,
+diagnostics, and tests. One prerequisite ownership refactor is included. Game
+integration (abilities, input, cameras, pickup rules) is out of scope; games consume
+the mechanism through components and events.
+
+---
+
+## 0. Decisions up front
+
+1. **The solver is global, bindings are registry-local, and a driven constraint
+   belongs to the follower.** The constraint definition is a component on the driven
+   body's entity, not a separate constraint entity. The follower's registry owns the
+   backend constraint.
+2. **Per-registry physics bindings move out of the ECS `World` resource bag into
+   `Registry::Resources`**, where `ResourceRegistry`'s own documentation already
+   places them. `PhysicsScene` is renamed `RigidBodyBinding` in the same refactor.
+3. **`PhysicsStepSystem` orchestrates explicit global passes** with a barrier
+   between body reconciliation and constraint reconciliation across all
+   participating registries.
+4. **Cross-registry target resolution is a span-scoped lookup over the physics
+   view**, built per step. No general registry directory class is introduced;
+   `EntityRef` has exactly one consumer today, so the general primitive is not yet
+   earned.
+5. **A driven constraint requires a target refresh every fixed step.** A constraint
+   whose owner did not refresh it expires terminally inside the step. This one rule
+   gives dormant-owner semantics without any registry bookkeeping in the backend.
+6. **An endpoint registry leaving the physics view is terminal**, same as unload.
+   Suspension, residency pinning, and cross-registry entity migration are deferred
+   world-partition features, not hidden constraint behavior.
+7. **Terminal events are published into one engine-owned buffer** on
+   `PhysicsStepSystem`, which outlives every registry, so unload-path events cannot
+   die with the registry that produced them.
+8. **`PhysicsConstraintId` is generational.** Constraint handles live in ECS link
+   components and survive churn; slot reuse without a generation is an ABA defect
+   waiting to happen. `RemoveConstraint` on a dead handle is a safe no-op.
+9. **Three update categories, three mechanisms**: topology through structural-version
+   gating, configuration edits through `Changed<DrivenPoseConstraint>`, per-tick
+   target state unconditionally.
+
+Rejected shapes, argued where cited:
+
+- Constraint entities with an arbitrary owning registry (Section 4).
+- A `PhysicsConstraintScene` that reads every registry and owns a global lookup
+  (Sections 4, 8).
+- A general `RegistryDirectoryView` world primitive (Section 8.3).
+- A universal joint hierarchy or bilateral joint graph (Section 19).
+
+---
+
+## 1. Goal
+
+Add a reusable physics mechanism that drives one physics body toward a pose defined
+relative to another entity while preserving collision response.
+
+The invariant: a follower body attempts to maintain a configured position and
+orientation relative to a moving target frame. The solver resolves the follower
+against the world, and the constraint reports when the relationship can no longer be
+maintained within configured limits.
+
+This supports suspended actors, physics-object pickups, grabs, moving machinery
+attachments, magnetic and tractor mechanics, breakable carries, and rigid or
+compliant pose following. No gameplay vocabulary, ability behavior, input handling,
+camera behavior, or player-character assumption enters the engine API.
+
+---
+
+## 2. Current foundation (verified)
+
+- `PhysicsStepSystem` owns the one shared `PhysicsWorld` and `CollisionShapeCache`
+  by value and outlives every zone registry
+  (`engine/include/physics/PhysicsStepSystem.h`). Its `Physics(PhysicsContext&)`
+  already iterates the physics participation span: `EngineFramePhases.cpp` sets
+  `PhysicsContext.ActiveRegistries = ctx.Registries.Physics`. No change of span
+  source is needed.
+- `PhysicsScene` is the per-registry ECS-to-body bridge: dense owned records,
+  structural-version-gated reconciliation, `PhysicsBodyLink` for hash-free
+  steady-state sync, destructor removes the zone's bodies from the shared world
+  (`engine/include/physics/PhysicsScene.h`). `CharacterMoverPool` follows the same
+  pattern for character movers (`engine/include/physics/CharacterMoverPool.h`).
+- Both bindings are stored in the ECS `World`'s internal resource storage, while
+  `Registry` carries a dedicated `ResourceRegistry Resources` member whose comment
+  names "physics worlds" among its intended tenants
+  (`engine/include/world/ResourceRegistry.h`, `engine/include/world/registry/Registry.h`).
+  `ActiveCameraService` already lives in `Registry::Resources` across engine,
+  editor, and examples. Two per-registry resource stores exist and physics is in
+  the one the documentation does not assign it to. Section 3 corrects this.
+- `EntityRef` (`RegistryId` + generational `EntityId`) exists at
+  `engine/include/world/registry/EntityRef.h` and currently has no consumer.
+  `RegistryId` allocation is monotonic with generation fixed at 1
+  (`ZoneRuntime::AllocateRegistryId`); indices are not recycled today.
+- `FrameRegistryView` carries the global registry plus per-domain spans; the global
+  registry participates in every span and is ordered first
+  (`ZoneRuntime::BuildFrameView`). Zone lifecycle changes only at drain points
+  outside a live frame view (asserted in `ZoneRuntime`), so the physics step never
+  observes a registry appearing or vanishing mid-step.
+- Dormancy is routine, not exotic: `WorldPartitionRuntime` demotes the previous
+  focus zone to dormant during normal streaming. A dormant registry is attached and
+  alive but absent from every frame span.
+- Transform propagation runs after the physics step inside the Simulate phase
+  (`EngineFramePhases.cpp`), so during physics a parented entity's `WorldTransform`
+  is the previous tick's. `CharacterControllerSystem` is scheduled after
+  `PhysicsStepSystem`, so a character-driven pose read during physics is also one
+  tick old.
+- Resource destruction order is unspecified in both `World`'s resource bag and
+  `ResourceRegistry` (both are hash maps of type-erased owners). Nothing may depend
+  on sibling-resource destructor order within a registry.
+- `RigidBody` is documented linear-only. It already carries a `GravityScale` field
+  that no code pushes to the backend. `PhysicsBodyId` is a non-generational
+  backend-width handle; that is safe for bodies because body records and links are
+  reconciled as a unit within one registry.
+
+---
+
+## 3. Refactor R1: honest binding ownership
+
+Move the per-registry physics bindings to `Registry::Resources` and name them for
+what they mechanically do:
+
+```text
+PhysicsStepSystem            owns PhysicsWorld, CollisionShapeCache,
+                             step orchestration, terminal event buffer
+
+Registry::Resources          RigidBodyBinding      (renamed from PhysicsScene)
+                             CharacterMoverPool
+                             DrivenPoseBinding     (new, Section 8)
+
+Registry::Components (World) authored components, runtime link components
+```
+
+Mechanics:
+
+- `RigidBodyBinding` keeps `PhysicsScene`'s exact contract: bind `Collider`,
+  `RigidBody`, and transforms from one registry to bodies in the shared world.
+  Rename only; no behavior change. Header moves to
+  `engine/include/physics/RigidBodyBinding.h`.
+- `PhysicsStepSystem` ensures bindings through `reg->Resources.Ensure<...>(...)`
+  instead of the `World` resource bag. The unload guarantee is unchanged: the
+  binding dies with the registry and its destructor removes the registry's backend
+  objects; the shared world outlives all registries exactly as before.
+- Direct tests keep constructing a bare `World` and may hold the binding as a plain
+  local object; storage location is orthogonal to the binding's API, which takes
+  `World&` explicitly.
+- Because sibling-resource destruction order is unspecified, every backend removal
+  path must be order-independent: removing a body whose dependent constraints were
+  already removed, and removing a constraint whose body already vanished, are both
+  safe no-ops (Sections 7, 10).
+
+This is the smallest correction that stops the tree carrying two competing
+per-registry resource stores with physics in the undocumented one. It lands as its
+own commit before any constraint work.
+
+---
+
+## 4. Constraint ownership: a component on the follower
+
+```cpp
+struct DrivenPoseConstraint
+{
+    EntityRef Target;
+
+    Transform3f FollowerLocalFrame;
+    Transform3f TargetLocalFrame;
+
+    PoseDriveSettings LinearDrive;
+    PoseDriveSettings AngularDrive;
+    ConstraintBreakSettings Break;
+};
+```
+
+The component lives on the follower entity — the body receiving the drive. The
+follower's registry owns the backend constraint. There is no constraint entity.
+
+Why this wins over constraint entities:
+
+- One unambiguous owner. The rejected shape assigned backend ownership to
+  "whichever registry holds the constraint entity," which forced placement guidance,
+  a third-registry lifecycle, and an owner that could unload independently of both
+  endpoints.
+- The follower and its body binding share a registry, so constraint discovery and
+  follower-body binding are own-registry concerns where structural-version gating
+  genuinely works. Cross-registry coupling shrinks to const reads of the target.
+- The target never needs a backend body. The driven frame consumes the target's
+  transform and, when present, its `RigidBody` component velocities — component
+  reads, never backend handles. The all-registries body barrier still exists
+  (Section 9) but almost nothing crosses it.
+- Lifecycle collapses: follower destroyed or its registry unloaded ends the
+  constraint with the definition; target loss is detected by the running owner.
+
+Accepted limitation, recorded deliberately: **one pose driver per follower.** One
+component per type per entity is an ECS invariant, so competing drives (two tractor
+sources fighting over one prop) cannot be expressed. Two complete pose drives on one
+body are overconstrained in the locked case and only meaningful as a blended spring
+tug-of-war, which no current requirement needs. If a real requirement for competing
+drives appears, that is the point where a relationship-entity mechanism gets earned —
+and the `PhysicsWorld` API below is component-model-agnostic, so that migration
+would not touch the backend.
+
+The desired follower frame each step:
+
+```text
+desiredFrame = targetWorldTransform * TargetLocalFrame
+```
+
+driving the follower's `FollowerLocalFrame` toward it. Two local frames support
+center attachment, held offsets, sockets, and off-center machinery. A pure helper
+constructs both frames from current world poses; it does transform math only and
+owns nothing.
+
+---
+
+## 5. Runtime components
+
+```cpp
+struct DrivenPoseLink
+{
+    PhysicsConstraintId Constraint;
+};
+
+enum class DrivenPoseState : uint8_t
+{
+    Pending,
+    Active,
+    Broken,
+    Invalid,
+};
+
+struct DrivenPoseTelemetry
+{
+    DrivenPoseState State = DrivenPoseState::Pending;
+
+    float PositionError = 0.0f;
+    float AngularError = 0.0f;
+    float AppliedForce = 0.0f;
+    float AppliedTorque = 0.0f;
+    float FailureDuration = 0.0f;
+};
+```
+
+`DrivenPoseLink` mirrors `PhysicsBodyLink` and `CharacterMoverLink`: the runtime
+handle that makes steady-state work a contiguous column walk with no hashing.
+
+`DrivenPoseTelemetry` is a published copy, written after each step the same way
+`RigidBody.LinearVelocity` is pulled from the backend. The binding's dense records
+(Section 8) are canonical for all constraint state; the component never feeds back
+into the binding. Games read it with const access.
+
+No backend or Jolt type enters ECS storage. All three components (plus
+`DrivenPoseConstraint`) register in `RegisterPhysicsComponents`
+(`engine/src/physics/PhysicsRegistration.cpp`) before any entity creation, per ECS
+rules.
+
+---
+
+## 6. Drive and break settings
+
+```cpp
+enum class PoseDriveResponse : uint8_t
+{
+    Locked,
+    Spring,
+};
+
+struct PoseDriveSettings
+{
+    PoseDriveResponse Response = PoseDriveResponse::Locked;
+
+    float FrequencyHz = 0.0f;
+    float DampingRatio = 1.0f;
+    float MaxForce = std::numeric_limits<float>::infinity(); // MaxTorque angular
+};
+```
+
+`Locked` requests rigid relative-pose preservation. `Spring` uses frequency and
+damping and may lag under collision or acceleration. These are the two response
+profiles real use cases need today: strict attachments lock both, held props soften
+both, mixed configurations lock translation and soften orientation. No vague
+interpolation speed; response is solver-oriented frequency, damping, and force and
+torque limits.
+
+```cpp
+struct ConstraintBreakSettings
+{
+    float MaxPositionError = std::numeric_limits<float>::infinity();
+    float MaxAngularError = std::numeric_limits<float>::infinity();
+    float MaxForce = std::numeric_limits<float>::infinity();
+    float MaxTorque = std::numeric_limits<float>::infinity();
+    float RequiredDuration = 0.0f;
+
+    float MaxTargetTranslationPerStep = std::numeric_limits<float>::infinity();
+    float MaxTargetRotationPerStep = std::numeric_limits<float>::infinity();
+};
+```
+
+`RequiredDuration` permits forgiving pickup behavior without game policy in the
+engine; strict attachments use zero. Error thresholds carry internal reset
+hysteresis so a value hovering at the threshold does not accumulate and clear
+failure time on alternating ticks. Break evaluation lives in the binding, not the
+backend, so the backend contract stays small.
+
+---
+
+## 7. PhysicsWorld constraint API
+
+Backend-neutral vocabulary, no Jolt type crossing the firewall:
+
+```cpp
+struct PhysicsConstraintId
+{
+    uint32_t Index;
+    uint32_t Generation; // generational: link components survive churn safely
+};
+
+struct DrivenPoseConstraintDesc
+{
+    PhysicsBodyId Follower;
+    Transform3f FollowerLocalFrame;
+    Transform3f TargetLocalFrame;
+
+    PoseDriveSettings LinearDrive;
+    PoseDriveSettings AngularDrive;
+
+    uint64_t OwnerTag = 0;  // opaque; the binding packs its RegistryId
+    uint64_t UserData = 0;  // opaque; the binding packs the follower EntityId
+};
+
+struct DrivenPoseTarget
+{
+    Vec3d Position;
+    Quatf Rotation;
+    Vec3d LinearVelocity;
+    Vec3d AngularVelocity;
+    bool Teleported = false;
+};
+
+struct PhysicsConstraintTelemetry
+{
+    float PositionError;
+    float AngularError;
+    float AppliedForce;
+    float AppliedTorque;
+};
+
+struct ExpiredConstraint
+{
+    PhysicsConstraintId Id;
+    uint64_t OwnerTag;
+    uint64_t UserData;
+};
+
+PhysicsConstraintId AddDrivenPoseConstraint(const DrivenPoseConstraintDesc& desc);
+void RemoveConstraint(PhysicsConstraintId id);          // dead handle: safe no-op
+bool IsConstraintValid(PhysicsConstraintId id) const;
+
+void SetDrivenPoseTarget(PhysicsConstraintId id, const DrivenPoseTarget& target);
+PhysicsConstraintTelemetry GetConstraintTelemetry(PhysicsConstraintId id) const;
+
+std::span<const ExpiredConstraint> TakeExpiredConstraints(); // drained post-step
+```
+
+Contract:
+
+- The target is a driven frame, not necessarily a body: dynamic, kinematic,
+  animated, scripted, or any entity with a valid world transform. The backend owns
+  whatever hidden representation realizes the frame (kinematic anchor, mass
+  scaling, or another Jolt-side mechanism); the choice never leaks.
+- One-way: the follower receives constraint forces, the target receives no solver
+  feedback, and the follower continues colliding normally.
+- **Refresh-or-expire.** `SetDrivenPoseTarget` must be called between steps for
+  every live constraint. `Step` terminally expires any constraint not refreshed
+  since the previous step, disables it for that step, and queues it in the expired
+  list with its opaque tags. Expiry sweeps in creation order, so the list is
+  deterministic. This is the whole dormancy mechanism: a registry that leaves the
+  physics view stops refreshing, and its constraints expire inside the shared
+  world without the backend knowing what a registry is. `OwnerTag` and `UserData`
+  exist so the orchestrator can publish a meaningful event afterward, mirroring
+  the `BodyDesc::UserData` entity-packing precedent.
+- `RemoveBody` first invalidates every constraint referencing the body (an internal
+  body-to-constraint reverse mapping or equivalent backend mechanism), then removes
+  the body. Invalidated handles answer `IsConstraintValid` false; removing them is
+  a no-op. This holds on every path, including registry teardown, where
+  sibling-resource destructor order is unspecified.
+- Telemetry is readable after a step until the constraint is removed.
+
+---
+
+## 8. DrivenPoseBinding
+
+A per-registry resource in `Registry::Resources`, the driven-pose analogue of
+`RigidBodyBinding`. It touches its own registry's components and the shared
+`PhysicsWorld`; the only foreign access is const reads of resolved targets.
+
+```cpp
+class DrivenPoseBinding
+{
+public:
+    void Reconcile(World& world, PhysicsWorld& physics);
+
+    void PrepareStep(World& world,
+                     std::span<Registry* const> physicsSpan,
+                     PhysicsWorld& physics,
+                     float dt);
+
+    void CollectResults(World& world,
+                        PhysicsWorld& physics,
+                        DrivenPoseEventSink& events,
+                        float dt);
+};
+```
+
+### 8.1 Records and update categories
+
+The binding keeps a dense owned-record array — the canonical constraint state —
+holding follower `EntityId`, constraint handle, resolved target, previous target
+transform (for velocity derivation and teleport classification), failure
+accumulation, and state. As with body records, the dense array is what makes
+destroy-detection possible: `DestroyEntity` fires no hook and the components vanish
+with the entity.
+
+Three update categories, three mechanisms:
+
+- **Topology** (component or entity created or destroyed in this registry):
+  structural-version gated, exactly like body reconciliation. A steady frame is one
+  integer compare. This gate is sound here precisely because the definition lives
+  on the follower in this registry; the rejected cross-registry design broke it,
+  since a foreign registry's structural changes never bump the owner's version.
+- **Configuration** (an existing `DrivenPoseConstraint` edited: retuned spring,
+  changed frames, changed thresholds): detected with
+  `Changed<DrivenPoseConstraint>` and pushed to the backend. Chunk-conservative is
+  acceptable — re-pushing a chunk's settings occasionally is cheap. All read paths
+  use const access so reads never mark the column.
+- **Per-tick target state**: resolved and refreshed unconditionally for every
+  active constraint. This is not reconciliation; the steady-state test in
+  Section 16 is worded against topology passes only.
+
+Structural changes the binding itself needs (adding `DrivenPoseLink` and
+`DrivenPoseTelemetry`, stripping them on termination) go through its reused
+`CommandBuffer`, flushed at the pass boundary.
+
+### 8.2 Per-step responsibilities
+
+- Reconcile: create backend constraints for followers whose body link exists
+  (the registry's body pass has already run — Section 9), remove backend
+  constraints whose definition vanished, sweep records for dead followers.
+- PrepareStep: resolve each record's `Target` ref against the physics span, read
+  target pose and velocities, classify teleports, call `SetDrivenPoseTarget`.
+  Resolution failure or target death is recorded for terminal handling in
+  CollectResults; the constraint is not refreshed, so the backend also disables it
+  for the step.
+- CollectResults: pull telemetry, evaluate break thresholds with hysteresis and
+  `RequiredDuration`, publish terminal events, remove broken backend constraints,
+  strip runtime components, update `DrivenPoseTelemetry` copies.
+- Destructor: remove all owned backend constraints and publish `OwnerUnloaded`
+  events through the sink pointer, which outlives every registry (Section 11).
+
+### 8.3 Target resolution
+
+Resolution is a linear scan of the physics span comparing `Registry::Id`, wrapped
+in a small free function. The span holds the global registry plus a handful of
+zones; a scan beats building any map at this size, and it is span-scoped on
+purpose: a registry outside the physics view is unresolvable, which is exactly the
+Section 10 semantics. No `RegistryDirectoryView` class is introduced — `EntityRef`
+has one consumer, and the repository rule is that abstractions are earned by real
+variation, not anticipated. If a second cross-registry consumer appears, promote
+the lookup to `FrameRegistryView` then.
+
+Foreign-registry reads are const-only. Non-const access counts as a write and would
+poison change detection in a registry this binding does not own; const access also
+keeps the binding compatible with any future decision about parallelizing
+per-registry work, from which the constraint passes are permanently excluded — they
+are serial orchestration by construction (Section 9).
+
+---
+
+## 9. Fixed-step orchestration
+
+`PhysicsStepSystem::Physics` becomes explicit global passes. Each pass completes
+for every participating registry before the next begins:
+
+```text
+1. For each registry: rigid-body reconcile + kinematic push   (RigidBodyBinding)
+2. For each registry: driven-pose reconcile                   (DrivenPoseBinding)
+3. For each registry: resolve targets, refresh driven frames  (DrivenPoseBinding)
+4. Step the shared PhysicsWorld once
+5. Drain expired constraints; publish their terminal events   (PhysicsStepSystem)
+6. For each registry: collect telemetry, evaluate breaks,
+   publish terminal events, flush deferred ECS changes        (DrivenPoseBinding)
+7. For each registry: pull dynamic body transforms/velocities (RigidBodyBinding)
+```
+
+The barrier between pass 1 and pass 2 guarantees every registry's bodies exist
+before any registry binds constraints. With follower-owned constraints the
+same-registry case would survive interleaving, but the barrier costs nothing, keeps
+the rule simple, and stays correct if a future mechanism does reference foreign
+bodies. Passes run serially on the simulation thread in span order (global first,
+zones in attach order), so event and reconcile ordering is deterministic.
+
+Body transforms are still pulled on the step a constraint breaks (pass 7 follows
+pass 6). Telemetry is collected before any backend constraint is destroyed.
+
+---
+
+## 10. Lifecycle and termination
+
+States: `Pending -> Active -> Broken | Invalid`. A terminal constraint never
+recreates itself; rearming requires the game to replace the component.
+
+- **Pending**: definition exists, follower body link not yet bound. Because the
+  registry's body pass precedes its constraint pass, the common case binds in the
+  same step the collider appears. Pending persists until the body exists; it is
+  re-checked per step at O(pending) and surfaced by diagnostics (Section 14), never
+  silently timed out.
+- **Invalid** (immediate, statically checkable): target ref equals the follower,
+  invalid `EntityRef`, follower has no dynamic `RigidBody` component, nonfinite
+  frames, invalid drive values. Fails loudly in debug, safely in release.
+- **Broken**: sustained position or angular error, force or torque limit, target
+  teleport beyond per-step bounds — all evaluated by the binding with hysteresis
+  and `RequiredDuration`.
+
+Terminal reasons:
+
+```cpp
+enum class DrivenPoseEndReason : uint8_t
+{
+    Removed,            // component removed by game code
+    FollowerDestroyed,  // follower entity destroyed while active
+    PositionError,
+    AngularError,
+    ForceLimit,
+    TorqueLimit,
+    TargetTeleported,
+    TargetDestroyed,    // target entity dead in a resolvable registry
+    TargetUnavailable,  // target registry unloaded or absent from the physics view
+    OwnerUnloaded,      // follower's registry destroyed (published by teardown)
+    OwnerInactive,      // follower's registry left the physics view (expiry path)
+    InvalidConfiguration,
+};
+```
+
+Registry participation semantics, stated once:
+
+- **Target registry absent from the physics view** — loaded-but-dormant and
+  unloaded are indistinguishable through the span lookup, and deliberately so —
+  is terminal `TargetUnavailable`, evaluated by the running owner binding.
+- **Owner registry absent from the physics view**: the binding does not run, its
+  constraints are not refreshed, and the backend expires them terminally inside
+  the step (Section 7). `PhysicsStepSystem` drains the expired list and publishes
+  `OwnerInactive`, reconstructing the follower ref from the packed tags; the
+  target ref in these events is invalid, which consumers must tolerate. If the
+  registry later returns, its binding finds dead handles, cleans records and
+  components, and publishes nothing further.
+- **Owner registry unloaded**: the binding destructor removes backend constraints
+  and publishes `OwnerUnloaded` with full refs through the engine-owned sink.
+
+The practical consequence must be documented loudly for game integrators: world
+partition demotes the previous focus zone to dormant as routine streaming behavior,
+so carrying a follower or targeting an entity whose zone demotes breaks the
+constraint by design. The engine-side remedies — residency pins that keep an
+endpoint's zone participating, or migrating a carried entity into the global
+registry — are world-partition features to be built there when a game needs them,
+not hidden constraint behavior.
+
+---
+
+## 11. Terminal events
+
+```cpp
+struct DrivenPoseEnded
+{
+    EntityRef Follower;
+    EntityRef Target;            // invalid in OwnerInactive events
+    PhysicsConstraintId Constraint;
+    DrivenPoseEndReason Reason;
+
+    float PositionError;
+    float AngularError;
+    float AppliedForce;
+    float AppliedTorque;
+};
+```
+
+`PhysicsStepSystem` owns an `EventBuffer<DrivenPoseEnded>` (the existing primitive
+at `engine/include/core/event/EventBuffer.h`; domain services own their buffers by
+design). Bindings hold a non-owning sink pointer with the same lifetime argument
+`RigidBodyBinding` already uses for its raw `PhysicsWorld*`: `EngineSchedule`
+outlives `ZoneRuntime`, so registry teardown can still publish.
+
+Buffer discipline: cleared at the start of each physics step. Consumers in the same
+fixed tick's `PostFixed` phase see that tick's events. Frame-lane (`Update`)
+consumers must not assume one tick per frame — a frame runs zero or several fixed
+ticks, and only the last tick's events survive to `Update`. Systems that must not
+miss events consume them in `PostFixed`.
+
+The engine reports the physical result only. It does not drop objects, end
+abilities, restore input, play cues, destroy game entities, or apply cooldowns;
+games consume the event and decide what it means.
+
+---
+
+## 12. Target pose and velocity
+
+Pose source: `WorldTransform` when present, `LocalTransform` otherwise — the same
+preference `RigidBodyBinding` uses at body creation. Two staleness facts are part
+of the v1 contract and are documented, not fixed:
+
+- Transform propagation runs after physics, so a parented target's `WorldTransform`
+  is one tick old during the step. Sockets on moving parents therefore lag one
+  fixed step. If this matters for a use case, the future option is on-demand
+  propagation of the target's parent chain at resolve time, bounded per constraint;
+  v1 recommends top-level or physics-driven targets.
+- `CharacterControllerSystem` runs after `PhysicsStepSystem`, so a character-driven
+  target's consumed pose is one tick old. Spring response masks it; locked response
+  will visibly trail by one step.
+
+Velocity: if the target carries a `RigidBody` component, use its linear and angular
+velocity values (component reads — the target's backend body, if any, is never
+touched). Otherwise derive from fixed-step transform deltas; angular velocity from
+the quaternion delta. The binding's record keeps the previous target transform.
+Discontinuities beyond the per-step translation and rotation bounds classify as
+teleports before velocity derivation, so a teleport never manufactures an enormous
+synthetic velocity — it either breaks the constraint (per break settings) or is
+passed with `Teleported = true` so the backend can snap rather than chase.
+
+---
+
+## 13. Rigid-body completion (prerequisite capability)
+
+Robust pose constraints need full body state. Complete the public component:
+
+```cpp
+struct RigidBody
+{
+    BodyMotion Motion = BodyMotion::Dynamic;
+
+    float Mass = 1.0f;
+    float GravityScale = 1.0f;
+
+    Vec3d LinearVelocity = Vec3d::Zero();
+    Vec3d AngularVelocity = Vec3d::Zero();
+
+    float LinearDamping = 0.0f;
+    float AngularDamping = 0.0f;
+};
+```
+
+`PhysicsWorld` adds `GetAngularVelocity`, `SetAngularVelocity`, `SetGravityScale`,
+and `WakeBody`. `RigidBodyBinding` pushes initial values (including the existing,
+currently-unsynchronized `GravityScale`) and pulls both velocities after
+simulation.
+
+Gravity belongs to the body, not the constraint: a suspended actor uses a
+zero-gravity body, a held prop keeps gravity. The constraint never mutates
+body-wide properties behind the game's back.
+
+---
+
+## 14. Collision and diagnostics
+
+The follower remains an ordinary body colliding with static, kinematic, dynamic,
+and layered geometry. The driven-frame representation carries no collision shape.
+Follower-versus-target-source collision is ordinary collision filtering, never
+hardcoded constraint behavior. Solver contacts and telemetry are the authority on
+whether the relationship held; queries and sweeps are diagnostic aids only.
+
+Debug drawing: target and follower frame axes, desired frame, position error
+vector, angular error arc, force and torque magnitudes, per-state coloring, break
+thresholds. Console:
+
+```text
+physics.constraints.debug
+physics.constraints.log_breaks
+physics.constraints.count
+physics.constraints.warn_pending_steps   (diagnostic warning threshold, 0 = off)
+```
+
+Counters: active, pending, created and removed this step, breaks by reason,
+expirations, reconcile passes, target resolution failures. No debug feature needs a
+Jolt type outside the physics implementation.
+
+---
+
+## 15. Phases
+
+**R1 — binding ownership refactor.**
+Move `PhysicsScene` and `CharacterMoverPool` into `Registry::Resources`; rename
+`PhysicsScene` to `RigidBodyBinding`; update `PhysicsStepSystem`,
+`CharacterControllerSystem`, registration, tests, and stale doc references.
+Behavior-preserving. Exit: full suite green with bindings living in
+`Registry::Resources`; a regression test asserts the binding is reachable there
+and absent from the `World` bag.
+
+**P1 — body capability completion.**
+Angular velocity, gravity-scale sync, linear and angular damping, wake support;
+`RigidBodyBinding` pushes and pulls full state; direct `PhysicsWorld` and binding
+tests. Exit: dynamic bodies preserve and report full linear and angular state
+through ECS synchronization.
+
+**P2 — backend constraint foundation.**
+Generational `PhysicsConstraintId`; driven-pose descriptors; create, refresh,
+telemetry, validity, removal; one-way locked driving; refresh-or-expire with the
+deterministic expired list; `RemoveBody` constraint invalidation; idempotent
+removal. Direct `PhysicsWorld` tests, no ECS. Exit: a dynamic body follows a
+translating and rotating driven frame while colliding, the source receives no
+feedback, and an unrefreshed constraint expires deterministically.
+
+**P3 — compliance and limits.**
+Spring response, frequency and damping, force and torque limits, telemetry values,
+tunable validation, deterministic fixed-step tests. Exit: the same mechanism
+expresses rigid following and forgiving pickup-style following.
+
+**P4 — ECS binding and orchestration.**
+Components and registration; `DrivenPoseBinding`; global pass restructure in
+`PhysicsStepSystem`; span-scoped target resolution; engine-owned event buffer and
+sink wiring; owner teardown publishing; expired-list draining. Exit: constraints
+bind and unbind across registries without leaking backend objects or scanning
+topology on steady frames.
+
+**P5 — breaking and events.**
+Threshold accumulation, hysteresis, teleport classification, `RequiredDuration`,
+full reason coverage including `OwnerInactive` and `TargetUnavailable`, no
+auto-recreation. Exit: obstruction, solver overload, and participation loss all
+produce deterministic, inspectable terminal events.
+
+**P6 — diagnostics and example.**
+Debug drawing, cvars, counters, and an engine physics example scene: translating
+and rotating targets, box and capsule followers, walls and ceiling, locked and
+spring configurations, threshold controls, live telemetry. Exit: the mechanism can
+be tuned and inspected without game code.
+
+**P7 — authoring (deferred until the runtime contract stabilizes).**
+`TypeSchema`, scene-serialization decision, editor frame gizmos, undoable
+commands, unloaded-endpoint authoring behavior. No persisted format commitment
+during the experimental backend phase.
+
+---
+
+## 16. Required tests
+
+PhysicsWorld (direct, headless, no Jolt headers, fixed stepping):
+
+- locked position and orientation follow translation and rotation
+- off-center follower traces the correct rotational path
+- zero-gravity follower stays suspended; follower collides with static geometry
+- one-way target unaffected by follower collision
+- spring follower lags and recovers; force and torque limits enforced
+- removal invalidates handles; removing a dead handle is a no-op
+- `RemoveBody` invalidates dependent constraints, in both destruction orders
+- unrefreshed constraint expires exactly once, in creation order
+- generational id: a recycled slot does not answer to a stale handle
+- identical fixed-step runs produce identical results
+
+ECS integration:
+
+- constraint binds in the same step its follower body binds; stays pending before
+- component removal, follower destruction, target destruction, and target-registry
+  unload each end the constraint with the correct reason
+- owner-registry unload removes backend constraints and publishes `OwnerUnloaded`
+- owner-registry dormancy expires constraints and publishes `OwnerInactive`;
+  the returning registry cleans up without publishing a second event
+- target-registry dormancy ends with `TargetUnavailable`
+- a global-registry follower drives against a zone-registry target
+- editing an existing component's settings reaches the backend (`Changed` path)
+- steady-state ticks perform no topology reconciliation (per-tick target refresh
+  is expected and excluded from the assertion)
+- broken constraints do not recreate
+
+Stress and fitness:
+
+- cost scales with active constraints; thousands of inactive entities are free
+- no steady-state heap allocation; repeated create-destroy cycles leak nothing
+- constraint counts return to zero after registry destruction
+- invalid data fails loudly in debug and safely in release
+
+The R1 refactor keeps every existing `PhysicsScene` and `CharacterMoverPool` test
+passing under the new names and storage.
+
+---
+
+## 17. Performance expectations
+
+Steady-state complexity: `O(active constraints + active bodies)`. No entity scans,
+no per-constraint registry scans, no repeated registration lookups, no backend
+creation during steady following, no schema interpretation or string lookup in the
+step. Topology work is structural-version gated; target refresh and telemetry are
+contiguous walks over dense records; span resolution is a bounded scan over a
+handful of registries. Any bounded behavior (expiry, pending diagnostics) logs what
+it dropped rather than truncating silently.
+
+---
+
+## 18. Acceptance criteria
+
+1. A dynamic body preserves a complete relative pose to a translating and rotating
+   target that can be any entity with a valid world transform.
+2. The follower collides normally; the target receives no solver feedback.
+3. Locked and spring responses use one mechanism; break conditions report error,
+   force, torque, and terminal reason.
+4. Endpoints work across active registries through `EntityRef`; every unload,
+   dormancy, and destruction path ends deterministically with the documented
+   reason and no dangling backend object.
+5. Physics bindings live in `Registry::Resources`; no game, genre, or project term
+   appears in the engine API; no Jolt type crosses the firewall.
+6. No steady-state structural scan or allocation.
+7. A game can implement suspended actors and forgiving pickups without modifying
+   the physics backend.
+
+---
+
+## 19. Deferred
+
+Bilateral joints, distance and rope limits, hinges, cone and twist limits,
+ragdolls, breakable structural assemblies, networked prediction, persistent saved
+constraints, editor-authored mechanical assemblies, residency pins, cross-registry
+entity migration, on-demand target-chain propagation, camera spring arms. Each may
+reuse the handle, lifecycle, tagging, and event substrate; none expands this
+mechanism now. Competing multi-driver poses are the recorded trigger for a future
+relationship-entity mechanism (Section 4).

--- a/docs/plans/physics-driven-pose-constraints.md
+++ b/docs/plans/physics-driven-pose-constraints.md
@@ -1,180 +1,394 @@
-# Driven Pose Constraints and Physics Binding Ownership
+# Driven Pose Constraints and Backend Residency
 
-Status: approved plan (2026-07-20). Supersedes the earlier driven-pose-constraint
-draft that modeled constraints as free-standing entities and introduced a
-`PhysicsConstraintScene`; the sections below record why that shape was rejected.
+Status: approved plan (2026-07-20), third revision. The first revision modeled
+constraints as free-standing entities; the second corrected ownership but patched
+around three substrate gaps with local mechanisms. This revision closes the gaps at
+the layer that owns each one, because the same gaps were generating defects and
+design conundrums independently of this feature. Scope is deliberately larger than
+the feature: the goal is boundaries that are still correct a year from now.
 
-Audience: whoever implements any phase here (human or agent), and reviewers. Every
-claim about the current tree in Section 2 was verified against source at the time of
-writing; re-verify against the tree before relying on one, per the repository rule
-that plans are not proof.
+Audience: whoever implements any track here (human or agent), and reviewers. Every
+claim about the current tree in Section 2 was verified against source at the time
+of writing; re-verify before relying on one, per the repository rule that plans are
+not proof.
 
-Scope: physics backend, per-registry physics bindings, fixed-step orchestration,
-diagnostics, and tests. One prerequisite ownership refactor is included. Game
-integration (abilities, input, cameras, pickup rules) is out of scope; games consume
-the mechanism through components and events.
+Scope: ECS lifecycle contract, registry lifecycle observability, event-channel
+primitive, physics binding ownership, the shared-simulation residency contract, the
+driven-pose constraint mechanism, diagnostics, and tests. Game integration
+(abilities, input, cameras, pickup rules) stays out of scope; games consume the
+mechanism through components and events.
 
 ---
 
 ## 0. Decisions up front
 
-1. **The solver is global, bindings are registry-local, and a driven constraint
-   belongs to the follower.** The constraint definition is a component on the driven
-   body's entity, not a separate constraint entity. The follower's registry owns the
-   backend constraint.
-2. **Per-registry physics bindings move out of the ECS `World` resource bag into
-   `Registry::Resources`**, where `ResourceRegistry`'s own documentation already
-   places them. `PhysicsScene` is renamed `RigidBodyBinding` in the same refactor.
-3. **`PhysicsStepSystem` orchestrates explicit global passes** with a barrier
-   between body reconciliation and constraint reconciliation across all
-   participating registries.
-4. **Cross-registry target resolution is a span-scoped lookup over the physics
-   view**, built per step. No general registry directory class is introduced;
-   `EntityRef` has exactly one consumer today, so the general primitive is not yet
-   earned.
-5. **A driven constraint requires a target refresh every fixed step.** A constraint
-   whose owner did not refresh it expires terminally inside the step. This one rule
-   gives dormant-owner semantics without any registry bookkeeping in the backend.
-6. **An endpoint registry leaving the physics view is terminal**, same as unload.
-   Suspension, residency pinning, and cross-registry entity migration are deferred
-   world-partition features, not hidden constraint behavior.
-7. **Terminal events are published into one engine-owned buffer** on
-   `PhysicsStepSystem`, which outlives every registry, so unload-path events cannot
-   die with the registry that produced them. Teardown events raised between steps
-   land in a pending staging list that the next step folds into the published
-   buffer before clearing, so the per-step clear cannot destroy them unread.
-8. **Terminal completion consumes the definition.** Ending a constraint for any
-   reason removes `DrivenPoseConstraint` from the follower along with the runtime
-   components. The component is a transient runtime request; rearming is
-   structural — the game adds a new component. Persistent authored constraints
-   arrive in P7 as an authoring component that instantiates transient requests.
-9. **`PhysicsConstraintId` is generational.** Constraint handles live in ECS link
-   components and survive churn; slot reuse without a generation is an ABA defect
-   waiting to happen. `RemoveConstraint` on a dead handle is a safe no-op.
-10. **Three update categories, three mechanisms**: topology through
+Substrate (Track A):
+
+1. **`DestroyEntity` fires `OnRemove` hooks.** The `ComponentTraits` contract is
+   completed: a component leaving the world fires its hook on every path — remove,
+   destroy, command buffer, and world teardown. Today destruction fires nothing,
+   which makes the documented retain/release pattern leak (Section 2.1).
+2. **`World` teardown drains entity hooks before resources die.** Hooks reach
+   their release targets through `World` resources; the current teardown order
+   destroys resources first, so unload-path releases are unreachable.
+3. **Registry lifecycle becomes observable as frame data.** `BuildFrameView`
+   additionally computes transitions — per-domain entered and left spans, plus
+   destroyed registry ids — from drain-point-stable state. No observer callbacks,
+   no bus: transitions are data delivered at one phase point.
+4. **`FrameRegistryView` owns cross-registry resolution.** `Find(RegistryId)`
+   resolves participating registries for simulation code; `FindAttached` resolves
+   any attached registry for engine orchestrators handling lifecycle edges;
+   `IsAlive(EntityRef)` composes resolution with the generational check.
+   `ZoneRuntime::FindRegistry` remains the tools-and-lifecycle lookup.
+5. **`TickEventChannel<T>` is a named primitive.** Two-phase publication over
+   `EventBuffer<T>`: stage from outside the step, fold-and-clear at tick entry,
+   publish during the step. Events that must outlive their publishing registry get
+   one mechanism instead of per-subsystem staging.
+
+Residency (Track B):
+
+6. **Dormant means absent from the shared simulation.** `ZoneParticipation`
+   already promises it ("cannot affect simulation or presentation"); physics
+   currently violates it — a dormant zone's bodies keep simulating and colliding.
+   On leaving the physics span a registry's bindings evict their backend objects
+   (records and links retained); on re-entry they restore from
+   component-authoritative state; destruction still cleans up via destructors.
+7. **Bindings live in `Registry::Resources` and are named for their mechanism.**
+   `PhysicsScene` becomes `RigidBodyBinding`; `CharacterMoverPool` moves beside
+   it; `DrivenPoseBinding` joins them. The binding criterion: retained backend
+   objects derived from this registry's entities, reconciled against entity
+   lifecycle, destroyed with the registry. Nothing else earns a binding.
+8. **A shared residency-conformance harness tests every binding** through the
+   same gauntlet: populate, go dormant, return, destroy — asserting zero backend
+   residue at each edge. The reconcile protocol shared by the three bindings is
+   extracted only after all three exist in code, and only the genuinely shared
+   part; storage semantics stay per-binding.
+
+Feature (Track C):
+
+9. **The solver is global, bindings are registry-local, and a driven constraint
+   belongs to the follower.** The definition is a component on the driven body's
+   entity; the follower's registry owns the backend constraint.
+10. **Terminal completion consumes the definition.** Ending a constraint removes
+    `DrivenPoseConstraint` and its runtime components in one flush. Rearming is
+    structural; chunk-conservative `Changed` marks cannot resurrect anything.
+11. **The binding owns frame and velocity composition.** The backend receives a
+    resolved world-space driven frame with velocities evaluated at the attachment
+    point; it never sees the target's local attachment frame.
+12. **An endpoint registry leaving the physics view is terminal.** With
+    transitions observable, the departing side's binding is visited and publishes
+    full-fidelity events. The backend's refresh-or-expire check demotes from
+    load-bearing mechanism to debug invariant. Residency pins and cross-registry
+    entity migration are future world-partition features, not constraint behavior.
+13. **`PhysicsConstraintId` is generational**, and `RemoveConstraint` on a dead
+    handle is a safe no-op — required by unspecified sibling-resource destruction
+    order, and by eviction and teardown paths crossing.
+14. **Three update categories, three mechanisms**: topology through
     structural-version gating, configuration edits through
     `Changed<DrivenPoseConstraint>`, per-tick target state unconditionally.
-    `Changed` never doubles as a rearm signal — decision 8 makes that impossible,
-    because a terminal constraint no longer has a component to be marked changed.
-11. **The binding owns frame and velocity composition.** The backend receives an
-    already-resolved world-space driven frame with velocities evaluated at the
-    attachment point; it never sees the target's ECS-side local attachment frame.
 
-Rejected shapes, argued where cited:
+Rejected regardless of budget, because they are wrong rather than expensive:
 
-- Constraint entities with an arbitrary owning registry (Section 4).
-- A `PhysicsConstraintScene` that reads every registry and owns a global lookup
-  (Sections 4, 8).
-- A general `RegistryDirectoryView` world primitive (Section 8.3).
-- A universal joint hierarchy or bilateral joint graph (Section 19).
+- Registry lifecycle observer callbacks or an event bus. Ordering becomes
+  implicit, ownership becomes spooky; transitions-as-frame-data delivers the same
+  information at a defined phase point.
+- Per-zone physics worlds. Cross-zone collision is a requirement; piecewise
+  ownership of one shared solver is the correct price.
+- A binding base-class framework. The three bindings share a protocol, not
+  storage semantics (dense swap-remove vs stable-slot pool). Extract the protocol
+  after the third instance exists; never force the storage.
+- Suspending and resuming constraints across dormancy. A relationship with an
+  absent endpoint is a ghost no system owns. Endpoint departure is terminal; a
+  game that wants the relationship to survive pins the zone.
+- Constraint entities with an arbitrary owning registry, and a
+  `PhysicsConstraintScene` with global authority (rejected in revision two;
+  arguments preserved in Section 5).
 
 ---
 
 ## 1. Goal
 
-Add a reusable physics mechanism that drives one physics body toward a pose defined
-relative to another entity while preserving collision response.
+Add a reusable physics mechanism that drives one physics body toward a pose
+defined relative to another entity while preserving collision response.
 
 The invariant: a follower body attempts to maintain a configured position and
 orientation relative to a moving target frame. The solver resolves the follower
-against the world, and the constraint reports when the relationship can no longer be
-maintained within configured limits.
+against the world, and the constraint reports when the relationship can no longer
+be maintained within configured limits.
 
 This supports suspended actors, physics-object pickups, grabs, moving machinery
 attachments, magnetic and tractor mechanics, breakable carries, and rigid or
-compliant pose following. No gameplay vocabulary, ability behavior, input handling,
-camera behavior, or player-character assumption enters the engine API.
+compliant pose following — all as component data on one mechanism.
+
+The larger goal of this revision: the feature must not be the last one to fight
+the substrate. Every gap it exposed is closed where it lives, so the next
+shared-backend mechanism (vehicles, bilateral joints, contact event streams)
+arrives on rails instead of re-litigating ownership.
 
 ---
 
 ## 2. Current foundation (verified)
 
-- `PhysicsStepSystem` owns the one shared `PhysicsWorld` and `CollisionShapeCache`
-  by value and outlives every zone registry
-  (`engine/include/physics/PhysicsStepSystem.h`). Its `Physics(PhysicsContext&)`
-  already iterates the physics participation span: `EngineFramePhases.cpp` sets
-  `PhysicsContext.ActiveRegistries = ctx.Registries.Physics`. No change of span
-  source is needed.
+- `PhysicsStepSystem` owns the one shared `PhysicsWorld` and
+  `CollisionShapeCache` by value and outlives every zone registry. Its
+  `Physics(PhysicsContext&)` already iterates the physics participation span
+  (`EngineFramePhases.cpp` sets `ActiveRegistries = ctx.Registries.Physics`).
 - `PhysicsScene` is the per-registry ECS-to-body bridge: dense owned records,
-  structural-version-gated reconciliation, `PhysicsBodyLink` for hash-free
-  steady-state sync, destructor removes the zone's bodies from the shared world
-  (`engine/include/physics/PhysicsScene.h`). `CharacterMoverPool` follows the same
-  pattern for character movers (`engine/include/physics/CharacterMoverPool.h`).
-- Both bindings are stored in the ECS `World`'s internal resource storage, while
-  `Registry` carries a dedicated `ResourceRegistry Resources` member whose comment
-  names "physics worlds" among its intended tenants
-  (`engine/include/world/ResourceRegistry.h`, `engine/include/world/registry/Registry.h`).
-  `ActiveCameraService` already lives in `Registry::Resources` across engine,
-  editor, and examples. Two per-registry resource stores exist and physics is in
-  the one the documentation does not assign it to. Section 3 corrects this.
-- `EntityRef` (`RegistryId` + generational `EntityId`) exists at
-  `engine/include/world/registry/EntityRef.h` and currently has no consumer.
-  `RegistryId` allocation is monotonic with generation fixed at 1
-  (`ZoneRuntime::AllocateRegistryId`); indices are not recycled today.
-- `FrameRegistryView` carries the global registry plus per-domain spans; the global
-  registry participates in every span and is ordered first
-  (`ZoneRuntime::BuildFrameView`). Zone lifecycle changes only at drain points
-  outside a live frame view (asserted in `ZoneRuntime`), so the physics step never
-  observes a registry appearing or vanishing mid-step.
-- Dormancy is routine, not exotic: `WorldPartitionRuntime` demotes the previous
-  focus zone to dormant during normal streaming. A dormant registry is attached and
-  alive but absent from every frame span.
-- Transform propagation runs after the physics step inside the Simulate phase
-  (`EngineFramePhases.cpp`), so during physics a parented entity's `WorldTransform`
-  is the previous tick's. `CharacterControllerSystem` is scheduled after
-  `PhysicsStepSystem`, so a character-driven pose read during physics is also one
-  tick old.
-- Resource destruction order is unspecified in both `World`'s resource bag and
-  `ResourceRegistry` (both are hash maps of type-erased owners). Nothing may depend
-  on sibling-resource destructor order within a registry.
-- `RigidBody` is documented linear-only. It already carries a `GravityScale` field
-  that no code pushes to the backend. `PhysicsBodyId` is a non-generational
-  backend-width handle; that is safe for bodies because body records and links are
-  reconciled as a unit within one registry.
+  structural-version-gated reconciliation, `PhysicsBodyLink` for hash-free sync,
+  destructor removes the registry's bodies. `CharacterMoverPool` repeats the
+  pattern for character movers. Both self-describe as registry-local but live in
+  the ECS `World`'s resource bag, while `Registry` carries a dedicated
+  `ResourceRegistry Resources` member whose comment names "physics worlds" among
+  intended tenants. `ActiveCameraService` already lives there.
+- `EntityRef` exists with zero consumers. `RegistryId` allocation is monotonic
+  (`ZoneRuntime::AllocateRegistryId`), generation currently fixed at 1.
+- `FrameRegistryView` is spans only. The global registry participates in every
+  span, ordered first. Zone lifecycle mutates only at drain points outside a live
+  frame view (asserted), so registry pointers are frame-stable.
+- Dormancy is routine: `WorldPartitionRuntime` demotes the previous focus zone as
+  normal streaming behavior. `ZoneParticipation`'s comment defines dormant as
+  unable to affect simulation or presentation.
+- Transform propagation runs after physics inside Simulate;
+  `CharacterControllerSystem` runs after `PhysicsStepSystem`. Both mean poses
+  read during physics can be one tick stale (Section 13).
+- Resource destruction order is unspecified in both resource stores.
+- `RigidBody` is linear-only with an unsynchronized `GravityScale` field.
+  `PhysicsBodyId` is non-generational, safe for bodies only because records and
+  links reconcile as a unit within one registry.
+
+### 2.1 Live defects this revision fixes
+
+- **Hook contract incomplete.** `World::DestroyEntity` removes the row and fires
+  no `OnRemove` (`World.h`), and the traits documentation's fire table
+  (`docs/ecs/component-traits.md`) lists add/remove paths only — destruction is
+  absent. Yet the documented flagship use is refcounted handles, and
+  `StaticMeshComponent` and `AudioSourceComponent` ship live `OnAdd` retains.
+  Destroying such an entity leaks its retains. Implementation must first write
+  the failing regression (destroy leaks a retain; unload leaks all retains) and
+  confirm no compensating sweep exists elsewhere.
+- **`World` teardown order.** The destructor clears resources before component
+  storage, so even with destruction hooks, unload-path releases could not reach
+  their targets. Teardown must drain hooks first.
+- **Dormant zones keep physical presence.** Bodies of a registry that left the
+  physics span remain active in the shared `PhysicsWorld`: they simulate,
+  collide, and answer queries, violating the documented participation contract.
+  No code path removes or parks them today.
 
 ---
 
-## 3. Refactor R1: honest binding ownership
+## 3. Track A: substrate
 
-Move the per-registry physics bindings to `Registry::Resources` and name them for
-what they mechanically do:
+### A1 — Complete the ECS lifecycle contract
+
+`DestroyEntity` fires `OnRemove` for every non-empty hooked component of the
+entity, before the row is removed, in column order (deterministic), under the
+existing `ScopedLifecycleHook` guard — the no-structural-mutation rule already
+covers reentrancy. The `CommandBuffer` destroy path fires the same hooks at
+flush. Archetypes precompute their hooked-column list at creation, so hook-free
+archetypes pay one branch.
+
+`World` teardown (destructor and move-assignment) drains `OnRemove` for all live
+hooked components before destroying component storage, and destroys resources
+last, so hooks can reach release targets. Zone unload thereby releases every
+retained handle.
+
+The batching rule in `docs/ecs/decisions.md` D1.5 extends naturally: bulk
+destroys of hooked archetypes run per-entity in record order; hook-free
+archetypes keep the bulk path.
+
+Division of labor, stated once and written into the traits doc: **hooks own
+per-component resource correctness** (refcounts, external retains);
+**binding records own per-mechanism backend residency** (backend objects that
+need reconciliation, iteration, and eviction). Hooks do not replace records:
+records are also the hot-path iteration structure and the destroy-detection
+mechanism for state that is not a refcount.
+
+Exit: the previously-failing leak regressions pass; hook order is deterministic
+and tested; `ctest` ECS suite green; the traits doc's fire table includes
+destruction and teardown rows.
+
+### A2 — Registry lifecycle transitions and resolution
+
+`ZoneRuntime::BuildFrameView` computes, against the previous frame's membership:
+
+```cpp
+struct RegistryTransitions
+{
+    // Newly participating this frame, per domain. Pointers frame-stable.
+    std::span<Registry* const> EnteredPhysics;   // (and per other domains as needed)
+
+    // Left the domain this frame but still attached (dormant). Pointers
+    // frame-stable: lifecycle mutates only at drain points.
+    std::span<Registry* const> LeftPhysics;
+
+    // Detached or destroyed since the last frame view. Ids only; teardown
+    // already ran via destructors.
+    std::span<const RegistryId> Destroyed;
+};
+```
+
+carried on `FrameRegistryView` beside the spans. Scratch-vector storage,
+allocation-free steady state, same pattern as the existing span scratch. Only the
+physics domain's transitions are consumed in this plan; other domains are
+computed when a consumer exists (the audio sweep in `AudioSystem` is the known
+candidate and can migrate later — noted, not required here).
+
+Resolution moves onto the view:
+
+```cpp
+Registry* Find(RegistryId id) const;          // participating this frame
+Registry* FindAttached(RegistryId id) const;  // any attached, incl. dormant
+bool IsAlive(EntityRef ref) const;            // Find + generational check
+```
+
+`Find` is the simulation-facing default: a registry outside the frame is
+unresolvable, which is the correct default semantics for gameplay systems.
+`FindAttached` exists for engine orchestrators processing lifecycle edges
+(Section 4.2's carried-over farewell case) and is documented as such.
+Implementation starts as a linear scan; registry counts are a handful. The
+indexed variant is a drop-in if profiling ever cares.
+
+Exit: transition and resolution coverage in zone runtime tests, including
+enter/leave/destroy across drain points, dormant-vs-destroyed distinction, and
+pointer stability within a frame.
+
+### A3 — TickEventChannel
+
+```cpp
+template <typename T>
+class TickEventChannel
+{
+public:
+    void Stage(const T& event);      // outside the step (teardown, drain points)
+    void Publish(const T& event);    // during the step
+    void BeginTick();                // fold staged into published, clear old
+    std::span<const T> Items() const;
+};
+```
+
+Built on `EventBuffer<T>`, placed beside it in `core/event`. Single-threaded by
+contract (teardown at drain points and publication in the step share the
+simulation thread). Visibility rules are the channel's documentation, not each
+subsystem's: same-tick `PostFixed` consumers see the tick's events plus staged
+events since the last executed tick; frame-lane consumers see only the last
+executed tick; a zero-tick frame leaves staged events pending until the next
+tick that runs.
+
+Exit: focused tests including the zero-tick frame, stage-then-destroy, and
+multi-tick frames.
+
+---
+
+## 4. Track B: physics residency
+
+### B1 — Binding ownership refactor
+
+Move `PhysicsScene` and `CharacterMoverPool` into `Registry::Resources`; rename
+`PhysicsScene` to `RigidBodyBinding`:
 
 ```text
 PhysicsStepSystem            owns PhysicsWorld, CollisionShapeCache,
-                             step orchestration, terminal event buffer
+                             step orchestration, TickEventChannel instances
 
-Registry::Resources          RigidBodyBinding      (renamed from PhysicsScene)
+Registry::Resources          RigidBodyBinding
                              CharacterMoverPool
-                             DrivenPoseBinding     (new, Section 8)
+                             DrivenPoseBinding     (Track C)
 
 Registry::Components (World) authored components, runtime link components
 ```
 
-Mechanics:
+Behavior-preserving; direct tests keep constructing bare `World`s and hold
+bindings as locals. Every backend removal path is order-independent (decision
+13), because sibling-resource destruction order is unspecified.
 
-- `RigidBodyBinding` keeps `PhysicsScene`'s exact contract: bind `Collider`,
-  `RigidBody`, and transforms from one registry to bodies in the shared world.
-  Rename only; no behavior change. Header moves to
-  `engine/include/physics/RigidBodyBinding.h`.
-- `PhysicsStepSystem` ensures bindings through `reg->Resources.Ensure<...>(...)`
-  instead of the `World` resource bag. The unload guarantee is unchanged: the
-  binding dies with the registry and its destructor removes the registry's backend
-  objects; the shared world outlives all registries exactly as before.
-- Direct tests keep constructing a bare `World` and may hold the binding as a plain
-  local object; storage location is orthogonal to the binding's API, which takes
-  `World&` explicitly.
-- Because sibling-resource destruction order is unspecified, every backend removal
-  path must be order-independent: removing a body whose dependent constraints were
-  already removed, and removing a constraint whose body already vanished, are both
-  safe no-ops (Sections 7, 10).
+Exit: full suite green; a regression asserts bindings are reachable in
+`Registry::Resources` and absent from the `World` bag.
 
-This is the smallest correction that stops the tree carrying two competing
-per-registry resource stores with physics in the undocumented one. It lands as its
-own commit before any constraint work.
+### B2 — Shared reconcile protocol
+
+`RigidBodyBinding`, `CharacterMoverPool`, and `DrivenPoseBinding` each carry the
+same skeleton: dense records, `LastStructuralVersion` gate, create-and-sweep
+reconcile, reconcile-count diagnostics, destructor teardown. After all three
+exist in code (i.e., after C's P4), extract the genuinely shared part — the
+version gate, the sweep protocol shape, the counters — as a small composition
+utility. Storage stays per-binding: the pool's stable-slot free list and the
+dense swap-remove vector are real semantic differences, not duplication. If the
+diff shows the shared part is smaller than the ceremony of extracting it, record
+that finding and keep the pattern; the conformance harness (B4), not code
+sharing, is what actually protects future bindings.
+
+### B3 — The dormancy contract: evict and restore
+
+The governing sentence: **dormant means absent from the shared simulation.**
+
+`PhysicsStepSystem`, at the start of its physics work each frame, consumes the
+transition data:
+
+- For each registry in `LeftPhysics` (and any carried-over leaver): a **farewell
+  visit** — each binding evicts its backend objects. `RigidBodyBinding` parks or
+  removes its bodies (mechanism is an implementation choice behind the binding
+  and `PhysicsWorld`; the contract is: no contacts, no default query hits, no
+  solver cost). `CharacterMoverPool` parks its movers under the same contract.
+  `DrivenPoseBinding` terminates its constraints with full-fidelity events
+  (decision 12). Records and link components are retained — eviction is not
+  teardown.
+- For each registry in `EnteredPhysics`: a **restore visit** — bindings
+  reinstate backend state from component-authoritative data (the last active
+  step synced transforms and velocities back to components, so restoration is
+  faithful). Restore precedes the frame's normal reconcile pass.
+- Farewell visits that cannot run because the frame executed zero physics ticks
+  carry over by `RegistryId`; on the next executed tick, ids found in
+  `Destroyed` are dropped (their destructors already tore down), the rest
+  resolve via `FindAttached`.
+
+This corrects the standing contract violation (Section 2.1) and is a behavior
+change: dormant zone geometry stops being collidable and stops answering default
+queries. That is what the participation contract always claimed; any content
+relying on the violation was relying on a bug. Called out loudly in the change
+notes.
+
+Restoration cost is bounded by zone size (room-scale by the engine's stated
+capacity assumptions); shapes stay in the cooked cache. If profiling shows
+restore spikes, the park-don't-remove mechanism absorbs them; the contract does
+not change either way.
+
+Exit: fitness tests prove a dormant zone's simulation presence is zero (no
+contacts against its geometry, no query hits, body/mover/constraint accounting
+correct), a returning zone restores bit-faithful component state, and repeated
+dormancy cycles allocate nothing in steady state.
+
+### B4 — Residency conformance harness
+
+A parameterized test gauntlet any binding can run: register components, populate
+entities, tick; leave the span (evict), assert zero simulation presence; return
+(restore), assert equivalence; destroy the registry, assert zero backend residue;
+repeat under churn. `RigidBodyBinding`, `CharacterMoverPool`, and
+`DrivenPoseBinding` all pass it in this ticket. The harness — not review vigilance
+— is what holds the line when the fourth binding arrives.
+
+The residency contract itself is written down in
+`docs/architecture/backend-residency.md`: the binding criterion (decision 7),
+the lifecycle table (participating / leaving / dormant / returning / destroyed —
+who acts, through which mechanism), the hooks-vs-records division (A1), and the
+two resolvers' semantics (A2). `ZoneParticipation`'s comment and the traits doc
+are updated to point at it.
 
 ---
 
-## 4. Constraint ownership: a component on the follower
+## 5. Track C: the driven pose constraint
+
+The mechanism as corrected through prior revisions, on top of Tracks A and B.
+Ownership argument, preserved: the follower is the one unambiguous owner. A
+constraint entity would need an arbitrary owning registry, third-party lifecycle,
+and placement guidance; a component on the follower makes discovery and body
+binding own-registry concerns where structural-version gating works, and shrinks
+cross-registry coupling to const reads of the target. Accepted limitation, still
+deliberate: one pose driver per follower (one component per type per entity).
+Competing drives are the recorded trigger for a future relationship-entity
+mechanism; the backend API below is component-model-agnostic, so that migration
+would not touch it.
+
+### 5.1 Components
 
 ```cpp
 struct DrivenPoseConstraint
@@ -188,64 +402,13 @@ struct DrivenPoseConstraint
     AngularPoseDriveSettings AngularDrive;
     ConstraintBreakSettings Break;
 };
-```
 
-The component lives on the follower entity — the body receiving the drive. The
-follower's registry owns the backend constraint. There is no constraint entity.
-
-Why this wins over constraint entities:
-
-- One unambiguous owner. The rejected shape assigned backend ownership to
-  "whichever registry holds the constraint entity," which forced placement guidance,
-  a third-registry lifecycle, and an owner that could unload independently of both
-  endpoints.
-- The follower and its body binding share a registry, so constraint discovery and
-  follower-body binding are own-registry concerns where structural-version gating
-  genuinely works. Cross-registry coupling shrinks to const reads of the target.
-- The target never needs a backend body. The driven frame consumes the target's
-  transform and, when present, its `RigidBody` component velocities — component
-  reads, never backend handles. The all-registries body barrier still exists
-  (Section 9) but almost nothing crosses it.
-- Lifecycle collapses: follower destroyed or its registry unloaded ends the
-  constraint with the definition; target loss is detected by the running owner.
-
-Accepted limitation, recorded deliberately: **one pose driver per follower.** One
-component per type per entity is an ECS invariant, so competing drives (two tractor
-sources fighting over one prop) cannot be expressed. Two complete pose drives on one
-body are overconstrained in the locked case and only meaningful as a blended spring
-tug-of-war, which no current requirement needs. If a real requirement for competing
-drives appears, that is the point where a relationship-entity mechanism gets earned —
-and the `PhysicsWorld` API below is component-model-agnostic, so that migration
-would not touch the backend.
-
-The desired follower frame each step:
-
-```text
-desiredFrame = targetWorldTransform * TargetLocalFrame
-```
-
-driving the follower's `FollowerLocalFrame` toward it. Two local frames support
-center attachment, held offsets, sockets, and off-center machinery. A pure helper
-constructs both frames from current world poses; it does transform math only and
-owns nothing.
-
----
-
-## 5. Runtime components
-
-```cpp
 struct DrivenPoseLink
 {
     PhysicsConstraintId Constraint;
 };
 
-enum class DrivenPoseState : uint8_t
-{
-    Pending,
-    Active,
-    Broken,
-    Invalid,
-};
+enum class DrivenPoseState : uint8_t { Pending, Active, Broken, Invalid };
 
 struct DrivenPoseTelemetry
 {
@@ -259,40 +422,21 @@ struct DrivenPoseTelemetry
 };
 ```
 
-`DrivenPoseLink` mirrors `PhysicsBodyLink` and `CharacterMoverLink`: the runtime
-handle that makes steady-state work a contiguous column walk with no hashing.
+All three register in `RegisterPhysicsComponents` before entity creation.
+`DrivenPoseLink` mirrors `PhysicsBodyLink`: hash-free steady state.
+`DrivenPoseTelemetry` is a published copy, records are canonical; because
+terminal completion removes all three components in one flush, the component
+only ever shows `Pending` or `Active` — terminal outcomes arrive exclusively via
+the event.
 
-`DrivenPoseTelemetry` is a published copy, written after each step the same way
-`RigidBody.LinearVelocity` is pulled from the backend. The binding's dense records
-(Section 8) are canonical for all constraint state; the component never feeds back
-into the binding. Games read it with const access.
-
-Because terminal completion removes all three components in the same flush
-(Section 10), `Broken` and `Invalid` are never observable through
-`DrivenPoseTelemetry` — the component only ever shows `Pending` or `Active`, and
-terminal outcomes reach the game exclusively through the `DrivenPoseEnded` event.
-The enum's terminal values exist for the binding's records and diagnostics.
-
-No backend or Jolt type enters ECS storage. All three components —
-`DrivenPoseConstraint`, `DrivenPoseLink`, `DrivenPoseTelemetry` — register in
-`RegisterPhysicsComponents` (`engine/src/physics/PhysicsRegistration.cpp`) before
-any entity creation, per ECS rules.
-
----
-
-## 6. Drive and break settings
+### 5.2 Drive and break settings
 
 ```cpp
-enum class PoseDriveResponse : uint8_t
-{
-    Locked,
-    Spring,
-};
+enum class PoseDriveResponse : uint8_t { Locked, Spring };
 
 struct LinearPoseDriveSettings
 {
     PoseDriveResponse Response = PoseDriveResponse::Locked;
-
     float FrequencyHz = 0.0f;
     float DampingRatio = 1.0f;
     float MaxForce = std::numeric_limits<float>::infinity();
@@ -301,25 +445,11 @@ struct LinearPoseDriveSettings
 struct AngularPoseDriveSettings
 {
     PoseDriveResponse Response = PoseDriveResponse::Locked;
-
     float FrequencyHz = 0.0f;
     float DampingRatio = 1.0f;
     float MaxTorque = std::numeric_limits<float>::infinity();
 };
-```
 
-Two structs rather than one reused struct with a context-dependent limit field: a
-member named `MaxForce` must not mean torque when the struct sits in the angular
-slot.
-
-`Locked` requests rigid relative-pose preservation. `Spring` uses frequency and
-damping and may lag under collision or acceleration. These are the two response
-profiles real use cases need today: strict attachments lock both, held props soften
-both, mixed configurations lock translation and soften orientation. No vague
-interpolation speed; response is solver-oriented frequency, damping, and force and
-torque limits.
-
-```cpp
 struct ConstraintBreakSettings
 {
     float MaxPositionError = std::numeric_limits<float>::infinity();
@@ -333,23 +463,20 @@ struct ConstraintBreakSettings
 };
 ```
 
-`RequiredDuration` permits forgiving pickup behavior without game policy in the
-engine; strict attachments use zero. Error thresholds carry internal reset
-hysteresis so a value hovering at the threshold does not accumulate and clear
-failure time on alternating ticks. Break evaluation lives in the binding, not the
-backend, so the backend contract stays small.
+Split linear/angular types so no field means force in one slot and torque in
+another. `Locked` is rigid preservation; `Spring` lags and recovers under
+frequency and damping. Error thresholds carry reset hysteresis so hovering
+values do not accumulate-and-clear on alternating ticks; `RequiredDuration`
+gives forgiving pickups without game policy in the engine. Break evaluation
+lives in the binding.
 
----
-
-## 7. PhysicsWorld constraint API
-
-Backend-neutral vocabulary, no Jolt type crossing the firewall:
+### 5.3 PhysicsWorld constraint API
 
 ```cpp
 struct PhysicsConstraintId
 {
     uint32_t Index;
-    uint32_t Generation; // generational: link components survive churn safely
+    uint32_t Generation;
 };
 
 struct DrivenPoseConstraintDesc
@@ -360,14 +487,13 @@ struct DrivenPoseConstraintDesc
     LinearPoseDriveSettings LinearDrive;
     AngularPoseDriveSettings AngularDrive;
 
-    uint64_t OwnerTag = 0;  // opaque; the binding packs its RegistryId
     uint64_t UserData = 0;  // opaque; the binding packs the follower EntityId
 };
 
 struct DrivenPoseTarget
 {
     Transform3f WorldFrame;  // already composed: targetWorld * TargetLocalFrame
-    Vec3d LinearVelocity;    // evaluated at the frame origin, not the target origin
+    Vec3d LinearVelocity;    // evaluated at the frame origin (v + w x r)
     Vec3d AngularVelocity;
     bool Teleported = false;
 };
@@ -380,256 +506,111 @@ struct PhysicsConstraintTelemetry
     float AppliedTorque;
 };
 
-struct ExpiredConstraint
-{
-    PhysicsConstraintId Id;
-    uint64_t OwnerTag;
-    uint64_t UserData;
-};
-
 PhysicsConstraintId AddDrivenPoseConstraint(const DrivenPoseConstraintDesc& desc);
-void RemoveConstraint(PhysicsConstraintId id);          // dead handle: safe no-op
+void RemoveConstraint(PhysicsConstraintId id);          // dead handle: no-op
 bool IsConstraintValid(PhysicsConstraintId id) const;
 
 void SetDrivenPoseTarget(PhysicsConstraintId id, const DrivenPoseTarget& target);
 PhysicsConstraintTelemetry GetConstraintTelemetry(PhysicsConstraintId id) const;
-
-std::span<const ExpiredConstraint> TakeExpiredConstraints(); // drained post-step
 ```
 
-Contract:
+The backend's whole contract: drive this follower-local frame toward this
+world-space frame, one-way, while the follower collides normally. It never sees
+the target entity or its attachment frame. The hidden realization (kinematic
+anchor, mass scaling, or another Jolt-side mechanism) never leaks.
 
-- The backend's whole contract is: drive this follower-local frame toward this
-  world-space frame. It never sees the target entity or its local attachment
-  frame; frame and velocity composition belong to the binding (Section 12), which
-  keeps `TargetLocalFrame` single-owner on the ECS side. The target is a driven
-  frame, not necessarily a body: dynamic, kinematic, animated, scripted, or any
-  entity with a valid world transform. The backend owns whatever hidden
-  representation realizes the frame (kinematic anchor, mass scaling, or another
-  Jolt-side mechanism); the choice never leaks.
-- One-way: the follower receives constraint forces, the target receives no solver
-  feedback, and the follower continues colliding normally.
-- **Refresh-or-expire.** `SetDrivenPoseTarget` must be called between steps for
-  every live constraint. `Step` terminally expires any constraint not refreshed
-  since the previous step, disables it for that step, and queues it in the expired
-  list with its opaque tags. Expiry sweeps in creation order, so the list is
-  deterministic. This is the whole dormancy mechanism: a registry that leaves the
-  physics view stops refreshing, and its constraints expire inside the shared
-  world without the backend knowing what a registry is. `OwnerTag` and `UserData`
-  exist so the orchestrator can publish a meaningful event afterward, mirroring
-  the `BodyDesc::UserData` entity-packing precedent.
-- `RemoveBody` first invalidates every constraint referencing the body (an internal
-  body-to-constraint reverse mapping or equivalent backend mechanism), then removes
-  the body. Invalidated handles answer `IsConstraintValid` false; removing them is
-  a no-op. This holds on every path, including registry teardown, where
-  sibling-resource destructor order is unspecified.
-- Telemetry is readable after a step until the constraint is removed.
+Targets are refreshed every step by the binding. With Track A's transitions, the
+orchestrator can always reach the binding that owes cleanup, so an unrefreshed
+live constraint is no longer a semantic state — it is an orchestration bug.
+Debug builds assert it (the former refresh-or-expire mechanism, demoted to
+invariant); release builds skip driving the stale constraint and count it in
+diagnostics.
 
----
+`RemoveBody` invalidates dependent constraints before removing the body, on
+every path including teardown, in either destruction order.
 
-## 8. DrivenPoseBinding
+### 5.4 DrivenPoseBinding
 
-A per-registry resource in `Registry::Resources`, the driven-pose analogue of
-`RigidBodyBinding`. It touches its own registry's components and the shared
-`PhysicsWorld`; the only foreign access is const reads of resolved targets.
+Per-registry resource beside the other two bindings. Dense records are canonical:
+follower id, handle, resolved target, previous target transform, failure
+accumulation, state.
 
-```cpp
-class DrivenPoseBinding
-{
-public:
-    void Reconcile(World& world, PhysicsWorld& physics);
+- **Reconcile** (structural-version gated): create backend constraints for
+  followers whose body link exists — the registry's body pass has run first —
+  remove constraints whose definition vanished, sweep dead followers.
+  Statically invalid configurations (target ref equals follower, invalid ref, no
+  dynamic `RigidBody`, nonfinite frames or drive values) consume the request
+  immediately with a loud debug diagnostic. Pending (body not yet bound) is
+  re-checked per step, surfaced by diagnostics, never silently timed out.
+- **Configuration** (`Changed<DrivenPoseConstraint>`): push edits to the
+  backend. Chunk-conservative re-pushes are cheap; resurrection is impossible
+  because terminal constraints have no component left to mark.
+- **PrepareStep** (every tick): resolve `Target` against the physics span,
+  compose the driven world frame (`targetWorld * TargetLocalFrame`) and its
+  velocities at the frame origin — `v + w x r` for off-center frames on rotating
+  targets, not the target origin's velocity — classify teleports, refresh the
+  backend. Composition is pure math with table-driven tests. Foreign-registry
+  reads are const-only. Resolution failure is recorded for terminal handling.
+- **CollectResults** (every tick): pull telemetry, evaluate breaks with
+  hysteresis, publish `DrivenPoseEnded`, and for each terminal constraint remove
+  the backend object plus all three components in one command-buffer flush.
+- **Farewell visit** (B3): terminate all constraints with full refs and reason
+  `OwnerInactive`; evict nothing else — constraints are relationships, and
+  relationships end when an endpoint leaves the simulation.
+- **Destructor**: remove backend constraints and stage `OwnerUnloaded` events
+  into the channel.
 
-    void PrepareStep(World& world,
-                     std::span<Registry* const> physicsSpan,
-                     PhysicsWorld& physics,
-                     float dt);
+Target velocity source: the target's `RigidBody` component values when present
+(component reads only), otherwise fixed-step transform deltas with quaternion
+delta for angular; teleports classify before derivation so a teleport never
+manufactures a synthetic velocity.
 
-    void CollectResults(World& world,
-                        PhysicsWorld& physics,
-                        DrivenPoseEventSink& events,
-                        float dt);
-};
-```
-
-### 8.1 Records and update categories
-
-The binding keeps a dense owned-record array — the canonical constraint state —
-holding follower `EntityId`, constraint handle, resolved target, previous target
-transform (for velocity derivation and teleport classification), failure
-accumulation, and state. As with body records, the dense array is what makes
-destroy-detection possible: `DestroyEntity` fires no hook and the components vanish
-with the entity.
-
-Three update categories, three mechanisms:
-
-- **Topology** (component or entity created or destroyed in this registry):
-  structural-version gated, exactly like body reconciliation. A steady frame is one
-  integer compare. This gate is sound here precisely because the definition lives
-  on the follower in this registry; the rejected cross-registry design broke it,
-  since a foreign registry's structural changes never bump the owner's version.
-- **Configuration** (an existing `DrivenPoseConstraint` edited: retuned spring,
-  changed frames, changed thresholds): detected with
-  `Changed<DrivenPoseConstraint>` and pushed to the backend. Chunk-conservative is
-  acceptable — re-pushing a chunk's settings occasionally is cheap, and a spurious
-  neighbor-write mark can never resurrect a terminal constraint because
-  termination removes the component itself (Section 10). All read paths use const
-  access so reads never mark the column.
-- **Per-tick target state**: resolved and refreshed unconditionally for every
-  active constraint. This is not reconciliation; the steady-state test in
-  Section 16 is worded against topology passes only.
-
-Structural changes the binding itself needs (adding `DrivenPoseLink` and
-`DrivenPoseTelemetry`, stripping them on termination) go through its reused
-`CommandBuffer`, flushed at the pass boundary.
-
-### 8.2 Per-step responsibilities
-
-- Reconcile: create backend constraints for followers whose body link exists
-  (the registry's body pass has already run — Section 9), remove backend
-  constraints whose definition vanished, sweep records for dead followers.
-- PrepareStep: resolve each record's `Target` ref against the physics span, read
-  the target pose, compose the driven world frame
-  (`targetWorld * TargetLocalFrame`) and its velocities at the frame origin —
-  for an off-center frame on a rotating target the linear velocity is
-  `v + ω × r`, not the target origin's velocity — classify teleports, and call
-  `SetDrivenPoseTarget`. Composition is pure transform math with focused
-  table-driven tests. Resolution failure or target death is recorded for terminal
-  handling in CollectResults; the constraint is not refreshed, so the backend
-  also disables it for the step.
-- CollectResults: pull telemetry, evaluate break thresholds with hysteresis and
-  `RequiredDuration`, publish terminal events, remove terminal backend
-  constraints, and remove the terminal followers' `DrivenPoseConstraint`,
-  `DrivenPoseLink`, and `DrivenPoseTelemetry` in one command-buffer flush
-  (Section 10). Surviving constraints get their `DrivenPoseTelemetry` copies
-  updated in place.
-- Destructor: remove all owned backend constraints and publish `OwnerUnloaded`
-  events through the sink pointer, which outlives every registry (Section 11).
-
-### 8.3 Target resolution
-
-Resolution is a linear scan of the physics span comparing `Registry::Id`, wrapped
-in a small free function. The span holds the global registry plus a handful of
-zones; a scan beats building any map at this size, and it is span-scoped on
-purpose: a registry outside the physics view is unresolvable, which is exactly the
-Section 10 semantics. No `RegistryDirectoryView` class is introduced — `EntityRef`
-has one consumer, and the repository rule is that abstractions are earned by real
-variation, not anticipated. If a second cross-registry consumer appears, promote
-the lookup to `FrameRegistryView` then.
-
-Foreign-registry reads are const-only. Non-const access counts as a write and would
-poison change detection in a registry this binding does not own; const access also
-keeps the binding compatible with any future decision about parallelizing
-per-registry work, from which the constraint passes are permanently excluded — they
-are serial orchestration by construction (Section 9).
-
----
-
-## 9. Fixed-step orchestration
-
-`PhysicsStepSystem::Physics` becomes explicit global passes. Each pass completes
-for every participating registry before the next begins:
+### 5.5 Step orchestration
 
 ```text
+0. Process transitions: farewell visits (leavers), restore visits (returners)
 1. For each registry: rigid-body reconcile + kinematic push   (RigidBodyBinding)
 2. For each registry: driven-pose reconcile                   (DrivenPoseBinding)
 3. For each registry: resolve targets, refresh driven frames  (DrivenPoseBinding)
 4. Step the shared PhysicsWorld once
-5. Drain expired constraints; publish their terminal events   (PhysicsStepSystem)
-6. For each registry: collect telemetry, evaluate breaks,
+5. For each registry: collect telemetry, evaluate breaks,
    publish terminal events, flush deferred ECS changes        (DrivenPoseBinding)
-7. For each registry: pull dynamic body transforms/velocities (RigidBodyBinding)
+6. For each registry: pull dynamic body transforms/velocities (RigidBodyBinding)
 ```
 
-The barrier between pass 1 and pass 2 guarantees every registry's bodies exist
-before any registry binds constraints. With follower-owned constraints the
-same-registry case would survive interleaving, but the barrier costs nothing, keeps
-the rule simple, and stays correct if a future mechanism does reference foreign
-bodies. Passes run serially on the simulation thread in span order (global first,
-zones in attach order), so event and reconcile ordering is deterministic.
+`TickEventChannel<DrivenPoseEnded>::BeginTick` runs at step entry. Passes are
+serial on the simulation thread in span order (global first, zones in attach
+order): deterministic event and reconcile ordering. The pass-1/pass-2 barrier
+guarantees every registry's bodies exist before any registry binds constraints.
+Constraint passes are permanently excluded from any per-registry parallel axis —
+they read foreign registries; the exclusion is by construction, not convention.
 
-Body transforms are still pulled on the step a constraint breaks (pass 7 follows
-pass 6). Telemetry is collected before any backend constraint is destroyed.
+### 5.6 Lifecycle, termination, events
 
----
-
-## 10. Lifecycle and termination
-
-States: `Pending -> Active -> Broken | Invalid`. Terminal completion consumes the
-request: in one command-buffer flush the binding publishes `DrivenPoseEnded`,
-removes the backend constraint, and removes `DrivenPoseConstraint`,
-`DrivenPoseLink`, and `DrivenPoseTelemetry` from the follower. This is what makes
-"broken constraints do not recreate" structurally true — after the flush there is
-no definition left for topology reconciliation to rediscover, and no component
-left for a chunk-conservative `Changed` mark to touch. Rearming is unambiguous:
-the game adds a fresh `DrivenPoseConstraint`. The `Invalid` path consumes the
-request the same way, with a loud debug diagnostic. When P7 introduces authored
-persistent constraints, the authoring component instantiates transient requests;
-the runtime contract here does not change.
-
-- **Pending**: definition exists, follower body link not yet bound. Because the
-  registry's body pass precedes its constraint pass, the common case binds in the
-  same step the collider appears. Pending persists until the body exists; it is
-  re-checked per step at O(pending) and surfaced by diagnostics (Section 14), never
-  silently timed out.
-- **Invalid** (immediate, statically checkable): target ref equals the follower,
-  invalid `EntityRef`, follower has no dynamic `RigidBody` component, nonfinite
-  frames, invalid drive values. Fails loudly in debug, safely in release.
-- **Broken**: sustained position or angular error, force or torque limit, target
-  teleport beyond per-step bounds — all evaluated by the binding with hysteresis
-  and `RequiredDuration`.
-
-Terminal reasons:
+States: `Pending -> Active -> Broken | Invalid`. Terminal completion consumes
+the request (decision 10); rearming is a fresh component.
 
 ```cpp
 enum class DrivenPoseEndReason : uint8_t
 {
     Removed,            // component removed by game code
-    FollowerDestroyed,  // follower entity destroyed while active
+    FollowerDestroyed,
     PositionError,
     AngularError,
     ForceLimit,
     TorqueLimit,
     TargetTeleported,
     TargetDestroyed,    // target entity dead in a resolvable registry
-    TargetUnavailable,  // target registry unloaded or absent from the physics view
-    OwnerUnloaded,      // follower's registry destroyed (published by teardown)
-    OwnerInactive,      // follower's registry left the physics view (expiry path)
+    TargetUnavailable,  // target registry unloaded or outside the physics view
+    OwnerUnloaded,      // follower's registry destroyed
+    OwnerInactive,      // follower's registry left the physics view
     InvalidConfiguration,
 };
-```
 
-Registry participation semantics, stated once:
-
-- **Target registry absent from the physics view** — loaded-but-dormant and
-  unloaded are indistinguishable through the span lookup, and deliberately so —
-  is terminal `TargetUnavailable`, evaluated by the running owner binding.
-- **Owner registry absent from the physics view**: the binding does not run, its
-  constraints are not refreshed, and the backend expires them terminally inside
-  the step (Section 7). `PhysicsStepSystem` drains the expired list and publishes
-  `OwnerInactive`, reconstructing the follower ref from the packed tags; the
-  target ref in these events is invalid, which consumers must tolerate. If the
-  registry later returns, its binding finds dead handles, cleans records and
-  components, and publishes nothing further.
-- **Owner registry unloaded**: the binding destructor removes backend constraints
-  and publishes `OwnerUnloaded` with full refs through the engine-owned sink.
-
-The practical consequence must be documented loudly for game integrators: world
-partition demotes the previous focus zone to dormant as routine streaming behavior,
-so carrying a follower or targeting an entity whose zone demotes breaks the
-constraint by design. The engine-side remedies — residency pins that keep an
-endpoint's zone participating, or migrating a carried entity into the global
-registry — are world-partition features to be built there when a game needs them,
-not hidden constraint behavior.
-
----
-
-## 11. Terminal events
-
-```cpp
 struct DrivenPoseEnded
 {
     EntityRef Follower;
-    EntityRef Target;            // invalid in OwnerInactive events
+    EntityRef Target;
     PhysicsConstraintId Constraint;
     DrivenPoseEndReason Reason;
 
@@ -640,279 +621,185 @@ struct DrivenPoseEnded
 };
 ```
 
-`PhysicsStepSystem` owns the event sink (built on the existing primitive at
-`engine/include/core/event/EventBuffer.h`; domain services own their buffers by
-design). Bindings hold a non-owning sink pointer with the same lifetime argument
-`RigidBodyBinding` already uses for its raw `PhysicsWorld*`: `EngineSchedule`
-outlives `ZoneRuntime`, so registry teardown can still publish.
+All events carry full refs — the farewell visit and the destructor both run with
+records intact, which the transitions work exists to guarantee. Events ride the
+engine-owned `TickEventChannel<DrivenPoseEnded>` on `PhysicsStepSystem`;
+bindings hold a non-owning channel pointer (same lifetime argument as their
+`PhysicsWorld*`: `EngineSchedule` outlives `ZoneRuntime`).
 
-The sink is two containers, because teardown publishes outside the step. Zone
-lifecycle mutates at drain points before `ScheduleTicks` builds the frame view, so
-an `OwnerUnloaded` raised by a binding destructor exists before the next physics
-step begins — a single buffer cleared at step entry would destroy it unread.
+The engine reports the physical result only; games decide what it means. The
+integrator-facing consequence stays documented loudly: streaming demotes zones
+routinely, so a constraint whose endpoint's zone demotes ends by design; the
+remedies (pins, migration) are world-partition features.
 
-```text
-published : EventBuffer<DrivenPoseEnded>   read by consumers
-pending   : append-only staging            written by teardown, between steps
+### 5.7 Target pose staleness (documented v1 contract)
 
-at physics-step entry:
-    published.Clear()
-    move pending into published
-during the step:
-    bindings and the expiry drain append to published
-```
+Pose source: `WorldTransform` when present, else `LocalTransform`. Propagation
+runs after physics, so a parented target's world pose is one tick old — sockets
+on moving parents lag one fixed step; v1 recommends top-level or physics-driven
+targets, and on-demand parent-chain propagation is the recorded future option.
+Character-driven targets are likewise one tick stale (`CharacterControllerSystem`
+runs after the step); spring response masks it, locked response will trail.
 
-Everything runs on the simulation thread (teardown at drain points, publication
-inside the step), so no synchronization is involved.
+### 5.8 Collision and diagnostics
 
-Visibility: consumers in the same fixed tick's `PostFixed` phase see that tick's
-events, including any teardown events staged since the previous step. Frame-lane
-(`Update`) consumers must not assume one tick per frame — a frame runs zero or
-several fixed ticks, and only the last tick's events survive to `Update`. Systems
-that must not miss events consume them in `PostFixed`. A frame that runs zero
-ticks leaves staged teardown events pending; they surface in the next tick that
-actually runs, which is the next moment physics state is coherent to act on.
-
-The engine reports the physical result only. It does not drop objects, end
-abilities, restore input, play cues, destroy game entities, or apply cooldowns;
-games consume the event and decide what it means.
-
----
-
-## 12. Target pose and velocity
-
-Pose source: `WorldTransform` when present, `LocalTransform` otherwise — the same
-preference `RigidBodyBinding` uses at body creation. Two staleness facts are part
-of the v1 contract and are documented, not fixed:
-
-- Transform propagation runs after physics, so a parented target's `WorldTransform`
-  is one tick old during the step. Sockets on moving parents therefore lag one
-  fixed step. If this matters for a use case, the future option is on-demand
-  propagation of the target's parent chain at resolve time, bounded per constraint;
-  v1 recommends top-level or physics-driven targets.
-- `CharacterControllerSystem` runs after `PhysicsStepSystem`, so a character-driven
-  target's consumed pose is one tick old. Spring response masks it; locked response
-  will visibly trail by one step.
-
-Velocity: if the target carries a `RigidBody` component, use its linear and angular
-velocity values (component reads — the target's backend body, if any, is never
-touched). Otherwise derive from fixed-step transform deltas; angular velocity from
-the quaternion delta. The binding's record keeps the previous target transform.
-
-The binding then evaluates velocity at the driven frame's origin before refreshing
-the backend: for an attachment offset `r` from the target origin, the frame's
-linear velocity is `v + ω × r`. Skipping this hands the backend the target
-origin's velocity and makes off-center attachments on rotating targets drag
-behind their true path; the frame-composition helper owns this math and its
-table-driven tests.
-Discontinuities beyond the per-step translation and rotation bounds classify as
-teleports before velocity derivation, so a teleport never manufactures an enormous
-synthetic velocity — it either breaks the constraint (per break settings) or is
-passed with `Teleported = true` so the backend can snap rather than chase.
-
----
-
-## 13. Rigid-body completion (prerequisite capability)
-
-Robust pose constraints need full body state. Complete the public component:
-
-```cpp
-struct RigidBody
-{
-    BodyMotion Motion = BodyMotion::Dynamic;
-
-    float Mass = 1.0f;
-    float GravityScale = 1.0f;
-
-    Vec3d LinearVelocity = Vec3d::Zero();
-    Vec3d AngularVelocity = Vec3d::Zero();
-
-    float LinearDamping = 0.0f;
-    float AngularDamping = 0.0f;
-};
-```
-
-`PhysicsWorld` adds `GetAngularVelocity`, `SetAngularVelocity`, `SetGravityScale`,
-and `WakeBody`. `RigidBodyBinding` pushes initial values (including the existing,
-currently-unsynchronized `GravityScale`) and pulls both velocities after
-simulation.
-
-Gravity belongs to the body, not the constraint: a suspended actor uses a
-zero-gravity body, a held prop keeps gravity. The constraint never mutates
-body-wide properties behind the game's back.
-
----
-
-## 14. Collision and diagnostics
-
-The follower remains an ordinary body colliding with static, kinematic, dynamic,
-and layered geometry. The driven-frame representation carries no collision shape.
-Follower-versus-target-source collision is ordinary collision filtering, never
-hardcoded constraint behavior. Solver contacts and telemetry are the authority on
-whether the relationship held; queries and sweeps are diagnostic aids only.
-
-Debug drawing: target and follower frame axes, desired frame, position error
-vector, angular error arc, force and torque magnitudes, per-state coloring, break
-thresholds. Console:
+The follower collides normally per collision filtering; the driven frame carries
+no collision shape; follower-versus-source filtering is ordinary layer
+configuration. Debug drawing: frame axes, desired frame, error vector and arc,
+force and torque magnitudes, state coloring, thresholds. Console:
 
 ```text
 physics.constraints.debug
 physics.constraints.log_breaks
 physics.constraints.count
-physics.constraints.warn_pending_steps   (diagnostic warning threshold, 0 = off)
+physics.constraints.warn_pending_steps   (0 = off)
 ```
 
-Counters: active, pending, created and removed this step, breaks by reason,
-expirations, reconcile passes, target resolution failures. No debug feature needs a
-Jolt type outside the physics implementation.
+Counters: active, pending, created and removed per step, breaks by reason,
+stale-refresh invariant hits, reconcile passes, resolution failures. No Jolt
+type outside the physics implementation.
 
 ---
 
-## 15. Phases
+## 6. Execution order
 
-**R1 — binding ownership refactor.**
-Move `PhysicsScene` and `CharacterMoverPool` into `Registry::Resources`; rename
-`PhysicsScene` to `RigidBodyBinding`; update `PhysicsStepSystem`,
-`CharacterControllerSystem`, registration, tests, and stale doc references.
-Behavior-preserving. Exit: full suite green with bindings living in
-`Registry::Resources`; a regression test asserts the binding is reachable there
-and absent from the `World` bag.
+```text
+Track A (substrate)      A1 destroy hooks + teardown order
+                         A2 view transitions + resolution
+                         A3 TickEventChannel
+Track B (residency)      B1 binding move + rename            (independent of A)
+                         B3 evict/restore                     (needs A2)
+                         B4 conformance harness + contract doc
+                         B2 protocol extraction               (after C/P4)
+Track C (feature)        P1 body completion                   (independent)
+                         P2 backend constraint foundation     (independent)
+                         P3 compliance and limits
+                         P4 DrivenPoseBinding + orchestration (needs A2, A3, B1, B3)
+                         P5 breaking and events
+                         P6 diagnostics + example scene
+                         P7 authoring                         (deferred as before)
+```
 
-**P1 — body capability completion.**
-Angular velocity, gravity-scale sync, linear and angular damping, wake support;
-`RigidBodyBinding` pushes and pulls full state; direct `PhysicsWorld` and binding
-tests. Exit: dynamic bodies preserve and report full linear and angular state
-through ECS synchronization.
+A1, A2, A3, B1, P1, and P2 are mutually independent and can proceed in
+parallel. Each lands as its own commit series with its own tests; no phase
+waits on the whole.
 
-**P2 — backend constraint foundation.**
-Generational `PhysicsConstraintId`; driven-pose descriptors; create, refresh,
-telemetry, validity, removal; one-way locked driving; refresh-or-expire with the
-deterministic expired list; `RemoveBody` constraint invalidation; idempotent
-removal. Direct `PhysicsWorld` tests, no ECS. Exit: a dynamic body follows a
-translating and rotating driven frame while colliding, the source receives no
-feedback, and an unrefreshed constraint expires deterministically.
+Phase exit conditions:
 
-**P3 — compliance and limits.**
-Spring response, frequency and damping, force and torque limits, telemetry values,
-tunable validation, deterministic fixed-step tests. Exit: the same mechanism
-expresses rigid following and forgiving pickup-style following.
-
-**P4 — ECS binding and orchestration.**
-Components and registration; `DrivenPoseBinding` with the frame- and
-velocity-composition helper; global pass restructure in `PhysicsStepSystem`;
-span-scoped target resolution; engine-owned event sink with pending staging;
-owner teardown publishing; expired-list draining. Exit: constraints bind and
-unbind across registries without leaking backend objects or scanning topology on
-steady frames, and teardown events survive to the next executed tick.
-
-**P5 — breaking and events.**
-Threshold accumulation, hysteresis, teleport classification, `RequiredDuration`,
-full reason coverage including `OwnerInactive` and `TargetUnavailable`, no
-auto-recreation. Exit: obstruction, solver overload, and participation loss all
-produce deterministic, inspectable terminal events.
-
-**P6 — diagnostics and example.**
-Debug drawing, cvars, counters, and an engine physics example scene: translating
-and rotating targets, box and capsule followers, walls and ceiling, locked and
-spring configurations, threshold controls, live telemetry. Exit: the mechanism can
-be tuned and inspected without game code.
-
-**P7 — authoring (deferred until the runtime contract stabilizes).**
-`TypeSchema`, scene-serialization decision, editor frame gizmos, undoable
-commands, unloaded-endpoint authoring behavior. No persisted format commitment
-during the experimental backend phase.
+- **A1/A2/A3**: as stated in Track A. A1's leak regressions must fail before the
+  fix, for the intended reason.
+- **B1**: suite green, bindings in `Registry::Resources`.
+- **B3**: dormant zone has zero simulation presence; returning zone restores
+  faithfully; cycles allocate nothing.
+- **B4**: all three bindings pass the gauntlet; `backend-residency.md` merged;
+  traits doc and participation comments updated.
+- **P1**: dynamic bodies preserve and report full linear and angular state
+  through ECS sync (including the currently-dead `GravityScale`).
+- **P2**: a body follows a translating and rotating driven frame while
+  colliding; source receives no feedback; stale-refresh asserts in debug;
+  handles are generational and idempotent to remove.
+- **P3**: rigid and forgiving following from one mechanism; limits enforced;
+  deterministic repeated runs.
+- **P4**: constraints bind and unbind across registries with no leaks and no
+  steady-state topology scans; events flow through the channel; farewell and
+  restore paths exercised.
+- **P5**: obstruction, overload, teleports, and participation loss produce
+  deterministic, inspectable terminal events; no auto-recreation.
+- **P6**: tunable and inspectable without game code.
 
 ---
 
-## 16. Required tests
+## 7. Required tests
 
-PhysicsWorld (direct, headless, no Jolt headers, fixed stepping):
+Substrate:
 
-- locked position and orientation follow translation and rotation
-- off-center follower traces the correct rotational path
-- zero-gravity follower stays suspended; follower collides with static geometry
-- one-way target unaffected by follower collision
-- spring follower lags and recovers; force and torque limits enforced
-- removal invalidates handles; removing a dead handle is a no-op
-- `RemoveBody` invalidates dependent constraints, in both destruction orders
-- unrefreshed constraint expires exactly once, in creation order
-- generational id: a recycled slot does not answer to a stale handle
-- identical fixed-step runs produce identical results
+- destroy fires `OnRemove` (direct and command buffer), in deterministic order;
+  world teardown drains hooks before resources; the mesh/audio retain leaks
+  regress before the fix and pass after
+- transition spans across enter/leave/destroy at drain points; dormant vs
+  destroyed distinguished; pointer stability within a frame
+- channel: zero-tick frames, stage-then-destroy, multi-tick frames
+
+Residency:
+
+- conformance gauntlet for all three bindings (populate / dormant / return /
+  destroy / churn), zero backend residue at each edge
+- dormant zone: no contacts, no default query hits, zero solver cost; restore
+  is component-faithful
+
+PhysicsWorld (direct, headless, fixed stepping):
+
+- locked and spring following, translation and rotation, off-center paths
+- zero-gravity suspension; collision preserved; one-way isolation
+- force and torque limits; teleport flag semantics
+- generational handles: stale handle never resolves after slot reuse
+- `RemoveBody` invalidates dependents in both destruction orders; dead-handle
+  removal is a no-op; stale-refresh asserts in debug
+- identical runs produce identical results
 
 ECS integration:
 
-- constraint binds in the same step its follower body binds; stays pending before
-- component removal, follower destruction, target destruction, and target-registry
-  unload each end the constraint with the correct reason and remove all three
-  components from a surviving follower in the same flush
-- after a break, a write to a different entity's `DrivenPoseConstraint` in the
-  same chunk does not resurrect or rebind the broken follower
-- an off-center frame on a rotating target receives attachment-point velocity
-  (`v + ω × r`), verified against the analytic path
-- owner-registry unload removes backend constraints and publishes `OwnerUnloaded`;
-  the event survives to the next executed tick's `PostFixed` consumer even when
-  the unload happens on a frame that runs zero fixed ticks
-- owner-registry dormancy expires constraints and publishes `OwnerInactive`;
-  the returning registry cleans up without publishing a second event
-- target-registry dormancy ends with `TargetUnavailable`
-- a global-registry follower drives against a zone-registry target
-- editing an existing component's settings reaches the backend (`Changed` path)
-- steady-state ticks perform no topology reconciliation (per-tick target refresh
-  is expected and excluded from the assertion)
-- broken constraints do not recreate
+- binds the step the follower's body binds; pending before
+- every terminal reason reachable and correct, components consumed in one flush
+- neighbor-chunk `Changed` marks cannot resurrect a broken follower
+- off-center rotating target receives `v + w x r`, verified analytically
+- `OwnerUnloaded` staged at teardown survives to the next executed tick's
+  `PostFixed`, including across zero-tick frames
+- global-registry follower against zone-registry target
+- steady-state ticks: no topology reconciliation (per-tick refresh expected)
 
 Stress and fitness:
 
-- cost scales with active constraints; thousands of inactive entities are free
-- no steady-state heap allocation; repeated create-destroy cycles leak nothing
-- constraint counts return to zero after registry destruction
-- invalid data fails loudly in debug and safely in release
-
-The R1 refactor keeps every existing `PhysicsScene` and `CharacterMoverPool` test
-passing under the new names and storage.
+- cost scales with active constraints; inactive entities free; no steady-state
+  allocation; create/destroy churn leaks nothing; counts reach zero after
+  registry destruction; invalid data loud in debug, safe in release
 
 ---
 
-## 17. Performance expectations
+## 8. Performance expectations
 
-Steady-state complexity, stated honestly:
-`O(active bodies + active constraints × physics registries)` — each active
-constraint's target resolution scans the physics span. The span is deliberately
-small (global plus a handful of streamed zones), so this is acceptable and is not
-disguised as `O(B + C)`; if profiling ever shows the resolution term, the fix is
-an indexed lookup, not a redesign. Beyond that: no entity scans, no repeated
-registration lookups, no backend creation during steady following, no schema
-interpretation or string lookup in the step. Topology work is structural-version
-gated; target refresh and telemetry are contiguous walks over dense records. Any
-bounded behavior (expiry, pending diagnostics) logs what it dropped rather than
-truncating silently.
+Steady state: `O(active bodies + active constraints x physics registries)` —
+the resolution term is a scan over a deliberately small span, stated honestly
+rather than disguised; an indexed lookup is the recorded fix if it ever shows in
+a profile. Topology work is version-gated; refresh and telemetry are contiguous
+record walks. Transition processing is proportional to transitions, which are
+rare. Eviction and restore are proportional to the leaving or returning zone's
+contents and occur at streaming frequency, not tick frequency. Hook completion
+adds cost only to hooked archetypes on structural paths. Anything bounded logs
+what it dropped.
 
 ---
 
-## 18. Acceptance criteria
+## 9. Acceptance criteria
 
-1. A dynamic body preserves a complete relative pose to a translating and rotating
-   target that can be any entity with a valid world transform.
-2. The follower collides normally; the target receives no solver feedback.
-3. Locked and spring responses use one mechanism; break conditions report error,
-   force, torque, and terminal reason.
-4. Endpoints work across active registries through `EntityRef`; every unload,
-   dormancy, and destruction path ends deterministically with the documented
-   reason and no dangling backend object.
-5. Physics bindings live in `Registry::Resources`; no game, genre, or project term
-   appears in the engine API; no Jolt type crosses the firewall.
-6. No steady-state structural scan or allocation.
-7. A game can implement suspended actors and forgiving pickups without modifying
-   the physics backend.
+1. A dynamic body preserves a complete relative pose to a translating and
+   rotating target that can be any entity with a valid world transform; the
+   follower collides normally; the target receives no feedback.
+2. Locked and spring responses are one mechanism; breaks report error, force,
+   torque, and terminal reason; endpoints work across registries via
+   `EntityRef`.
+3. Component lifecycle is complete: no path exists on which a hooked component
+   leaves the world without its hook firing, including zone unload.
+4. A dormant registry has zero presence in the shared simulation, and returning
+   restores it faithfully.
+5. Every unload, dormancy, and destruction path ends deterministically with the
+   documented reason, full refs, and no dangling backend object — proven by the
+   conformance harness for all three bindings.
+6. Bindings live in `Registry::Resources`; the residency contract is a merged
+   document; no game, genre, or project term in the engine API; no Jolt type
+   across the firewall.
+7. No steady-state structural scan or allocation; a game implements suspended
+   actors and forgiving pickups without touching the backend.
 
 ---
 
-## 19. Deferred
+## 10. Deferred
 
 Bilateral joints, distance and rope limits, hinges, cone and twist limits,
-ragdolls, breakable structural assemblies, networked prediction, persistent saved
-constraints, editor-authored mechanical assemblies, residency pins, cross-registry
-entity migration, on-demand target-chain propagation, camera spring arms. Each may
-reuse the handle, lifecycle, tagging, and event substrate; none expands this
-mechanism now. Competing multi-driver poses are the recorded trigger for a future
-relationship-entity mechanism (Section 4).
+ragdolls, breakable assemblies, networked prediction, persistent saved
+constraints, editor-authored mechanical assemblies, residency pins,
+cross-registry entity migration, on-demand target-chain propagation, camera
+spring arms, audio-sweep migration onto A2 transitions, indexed registry
+resolution, non-physics domain transition consumers. Each now has a substrate to
+land on; none expands this ticket further. Competing multi-driver poses remain
+the recorded trigger for a relationship-entity mechanism.

--- a/engine/include/app/EngineSchedule.h
+++ b/engine/include/app/EngineSchedule.h
@@ -18,6 +18,10 @@ template<typename T>
 concept HasScheduleShutdown = requires(T& t) { t.Shutdown(); };
 
 template<typename T>
+concept HasRegistryResidency =
+    requires(T& t, RegistryResidencyContext& ctx) { t.RegistryResidency(ctx); };
+
+template<typename T>
 concept HasFixedLogic = requires(T& t, FixedLogicContext& ctx) { t.FixedLogic(ctx); };
 
 template<typename T>
@@ -40,8 +44,8 @@ concept HasEndFrame = requires(T& t, EndFrameContext& ctx) { t.EndFrame(ctx); };
 
 template<typename T>
 concept IsScheduledSystem =
-    HasFixedLogic<T> || HasPhysics<T> || HasPostFixed<T> || HasFrameUpdate<T>
-    || HasExtractRender<T> || HasAudio<T> || HasEndFrame<T>;
+    HasRegistryResidency<T> || HasFixedLogic<T> || HasPhysics<T> || HasPostFixed<T>
+    || HasFrameUpdate<T> || HasExtractRender<T> || HasAudio<T> || HasEndFrame<T>;
 
 //=============================================================================
 // EngineSchedule
@@ -77,6 +81,7 @@ public:
 
     FrameRegistryView BuildFrameView(ZoneRuntime& zones);
 
+    void RunRegistryResidency(RegistryResidencyContext& ctx);
     void RunFixedLogic(FixedLogicContext& ctx);
     void RunPhysics(PhysicsContext& ctx);
     void RunPostFixed(PostFixedContext& ctx);
@@ -130,6 +135,7 @@ private:
     std::vector<SystemRecord> Records;
     std::unordered_map<std::type_index, void*> TypeIndex;
 
+    std::vector<DispatchEntry<RegistryResidencyContext>> RegistryResidencyEntries;
     std::vector<DispatchEntry<FixedLogicContext>> FixedLogicEntries;
     std::vector<DispatchEntry<PhysicsContext>> PhysicsEntries;
     std::vector<DispatchEntry<PostFixedContext>> PostFixedEntries;
@@ -164,6 +170,9 @@ T& EngineSchedule::Register(Args&&... args)
         rec.ShutdownFn = [](void* p) { static_cast<T*>(p)->Shutdown(); };
     Records.push_back(rec);
 
+    if constexpr (HasRegistryResidency<T>)
+        RegistryResidencyEntries.push_back({ std::type_index(typeid(T)), raw,
+            [](void* p, RegistryResidencyContext& ctx) { static_cast<T*>(p)->RegistryResidency(ctx); }, {} });
     if constexpr (HasFixedLogic<T>)
         FixedLogicEntries.push_back({ std::type_index(typeid(T)), raw,
             [](void* p, FixedLogicContext& ctx) { static_cast<T*>(p)->FixedLogic(ctx); }, {} });
@@ -194,6 +203,7 @@ void EngineSchedule::After()
 {
     const std::type_index tid(typeid(T));
     const std::type_index dep(typeid(TDep));
+    AddDependency(RegistryResidencyEntries, tid, dep);
     AddDependency(FixedLogicEntries, tid, dep);
     AddDependency(PhysicsEntries, tid, dep);
     AddDependency(PostFixedEntries, tid, dep);

--- a/engine/include/app/GameContexts.h
+++ b/engine/include/app/GameContexts.h
@@ -6,6 +6,7 @@
 #include <runtime/RuntimeFrameLoop.h>
 #include <time/FrameClock.h>
 #include <world/registry/FrameRegistryView.h>
+#include <zone/RegistryResidency.h>
 
 #include <SDL3/SDL.h>
 
@@ -81,6 +82,22 @@ struct PlatformEventContext
     EngineConfig& Config;
     SDL_Event& Event;
     bool Handled = false;
+};
+
+//=============================================================================
+// RegistryResidencyContext
+//
+// Provides the frame's registry residency-change batch, processed once per
+// rendered frame after async commits and before the frame view is built —
+// including frames that run zero fixed ticks. Systems owning retained backend
+// state react here: evict on a registry leaving their domain, restore on it
+// entering, tear down on Detaching while the registry is still fully alive.
+// No frame view exists yet at this point; change records carry live pointers.
+//=============================================================================
+struct RegistryResidencyContext
+{
+    EngineConfig& Config;
+    std::span<const RegistryResidencyChange> Changes;
 };
 
 //=============================================================================

--- a/engine/include/core/event/TickEventChannel.h
+++ b/engine/include/core/event/TickEventChannel.h
@@ -1,0 +1,100 @@
+#pragma once
+#include <core/event/EventBuffer.h>
+
+#include <span>
+#include <utility>
+#include <vector>
+
+//=============================================================================
+// TickEventChannel<T>
+//
+// Tick-scoped publication over EventBuffer<T> for events that can be raised
+// outside the step that consumers read them in. Two containers:
+//
+//   published — what consumers see for the current tick
+//   pending   — staged by code running between ticks (registry residency
+//               processing, teardown), folded into published at tick entry
+//
+// Lifecycle, driven by the owning system:
+//   1. BeginTick() at step entry: clear last tick's published events, then
+//      move everything staged since the last executed tick into published.
+//   2. Publish() during the step appends directly to published.
+//   3. Consumers read Items() later in the same tick (e.g. PostFixed).
+//
+// A frame that runs zero ticks leaves staged events pending; they surface in
+// the next tick that actually executes. Frame-lane consumers see only the
+// last executed tick's events. Single-threaded by contract: staging sites
+// (drain-point residency processing, registry teardown) and publication share
+// the simulation thread.
+//
+// The owner outlives every producer that holds a pointer to the channel —
+// the same lifetime argument bindings already rely on for the shared
+// simulation itself.
+//=============================================================================
+template <typename T>
+class TickEventChannel
+{
+public:
+	// Stage an event from outside the step. Not visible until the next
+	// BeginTick folds it into the published buffer.
+	void Stage(const T& event)
+	{
+		Pending.push_back(event);
+	}
+
+	void Stage(T&& event)
+	{
+		Pending.push_back(std::move(event));
+	}
+
+	// Publish an event during the step: visible to this tick's consumers.
+	void Publish(const T& event)
+	{
+		Published.Push(event);
+	}
+
+	void Publish(T&& event)
+	{
+		Published.Push(std::move(event));
+	}
+
+	// Called once at step entry by the owning system. Clears the previous
+	// tick's events, then promotes everything staged since.
+	void BeginTick()
+	{
+		Published.Clear();
+		for (T& event : Pending)
+			Published.Push(std::move(event));
+		Pending.clear();
+	}
+
+	[[nodiscard]] std::span<const T> Items() const noexcept
+	{
+		return Published.Items();
+	}
+
+	[[nodiscard]] bool Empty() const noexcept
+	{
+		return Published.Empty();
+	}
+
+	[[nodiscard]] std::size_t Size() const noexcept
+	{
+		return Published.Size();
+	}
+
+	[[nodiscard]] std::size_t PendingCount() const noexcept
+	{
+		return Pending.size();
+	}
+
+	void Reserve(std::size_t capacity)
+	{
+		Published.Reserve(capacity);
+		Pending.reserve(capacity);
+	}
+
+private:
+	EventBuffer<T> Published;
+	std::vector<T> Pending;
+};

--- a/engine/include/ecs/World.h
+++ b/engine/include/ecs/World.h
@@ -22,6 +22,7 @@
 
 // Forward declarations — defined in their own headers.
 class CommandBuffer;
+class World;
 template <typename... Accessors> class Query;
 
 // ─── ComponentMeta ──────────────────────────────────────────────────────────
@@ -34,6 +35,11 @@ struct ComponentMeta
     size_t           Size;
     size_t           Alignment;
     bool             IsTag;     // zero-size marker; no per-entity column
+
+    // Type-erased OnRemove dispatch for paths that cannot name T: entity
+    // destruction and World teardown. Typed remove paths dispatch the trait
+    // directly. Null when T has no OnRemove hook or is a tag.
+    void (*OnRemoveHook)(const void* component, World& world, EntityId entity) = nullptr;
 };
 
 struct ComponentBatchItem
@@ -60,8 +66,14 @@ class World
 
 public:
     World() = default;
+
+    // Teardown order contract: live components' OnRemove hooks fire first,
+    // while resources are still reachable, then resources are destroyed.
+    // Reversed, retain/release components could not reach their services and
+    // would leak their external handles on unload.
     ~World()
     {
+        DrainRemoveHooks();
         ClearOwnedTypeErased(Resources);
         ClearOwnedTypeErased(LegacyStores);
     }
@@ -78,6 +90,7 @@ public:
     {
         if (this != &other)
         {
+            DrainRemoveHooks();
             ClearOwnedTypeErased(Resources);
             ClearOwnedTypeErased(LegacyStores);
             MoveFrom(std::move(other));
@@ -129,6 +142,12 @@ public:
         meta.Size      = size;
         meta.Alignment = align;
         meta.IsTag     = std::is_empty_v<T>;
+        if constexpr (!std::is_empty_v<T> && ComponentHasOnRemove<T>)
+        {
+            meta.OnRemoveHook = [](const void* ptr, World& w, EntityId e) {
+                ComponentTraits<T>::OnRemove(*static_cast<const T*>(ptr), w, e);
+            };
+        }
         ComponentMetas.push_back(meta);
 
         return id;
@@ -202,6 +221,10 @@ public:
 
         EntityLocation loc  = Entities.GetLocation(entity);
         Archetype&     arch = *ArchetypeList[loc.ArchetypeId];
+
+        // Hooks fire before the swap-remove so they observe the destroyed
+        // entity's own component values, not a moved neighbor's.
+        FireRemoveHooks(entity, loc);
 
         EntityIndex moved = arch.RemoveRow(loc.ChunkIndex, loc.RowIndex);
         if (moved != InvalidEntityIndex)
@@ -826,6 +849,11 @@ private:
     EntityRegistry                          Entities;
     std::vector<std::unique_ptr<Archetype>> ArchetypeList;
 
+    // Index-aligned with ArchetypeList: the component ids in this archetype
+    // that carry an OnRemove hook, in column order. Empty for the common
+    // hook-free archetype, so destruction pays one lookup and one branch.
+    std::vector<std::vector<ComponentId>>   HookedRemoveIdsByArchetype;
+
     struct SigHash
     {
         size_t operator()(const ArchetypeSignature& s) const noexcept
@@ -883,6 +911,7 @@ private:
     {
         Entities = std::move(other.Entities);
         ArchetypeList = std::move(other.ArchetypeList);
+        HookedRemoveIdsByArchetype = std::move(other.HookedRemoveIdsByArchetype);
         SignatureToArchetype = std::move(other.SignatureToArchetype);
         ComponentMetas = std::move(other.ComponentMetas);
         TypeToId = std::move(other.TypeToId);
@@ -905,6 +934,58 @@ private:
     uint32_t GenerationForIndex(EntityIndex index) const
     {
         return Entities.GenerationForIndex(index);
+    }
+
+    // Fire OnRemove for every hooked component of one live row, in column
+    // (registration) order — deterministic. Entity destruction cannot name
+    // component types, so dispatch goes through the pointers captured at
+    // registration. One vector index + empty check for hook-free archetypes.
+    void FireRemoveHooks(EntityId entity, const EntityLocation& loc)
+    {
+        const auto& hooked = HookedRemoveIdsByArchetype[loc.ArchetypeId];
+        if (hooked.empty())
+            return;
+
+        Chunk* ch = ArchetypeList[loc.ArchetypeId]->Chunks[loc.ChunkIndex].get();
+        ScopedLifecycleHook hookScope(*this);
+        for (const ComponentId id : hooked)
+        {
+            const uint32_t col = ch->FindColumn(id);
+            assert(col != UINT32_MAX && "Hooked component missing its column");
+            const void* ptr = ch->ColumnData(col) + loc.RowIndex * ch->Columns[col].Stride;
+            ComponentMetas[id].OnRemoveHook(ptr, *this, entity);
+        }
+    }
+
+    // Teardown pass: fire OnRemove for every live hooked component so the
+    // hook contract holds on World destruction (see the destructor comment).
+    // Row storage stays intact while hooks run. No-op on moved-from worlds.
+    void DrainRemoveHooks()
+    {
+        for (const auto& archPtr : ArchetypeList)
+        {
+            const auto& hooked = HookedRemoveIdsByArchetype[archPtr->Id];
+            if (hooked.empty())
+                continue;
+
+            for (const auto& chunkPtr : archPtr->Chunks)
+            {
+                Chunk* ch = chunkPtr.get();
+                for (uint32_t row = 0; row < ch->RowCount; ++row)
+                {
+                    const EntityIndex index = ch->EntityIndices()[row];
+                    const EntityId entity{ index, Entities.GenerationForIndex(index) };
+                    ScopedLifecycleHook hookScope(*this);
+                    for (const ComponentId id : hooked)
+                    {
+                        const uint32_t col = ch->FindColumn(id);
+                        const void* ptr =
+                            ch->ColumnData(col) + row * ch->Columns[col].Stride;
+                        ComponentMetas[id].OnRemoveHook(ptr, *this, entity);
+                    }
+                }
+            }
+        }
     }
 
     template <typename Move>
@@ -933,13 +1014,20 @@ private:
         arch->Id        = id;
 
         std::vector<ComponentInfo> cols;
+        std::vector<ComponentId>   hooked;
         for (const auto& meta : ComponentMetas)
-            if (sig.test(meta.Id))
-                cols.push_back(ComponentInfo{ meta.Id, meta.Size, meta.Alignment });
+        {
+            if (!sig.test(meta.Id))
+                continue;
+            cols.push_back(ComponentInfo{ meta.Id, meta.Size, meta.Alignment });
+            if (meta.OnRemoveHook != nullptr)
+                hooked.push_back(meta.Id);
+        }
 
         arch->BuildLayout(cols);
         SignatureToArchetype[sig] = id;
         ArchetypeList.push_back(std::move(arch));
+        HookedRemoveIdsByArchetype.push_back(std::move(hooked));
         return ArchetypeList.back().get();
     }
 };

--- a/engine/include/physics/CharacterMoverPool.h
+++ b/engine/include/physics/CharacterMoverPool.h
@@ -43,6 +43,11 @@ public:
     // CharacterMoverLink); the only indirection is the slot into the pool.
     void Drive(World& world, float dt, const Vec3d& gravity);
 
+    // Release every mover and strip links, so the next Reconcile recreates
+    // them from component state. Called when the registry leaves the physics
+    // domain or detaches: dormant means zero backend presence.
+    void Evict(World& world);
+
     [[nodiscard]] size_t   MoverCount() const;
     [[nodiscard]] uint64_t ReconcilePasses() const { return ReconcileCount; }
 

--- a/engine/include/physics/CharacterMoverPool.h
+++ b/engine/include/physics/CharacterMoverPool.h
@@ -20,10 +20,10 @@ class PhysicsWorld;
 // registry and releases its CharacterVirtuals; the shared PhysicsWorld it
 // points at outlives it (same teardown order as bodies).
 //
-// Reconcile is gated on the World's structural version, like RigidBodyBinding, so a
-// steady frame skips topology work; the pool itself is the physics-side record
-// that lets a destroyed entity's mover be reclaimed (DestroyEntity fires no hook
-// and the link vanishes with the entity).
+// Reconcile is gated on the World's structural version, like RigidBodyBinding,
+// so a steady frame skips topology work; the pool itself is the physics-side
+// record that lets a destroyed entity's mover be reclaimed (CharacterMoverLink
+// is a hook-free handle, so it vanishes silently with the entity).
 //=============================================================================
 class CharacterMoverPool
 {

--- a/engine/include/physics/CharacterMoverPool.h
+++ b/engine/include/physics/CharacterMoverPool.h
@@ -11,15 +11,16 @@ class PhysicsWorld;
 //=============================================================================
 // CharacterMoverPool
 //
-// Per-registry ECS<->character bridge, the character analogue of PhysicsScene.
+// Per-registry ECS<->character bridge, the character analogue of RigidBodyBinding.
 // A CharacterMover owns a Jolt CharacterVirtual and is not trivially copyable,
 // so it cannot live in a chunk; the movers live here in a dense pool with a free
 // list (so a slot stays valid for the mover's lifetime) and each controller
-// entity carries its slot in a CharacterMoverLink component. Stored as a World
-// resource, so it dies with the zone and releases its CharacterVirtuals; the
-// shared PhysicsWorld it points at outlives it (same teardown order as bodies).
+// entity carries its slot in a CharacterMoverLink component. Stored in
+// Registry::Resources beside the other physics bindings, so it dies with the
+// registry and releases its CharacterVirtuals; the shared PhysicsWorld it
+// points at outlives it (same teardown order as bodies).
 //
-// Reconcile is gated on the World's structural version, like PhysicsScene, so a
+// Reconcile is gated on the World's structural version, like RigidBodyBinding, so a
 // steady frame skips topology work; the pool itself is the physics-side record
 // that lets a destroyed entity's mover be reclaimed (DestroyEntity fires no hook
 // and the link vanishes with the entity).

--- a/engine/include/physics/PhysicsConstraintTypes.h
+++ b/engine/include/physics/PhysicsConstraintTypes.h
@@ -12,14 +12,10 @@
 // Backend-free, like PhysicsTypes.h. The backend's whole contract is: drive
 // this follower-local frame toward this world-space frame, one-way, while the
 // follower collides normally. It never sees the target entity or its local
-// attachment frame — frame and velocity composition belong to the ECS-side
+// attachment frame; frame and velocity composition belong to the ECS-side
 // binding. The hidden realization never leaks through these types.
 //=============================================================================
 
-// Generational handle to a constraint inside a PhysicsWorld. Unlike body ids,
-// constraint handles live in ECS link components and outlive breaks in
-// telemetry queries, so slot reuse without a generation would be an ABA
-// defect. A stale handle never resolves.
 struct PhysicsConstraintId
 {
     static constexpr uint32_t kInvalid = 0xffffffffu;
@@ -33,8 +29,8 @@ struct PhysicsConstraintId
 
 enum class PoseDriveResponse : uint8_t
 {
-    Locked, // rigid relative-pose preservation
-    Spring, // lags and recovers under FrequencyHz / DampingRatio
+    Locked,
+    Spring,
 };
 
 struct LinearPoseDriveSettings
@@ -53,27 +49,28 @@ struct AngularPoseDriveSettings
     float MaxTorque = std::numeric_limits<float>::infinity();
 };
 
-// Everything needed to create one driven pose constraint. The follower must
-// be a dynamic body in the same world.
 struct DrivenPoseConstraintDesc
 {
     PhysicsBodyId Follower;
 
-    // The attachment frame on the follower, in body space. The backend drives
-    // this frame toward the target's world frame.
+    // Attachment frame on the follower, in body space. The backend drives this
+    // frame toward the target's world frame.
     BodyTransform FollowerLocalFrame{ Vec3d::Zero(), Quatf::Identity() };
 
     LinearPoseDriveSettings LinearDrive;
     AngularPoseDriveSettings AngularDrive;
 
-    uint64_t UserData = 0; // opaque tag for the ECS bridge, like BodyDesc::UserData
+    uint64_t UserData = 0;
 };
 
-// The per-step target input. A constraint must be refreshed between steps:
-// the target is per-step input exactly like a kinematic body's transform.
+// Per-step target input. WorldFrame is the target frame at the beginning of the
+// upcoming physics step. LinearVelocity and AngularVelocity describe how that
+// frame moves through the step, so locked response corrects the current error
+// and adds feed-forward motion exactly once.
+//
 // Velocities are evaluated at the frame origin (v + w x r for off-center
-// frames), not at the target object's origin — that composition is the
-// caller's job.
+// frames), not at the target object's origin; that composition is the caller's
+// job.
 struct DrivenPoseTarget
 {
     BodyTransform WorldFrame{ Vec3d::Zero(), Quatf::Identity() };
@@ -85,11 +82,15 @@ struct DrivenPoseTarget
     bool Teleported = false;
 };
 
-// Read after a step, until the constraint is removed.
+// Read after a step, until the constraint is removed. The velocity-drive
+// prototype cannot report physical force or torque because it does not expose a
+// solver impulse. These diagnostics therefore name exactly what was commanded;
+// P3 replaces them with force/torque only when a real solver-side realization
+// can aggregate impulses over the outer fixed step.
 struct PhysicsConstraintTelemetry
 {
-    float PositionError = 0.0f;  // meters, before this step's drive
-    float AngularError = 0.0f;   // radians, before this step's drive
-    float AppliedForce = 0.0f;   // newtons realized by this step's drive
-    float AppliedTorque = 0.0f;  // newton-meters realized by this step's drive
+    float PositionError = 0.0f;
+    float AngularError = 0.0f;
+    float CommandedLinearSpeed = 0.0f;
+    float CommandedAngularSpeed = 0.0f;
 };

--- a/engine/include/physics/PhysicsConstraintTypes.h
+++ b/engine/include/physics/PhysicsConstraintTypes.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+#include <math/Vec.h>
+#include <physics/PhysicsTypes.h>
+
+//=============================================================================
+// Driven pose constraint vocabulary
+//
+// Backend-free, like PhysicsTypes.h. The backend's whole contract is: drive
+// this follower-local frame toward this world-space frame, one-way, while the
+// follower collides normally. It never sees the target entity or its local
+// attachment frame — frame and velocity composition belong to the ECS-side
+// binding. The hidden realization never leaks through these types.
+//=============================================================================
+
+// Generational handle to a constraint inside a PhysicsWorld. Unlike body ids,
+// constraint handles live in ECS link components and outlive breaks in
+// telemetry queries, so slot reuse without a generation would be an ABA
+// defect. A stale handle never resolves.
+struct PhysicsConstraintId
+{
+    static constexpr uint32_t kInvalid = 0xffffffffu;
+
+    uint32_t Index = kInvalid;
+    uint32_t Generation = 0;
+
+    [[nodiscard]] bool IsValid() const { return Index != kInvalid; }
+    friend bool operator==(PhysicsConstraintId, PhysicsConstraintId) = default;
+};
+
+enum class PoseDriveResponse : uint8_t
+{
+    Locked, // rigid relative-pose preservation
+    Spring, // lags and recovers under FrequencyHz / DampingRatio
+};
+
+struct LinearPoseDriveSettings
+{
+    PoseDriveResponse Response = PoseDriveResponse::Locked;
+    float FrequencyHz = 0.0f;
+    float DampingRatio = 1.0f;
+    float MaxForce = std::numeric_limits<float>::infinity();
+};
+
+struct AngularPoseDriveSettings
+{
+    PoseDriveResponse Response = PoseDriveResponse::Locked;
+    float FrequencyHz = 0.0f;
+    float DampingRatio = 1.0f;
+    float MaxTorque = std::numeric_limits<float>::infinity();
+};
+
+// Everything needed to create one driven pose constraint. The follower must
+// be a dynamic body in the same world.
+struct DrivenPoseConstraintDesc
+{
+    PhysicsBodyId Follower;
+
+    // The attachment frame on the follower, in body space. The backend drives
+    // this frame toward the target's world frame.
+    BodyTransform FollowerLocalFrame{ Vec3d::Zero(), Quatf::Identity() };
+
+    LinearPoseDriveSettings LinearDrive;
+    AngularPoseDriveSettings AngularDrive;
+
+    uint64_t UserData = 0; // opaque tag for the ECS bridge, like BodyDesc::UserData
+};
+
+// The per-step target input. A constraint must be refreshed between steps:
+// the target is per-step input exactly like a kinematic body's transform.
+// Velocities are evaluated at the frame origin (v + w x r for off-center
+// frames), not at the target object's origin — that composition is the
+// caller's job.
+struct DrivenPoseTarget
+{
+    BodyTransform WorldFrame{ Vec3d::Zero(), Quatf::Identity() };
+    Vec3d LinearVelocity = Vec3d::Zero();
+    Vec3d AngularVelocity = Vec3d::Zero();
+
+    // A discontinuity: the follower snaps to the frame instead of chasing it,
+    // so a teleport never manufactures an enormous synthetic velocity.
+    bool Teleported = false;
+};
+
+// Read after a step, until the constraint is removed.
+struct PhysicsConstraintTelemetry
+{
+    float PositionError = 0.0f;  // meters, before this step's drive
+    float AngularError = 0.0f;   // radians, before this step's drive
+    float AppliedForce = 0.0f;   // newtons realized by this step's drive
+    float AppliedTorque = 0.0f;  // newton-meters realized by this step's drive
+};

--- a/engine/include/physics/PhysicsStepSystem.h
+++ b/engine/include/physics/PhysicsStepSystem.h
@@ -11,13 +11,13 @@ struct PhysicsContext;
 // Frame orchestration for physics, scheduled in the Simulate phase's Physics
 // step (it implements Physics(PhysicsContext&), detected by HasPhysics). Owns,
 // by value, the one shared simulation and collision cache for all active zones.
-// Per tick: sync each active registry's PhysicsScene into the world, step once at
+// Per tick: sync each active registry's RigidBodyBinding into the world, step once at
 // a fixed substep count, then sync resolved transforms back.
 //
 // The world and cache are plain members (no refcounting): they outlive every
 // zone registry because EngineSchedule (which owns this system) is destroyed
-// after ZoneRuntime (which owns the registries and their PhysicsScenes). So a
-// PhysicsScene can hold a raw PhysicsWorld* and clean up its bodies safely.
+// after ZoneRuntime (which owns the registries and their RigidBodyBindings). So a
+// RigidBodyBinding can hold a raw PhysicsWorld* and clean up its bodies safely.
 //=============================================================================
 class PhysicsStepSystem
 {

--- a/engine/include/physics/PhysicsStepSystem.h
+++ b/engine/include/physics/PhysicsStepSystem.h
@@ -9,16 +9,11 @@ struct RegistryResidencyContext;
 //=============================================================================
 // PhysicsStepSystem
 //
-// Frame orchestration for physics, scheduled in the Simulate phase's Physics
-// step (it implements Physics(PhysicsContext&), detected by HasPhysics). Owns,
-// by value, the one shared simulation and collision cache for all active zones.
-// Per tick: sync each active registry's RigidBodyBinding into the world, step once at
-// a fixed substep count, then sync resolved transforms back.
-//
-// The world and cache are plain members (no refcounting): they outlive every
-// zone registry because EngineSchedule (which owns this system) is destroyed
-// after ZoneRuntime (which owns the registries and their RigidBodyBindings). So a
-// RigidBodyBinding can hold a raw PhysicsWorld* and clean up its bodies safely.
+// Owns the one shared PhysicsWorld and orchestrates registry-local backend
+// bindings. RegistryResidency runs once per rendered frame before the frame view:
+// it evicts registries leaving physics, restores registries entering physics,
+// and performs unconditional final teardown for Detaching registries. Physics
+// then synchronizes every active registry, steps once, and pulls results back.
 //=============================================================================
 class PhysicsStepSystem
 {
@@ -26,14 +21,8 @@ public:
     PhysicsStepSystem();
     ~PhysicsStepSystem();
 
-    void Physics(PhysicsContext& ctx);
-
-    // Lifecycle edges for retained physics state, dispatched by the
-    // RegistryResidency frame phase: a registry leaving the physics domain
-    // (dormancy or detach) evicts its backend objects while the registry is
-    // still readable. Entering needs nothing here — eviction's link strips
-    // bump the structural version, so the next sync's reconcile restores.
     void RegistryResidency(RegistryResidencyContext& ctx);
+    void Physics(PhysicsContext& ctx);
 
     [[nodiscard]] PhysicsWorld& GetSimulation() { return Simulation; }
     [[nodiscard]] CollisionShapeCache& GetShapeCache() { return Shapes; }

--- a/engine/include/physics/PhysicsStepSystem.h
+++ b/engine/include/physics/PhysicsStepSystem.h
@@ -4,6 +4,7 @@
 #include <physics/PhysicsWorld.h>
 
 struct PhysicsContext;
+struct RegistryResidencyContext;
 
 //=============================================================================
 // PhysicsStepSystem
@@ -26,6 +27,13 @@ public:
     ~PhysicsStepSystem();
 
     void Physics(PhysicsContext& ctx);
+
+    // Lifecycle edges for retained physics state, dispatched by the
+    // RegistryResidency frame phase: a registry leaving the physics domain
+    // (dormancy or detach) evicts its backend objects while the registry is
+    // still readable. Entering needs nothing here — eviction's link strips
+    // bump the structural version, so the next sync's reconcile restores.
+    void RegistryResidency(RegistryResidencyContext& ctx);
 
     [[nodiscard]] PhysicsWorld& GetSimulation() { return Simulation; }
     [[nodiscard]] CollisionShapeCache& GetShapeCache() { return Shapes; }

--- a/engine/include/physics/PhysicsTypes.h
+++ b/engine/include/physics/PhysicsTypes.h
@@ -3,6 +3,9 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <math/Quat.h>
+#include <math/Vec.h>
+
 //=============================================================================
 // Physics public vocabulary
 //
@@ -54,4 +57,12 @@ struct std::hash<PhysicsBodyId>
     {
         return std::hash<uint32_t>{}(id.Value);
     }
+};
+
+// A body-space or world-space pose in facade vocabulary. Also the frame type
+// for driven pose constraints (see PhysicsConstraintTypes.h).
+struct BodyTransform
+{
+    Vec3d Position;
+    Quatf Rotation;
 };

--- a/engine/include/physics/PhysicsWorld.h
+++ b/engine/include/physics/PhysicsWorld.h
@@ -6,6 +6,7 @@
 #include <math/Quat.h>
 #include <math/Vec.h>
 #include <physics/CollisionShape.h>
+#include <physics/PhysicsConstraintTypes.h>
 #include <physics/PhysicsTypes.h>
 
 //=============================================================================
@@ -36,6 +37,16 @@ struct PhysicsWorldConfig
     uint32_t MaxBodies = 10240;
     uint32_t MaxBodyPairs = 16384;
     uint32_t MaxContactConstraints = 8192;
+
+    // Ceiling on the error-closing speed a driven pose constraint commands,
+    // beyond the target frame's own velocity (which is never capped). Discrete
+    // collision cannot resolve arbitrary closing speeds — an uncapped locked
+    // drive tunnels through geometry when the error is large. 50 m/s crosses
+    // ~0.8 m per 60 Hz step, within what room-scale geometry resolves; thin
+    // geometry that needs more headroom is a motion-quality concern on the
+    // body, not the constraint's.
+    float MaxDriveClosingSpeed = 50.0f;
+    float MaxDriveClosingAngularSpeed = 30.0f; // radians/second
 };
 
 // Everything needed to create one body. Backend-free: the shape is described by
@@ -60,12 +71,6 @@ struct BodyDesc
     float GravityScale = 1.0f;
     float LinearDamping = 0.05f;
     float AngularDamping = 0.05f;
-};
-
-struct BodyTransform
-{
-    Vec3d Position;
-    Quatf Rotation;
 };
 
 class PhysicsWorld
@@ -110,6 +115,27 @@ public:
     [[nodiscard]] uint64_t GetUserData(PhysicsBodyId id) const;
     [[nodiscard]] uint32_t BodyCount() const;
 
+    // --- Driven pose constraints (used by DrivenPoseBinding, not gameplay) --
+    //
+    // One-way: the follower is driven toward the target frame and keeps
+    // colliding; nothing feeds back into whatever produced the frame. Targets
+    // are per-step input — SetDrivenPoseTarget must be called between steps
+    // for every live constraint. An unrefreshed constraint is an orchestration
+    // bug: debug builds assert, release builds skip driving it for the step
+    // and count it (StaleRefreshCount). RemoveBody invalidates constraints
+    // referencing the removed body first, so a dependent constraint can never
+    // dangle; removing an invalidated handle is a safe no-op in any order.
+
+    [[nodiscard]] PhysicsConstraintId AddDrivenPoseConstraint(const DrivenPoseConstraintDesc& desc);
+    void RemoveConstraint(PhysicsConstraintId id);
+    [[nodiscard]] bool IsConstraintValid(PhysicsConstraintId id) const;
+
+    void SetDrivenPoseTarget(PhysicsConstraintId id, const DrivenPoseTarget& target);
+    [[nodiscard]] PhysicsConstraintTelemetry GetConstraintTelemetry(PhysicsConstraintId id) const;
+
+    [[nodiscard]] uint32_t ConstraintCount() const;
+    [[nodiscard]] uint64_t StaleRefreshCount() const;
+
     // Backend access for in-module collaborators (queries, scene, character).
     // Returns an incomplete type here; only physics .cpp files that include the
     // internal header can use it, which is the firewall.
@@ -117,6 +143,8 @@ public:
     [[nodiscard]] const PhysicsWorldImpl& Internal() const { return *Impl; }
 
 private:
+    void DriveConstraints(float dt);
+
     std::unique_ptr<PhysicsWorldImpl> Impl;
     const CollisionShapeCache* ShapeCache = nullptr;
 };

--- a/engine/include/physics/PhysicsWorld.h
+++ b/engine/include/physics/PhysicsWorld.h
@@ -80,6 +80,7 @@ public:
     [[nodiscard]] float GetGravityScale(PhysicsBodyId id) const;
     void SetGravityScale(PhysicsBodyId id, float scale);
 
+    [[nodiscard]] bool IsBodyActive(PhysicsBodyId id) const;
     void WakeBody(PhysicsBodyId id);
 
     [[nodiscard]] uint64_t GetUserData(PhysicsBodyId id) const;

--- a/engine/include/physics/PhysicsWorld.h
+++ b/engine/include/physics/PhysicsWorld.h
@@ -11,63 +11,39 @@
 
 //=============================================================================
 // PhysicsWorld
-//
-// Owns and advances one simulation, nothing more. It holds the backend (Jolt)
-// instance and the scaffolding it cannot exist without (temp allocator, single-
-// thread job system, layer filters) behind a PIMPL, so this header pulls in no
-// backend type. ECS-free and renderer-free: tests construct it directly and
-// step it without graphics.
-//
-// Responsibility boundary (see the physics plan): body lifetime/ECS binding
-// lives in RigidBodyBinding, read-only spatial queries in PhysicsQueries, frame
-// orchestration in PhysicsStepSystem. Those collaborators reach the backend
-// through Internal(); gameplay never does.
 //=============================================================================
 
-struct PhysicsWorldImpl; // defined in src/physics/PhysicsWorldImpl.h (Jolt-side)
+struct PhysicsWorldImpl;
 class CollisionShapeCache;
 
 struct PhysicsWorldConfig
 {
     Vec3d Gravity = Vec3d(0.0f, -9.81f, 0.0f);
 
-    // Backend capacity hints. Sized for streamed room-scale zones; raise if a
-    // game holds more simultaneous bodies. These bound allocations, not a hard
-    // game limit beyond the backend's own.
     uint32_t MaxBodies = 10240;
     uint32_t MaxBodyPairs = 16384;
     uint32_t MaxContactConstraints = 8192;
 
     // Ceiling on the error-closing speed a driven pose constraint commands,
-    // beyond the target frame's own velocity (which is never capped). Discrete
-    // collision cannot resolve arbitrary closing speeds — an uncapped locked
-    // drive tunnels through geometry when the error is large. 50 m/s crosses
-    // ~0.8 m per 60 Hz step, within what room-scale geometry resolves; thin
-    // geometry that needs more headroom is a motion-quality concern on the
-    // body, not the constraint's.
+    // beyond the target frame's own velocity. Discrete collision cannot resolve
+    // arbitrary closing speeds; the cap keeps large initial error from becoming
+    // an immediate tunneling request.
     float MaxDriveClosingSpeed = 50.0f;
-    float MaxDriveClosingAngularSpeed = 30.0f; // radians/second
+    float MaxDriveClosingAngularSpeed = 30.0f;
 };
 
-// Everything needed to create one body. Backend-free: the shape is described by
-// CollisionShape, the body is categorized by CollisionLayer, and UserData is an
-// opaque tag the ECS bridge uses to carry the owning entity id.
 struct BodyDesc
 {
-    // A valid MeshShape (a cooked shape in the bound CollisionShapeCache) takes
-    // precedence over the inline primitive Shape.
     CollisionShape Shape;
     CollisionShapeHandle MeshShape;
     Vec3d Position = Vec3d::Zero();
     Quatf Rotation = Quatf::Identity();
     BodyMotion Motion = BodyMotion::Static;
     CollisionLayer Layer = CollisionLayer::Moving;
-    float Mass = 1.0f; // dynamic only; <= 0 asks the backend to derive it from the shape
+    float Mass = 1.0f;
     bool IsTrigger = false;
     uint64_t UserData = 0;
 
-    // Dynamic-body motion parameters; ignored for static bodies. Damping
-    // defaults match the backend's, so omitting them changes nothing.
     float GravityScale = 1.0f;
     float LinearDamping = 0.05f;
     float AngularDamping = 0.05f;
@@ -84,15 +60,11 @@ public:
     PhysicsWorld(PhysicsWorld&&) noexcept;
     PhysicsWorld& operator=(PhysicsWorld&&) noexcept;
 
-    // Bind the cache that resolves BodyDesc::MeshShape handles to cooked shapes.
-    // Not owned. PhysicsStepSystem wires the shared cache here.
     void SetShapeCache(const CollisionShapeCache* cache);
 
-    // Advance the simulation by dt seconds. collisionSteps subdivides dt for
-    // contact stability; a fixed value keeps the step reproducible.
     void Step(float dt, int collisionSteps = 1);
 
-    // --- Body interface (used by RigidBodyBinding, not gameplay) ---------------
+    // --- Body interface ------------------------------------------------------
     [[nodiscard]] PhysicsBodyId AddBody(const BodyDesc& desc);
     void RemoveBody(PhysicsBodyId id);
 
@@ -105,9 +77,7 @@ public:
     [[nodiscard]] Vec3d GetAngularVelocity(PhysicsBodyId id) const;
     void SetAngularVelocity(PhysicsBodyId id, const Vec3d& velocity);
 
-    // Per-body gravity multiplier: 0 suspends, 1 is world gravity. Does not
-    // wake a sleeping body — pair with WakeBody when a slept body must respond
-    // to the change. (Velocity writes, by contrast, wake on their own.)
+    [[nodiscard]] float GetGravityScale(PhysicsBodyId id) const;
     void SetGravityScale(PhysicsBodyId id, float scale);
 
     void WakeBody(PhysicsBodyId id);
@@ -115,17 +85,10 @@ public:
     [[nodiscard]] uint64_t GetUserData(PhysicsBodyId id) const;
     [[nodiscard]] uint32_t BodyCount() const;
 
-    // --- Driven pose constraints (used by DrivenPoseBinding, not gameplay) --
-    //
-    // One-way: the follower is driven toward the target frame and keeps
-    // colliding; nothing feeds back into whatever produced the frame. Targets
-    // are per-step input — SetDrivenPoseTarget must be called between steps
-    // for every live constraint. An unrefreshed constraint is an orchestration
-    // bug: debug builds assert, release builds skip driving it for the step
-    // and count it (StaleRefreshCount). RemoveBody invalidates constraints
-    // referencing the removed body first, so a dependent constraint can never
-    // dangle; removing an invalidated handle is a safe no-op in any order.
-
+    // --- Driven pose constraints -------------------------------------------
+    // Targets are refreshed for every live constraint before each step. An
+    // unrefreshed constraint is an orchestration bug: debug builds assert;
+    // release builds skip it and count the miss.
     [[nodiscard]] PhysicsConstraintId AddDrivenPoseConstraint(const DrivenPoseConstraintDesc& desc);
     void RemoveConstraint(PhysicsConstraintId id);
     [[nodiscard]] bool IsConstraintValid(PhysicsConstraintId id) const;
@@ -136,9 +99,6 @@ public:
     [[nodiscard]] uint32_t ConstraintCount() const;
     [[nodiscard]] uint64_t StaleRefreshCount() const;
 
-    // Backend access for in-module collaborators (queries, scene, character).
-    // Returns an incomplete type here; only physics .cpp files that include the
-    // internal header can use it, which is the firewall.
     [[nodiscard]] PhysicsWorldImpl& Internal() { return *Impl; }
     [[nodiscard]] const PhysicsWorldImpl& Internal() const { return *Impl; }
 

--- a/engine/include/physics/PhysicsWorld.h
+++ b/engine/include/physics/PhysicsWorld.h
@@ -54,6 +54,12 @@ struct BodyDesc
     float Mass = 1.0f; // dynamic only; <= 0 asks the backend to derive it from the shape
     bool IsTrigger = false;
     uint64_t UserData = 0;
+
+    // Dynamic-body motion parameters; ignored for static bodies. Damping
+    // defaults match the backend's, so omitting them changes nothing.
+    float GravityScale = 1.0f;
+    float LinearDamping = 0.05f;
+    float AngularDamping = 0.05f;
 };
 
 struct BodyTransform
@@ -90,6 +96,16 @@ public:
 
     [[nodiscard]] Vec3d GetLinearVelocity(PhysicsBodyId id) const;
     void SetLinearVelocity(PhysicsBodyId id, const Vec3d& velocity);
+
+    [[nodiscard]] Vec3d GetAngularVelocity(PhysicsBodyId id) const;
+    void SetAngularVelocity(PhysicsBodyId id, const Vec3d& velocity);
+
+    // Per-body gravity multiplier: 0 suspends, 1 is world gravity. Does not
+    // wake a sleeping body — pair with WakeBody when a slept body must respond
+    // to the change. (Velocity writes, by contrast, wake on their own.)
+    void SetGravityScale(PhysicsBodyId id, float scale);
+
+    void WakeBody(PhysicsBodyId id);
 
     [[nodiscard]] uint64_t GetUserData(PhysicsBodyId id) const;
     [[nodiscard]] uint32_t BodyCount() const;

--- a/engine/include/physics/PhysicsWorld.h
+++ b/engine/include/physics/PhysicsWorld.h
@@ -18,7 +18,7 @@
 // step it without graphics.
 //
 // Responsibility boundary (see the physics plan): body lifetime/ECS binding
-// lives in PhysicsScene, read-only spatial queries in PhysicsQueries, frame
+// lives in RigidBodyBinding, read-only spatial queries in PhysicsQueries, frame
 // orchestration in PhysicsStepSystem. Those collaborators reach the backend
 // through Internal(); gameplay never does.
 //=============================================================================
@@ -81,7 +81,7 @@ public:
     // contact stability; a fixed value keeps the step reproducible.
     void Step(float dt, int collisionSteps = 1);
 
-    // --- Body interface (used by PhysicsScene, not gameplay) ---------------
+    // --- Body interface (used by RigidBodyBinding, not gameplay) ---------------
     [[nodiscard]] PhysicsBodyId AddBody(const BodyDesc& desc);
     void RemoveBody(PhysicsBodyId id);
 

--- a/engine/include/physics/RigidBodyBinding.h
+++ b/engine/include/physics/RigidBodyBinding.h
@@ -65,6 +65,15 @@ public:
     // Post-step: write dynamic bodies' resolved transforms back to LocalTransform.
     void SyncFromPhysics(World& world);
 
+    // Remove every body from the shared simulation after capturing its latest
+    // state into components, stripping links so the next SyncToPhysics
+    // reconcile recreates the bodies from component-authoritative state.
+    // Called when the registry leaves the physics domain or detaches: dormant
+    // means zero backend presence — no contacts, no query hits, no solver
+    // cost. Restore needs no dedicated path; the link strips bump the
+    // structural version, making the ordinary reconcile the restore.
+    void Evict(World& world);
+
     [[nodiscard]] size_t BodyCount() const { return Owned.size(); }
 
     // Times the topology reconcile pass has run. A steady frame (no structural

--- a/engine/include/physics/RigidBodyBinding.h
+++ b/engine/include/physics/RigidBodyBinding.h
@@ -28,15 +28,15 @@ inline EntityId UnpackEntity(uint64_t value)
 }
 
 //=============================================================================
-// PhysicsScene
+// RigidBodyBinding
 //
 // Per-registry ECS<->body bridge. Backend-free: it drives the PhysicsWorld
-// facade, never Jolt. Stored as a World resource, so it is owned by the World
-// (one per registry) and its destructor removes that zone's bodies from the
-// shared PhysicsWorld when the zone unloads. The world is a raw pointer, not
-// owned: it always outlives this scene because ZoneRuntime (registries + their
-// PhysicsScenes) is destroyed before EngineSchedule (the PhysicsStepSystem that
-// owns the world). No refcounting.
+// facade, never Jolt. Stored in Registry::Resources — the owner of per-registry
+// backend bindings — so it dies with the registry and its destructor removes
+// that zone's bodies from the shared PhysicsWorld when the zone unloads. The
+// world is a raw pointer, not owned: it always outlives this binding because
+// ZoneRuntime (registries + their RigidBodyBindings) is destroyed before
+// EngineSchedule (the PhysicsStepSystem that owns the world). No refcounting.
 //
 // Steady-state cost is proportional to what moved, not what exists. The body
 // handle lives in a per-entity PhysicsBodyLink component, so the per-frame
@@ -48,14 +48,14 @@ inline EntityId UnpackEntity(uint64_t value)
 // PhysicsBodyLink vanishes with it, so nothing in the ECS can report the dead
 // body. Reconcile sweeps Owned for dead or collider-less entities.
 //=============================================================================
-class PhysicsScene
+class RigidBodyBinding
 {
 public:
-    explicit PhysicsScene(PhysicsWorld& world);
-    ~PhysicsScene();
+    explicit RigidBodyBinding(PhysicsWorld& world);
+    ~RigidBodyBinding();
 
-    PhysicsScene(const PhysicsScene&) = delete;
-    PhysicsScene& operator=(const PhysicsScene&) = delete;
+    RigidBodyBinding(const RigidBodyBinding&) = delete;
+    RigidBodyBinding& operator=(const RigidBodyBinding&) = delete;
 
     // Pre-step: reconcile body topology (gated on the structural version), then
     // push kinematic transforms into the simulation.

--- a/engine/include/physics/RigidBodyBinding.h
+++ b/engine/include/physics/RigidBodyBinding.h
@@ -44,9 +44,10 @@ inline EntityId UnpackEntity(uint64_t value)
 // reconciled only when the World's structural version changes (an entity or
 // component was created/destroyed/added/removed); a steady frame is a single
 // integer compare. The dense Owned vector is the physics-side record that makes
-// destroy-detection possible: DestroyEntity fires no hook and the entity's
-// PhysicsBodyLink vanishes with it, so nothing in the ECS can report the dead
-// body. Reconcile sweeps Owned for dead or collider-less entities.
+// destroy-detection possible: PhysicsBodyLink is a plain handle with no
+// lifecycle hook — backend residency belongs to binding records, not component
+// hooks — so the link vanishes silently with a destroyed entity and reconcile
+// sweeps Owned for dead or collider-less entities.
 //=============================================================================
 class RigidBodyBinding
 {

--- a/engine/include/physics/ZoneCollisionLoader.h
+++ b/engine/include/physics/ZoneCollisionLoader.h
@@ -10,7 +10,7 @@ class CollisionShapeCache;
 //
 // Loads a level's cooked collision sidecar (written by the level cook): for each
 // entry, restores the pre-baked Jolt blob into `cache` and spawns a static
-// collider entity at its origin. PhysicsScene then turns those into static
+// collider entity at its origin. RigidBodyBinding then turns those into static
 // bodies; they die with the zone's registry. Returns the number loaded.
 //
 // This is how authored brush geometry becomes collidable: zero authoring, world

--- a/engine/include/physics/components/PhysicsBodyLink.h
+++ b/engine/include/physics/components/PhysicsBodyLink.h
@@ -7,7 +7,7 @@
 // PhysicsBodyLink
 //
 // Runtime-only link from a collider entity to its body in the shared
-// PhysicsWorld. PhysicsScene's reconcile adds it when it creates a body and
+// PhysicsWorld. RigidBodyBinding's reconcile adds it when it creates a body and
 // removes it when the body goes away. Never authored, never serialized, never
 // cooked: it is rebuilt every run. Storing the handle in the chunk lets the
 // per-frame transform sync walk (LocalTransform, RigidBody, PhysicsBodyLink) as

--- a/engine/include/physics/components/RigidBody.h
+++ b/engine/include/physics/components/RigidBody.h
@@ -11,8 +11,12 @@
 // dynamics and carries its motion parameters. An entity with a Collider but no
 // RigidBody is treated as static world geometry.
 //
-// Phase 1 is linear-only: angular motion is not integrated yet. Logic lives in
-// the physics systems; this struct holds no behavior.
+// Velocities are the round-trip state: pushed into the body at bind, pulled
+// back after every step for dynamic bodies. GravityScale is pushed every
+// step, so a runtime edit (a held prop going weightless) takes effect on the
+// next tick without a structural change. Damping is applied when the body is
+// created; the backend exposes no cheap per-step setter for it. Logic lives
+// in the physics systems; this struct holds no behavior.
 //=============================================================================
 struct RigidBody
 {
@@ -20,6 +24,13 @@ struct RigidBody
     float Mass = 1.0f; // <= 0 lets the backend derive mass from the shape
     Vec3d LinearVelocity = Vec3d::Zero();
     float GravityScale = 1.0f;
+
+    Vec3d AngularVelocity = Vec3d::Zero(); // radians/second, world space
+
+    // Velocity fraction removed per second, matching the backend's default so
+    // a default component behaves exactly like a body without these fields.
+    float LinearDamping = 0.05f;
+    float AngularDamping = 0.05f;
 };
 
 SENCHA_DECLARE_COMPONENT_TYPE(RigidBody, "sencha.physics.rigid_body");

--- a/engine/include/runtime/FrameDriver.h
+++ b/engine/include/runtime/FrameDriver.h
@@ -29,12 +29,13 @@ enum class FramePhase : int
     ResolveLifecycle = 1,     // Apply window events to RuntimeFrameLoop
     RebuildGraphics = 2,      // Recreate swapchain / swap device resources
     DrainAsyncTasks = 3,      // Run async-task commits (zone attach, asset publish)
-    ScheduleTicks = 4,        // Resolve presentation resets and fixed tick budget
-    Simulate = 5,             // Fixed-step: gameplay + propagation (0..N calls)
-    Update = 6,               // Per-frame game update: camera, HUD, input reactions
-    ExtractRenderPacket = 7,  // Build RenderPacket for this frame
-    Render = 8,               // Submit + present
-    EndFrame = 9,             // Flip buffers, pace, stamp telemetry
+    RegistryResidency = 4,    // Process registry residency transitions; finalize detach
+    ScheduleTicks = 5,        // Resolve presentation resets and fixed tick budget
+    Simulate = 6,             // Fixed-step: gameplay + propagation (0..N calls)
+    Update = 7,               // Per-frame game update: camera, HUD, input reactions
+    ExtractRenderPacket = 8,  // Build RenderPacket for this frame
+    Render = 9,               // Submit + present
+    EndFrame = 10,            // Flip buffers, pace, stamp telemetry
     Count,
 };
 

--- a/engine/include/world/registry/FrameRegistryView.h
+++ b/engine/include/world/registry/FrameRegistryView.h
@@ -1,8 +1,22 @@
 #pragma once
 
+#include <world/registry/EntityRef.h>
 #include <world/registry/Registry.h>
 #include <span>
 
+//=============================================================================
+// FrameRegistryView
+//
+// The frame's iteration view: which registries each domain visits this frame,
+// built once at ScheduleTicks from drain-point-stable lifecycle state. Spans
+// never contain null entries and stay valid until EndFrameView.
+//
+// Resolution is deliberately view-scoped: Find answers only for registries
+// participating this frame, which is the correct default for simulation code —
+// a dormant or detached registry is unresolvable, exactly as if it were gone.
+// Residency-transition consumers get live pointers in their change records;
+// tools and lifecycle orchestration use ZoneRuntime::FindRegistry.
+//=============================================================================
 struct FrameRegistryView
 {
     Registry* Global = nullptr;
@@ -11,4 +25,28 @@ struct FrameRegistryView
     std::span<Registry*> Physics;
     std::span<Registry*> Logic;
     std::span<Registry*> Audio;
+
+    // Global plus every zone in at least one span this frame, in span order
+    // (global first, zones in attach order).
+    std::span<Registry* const> Participating;
+
+    // Resolve a registry participating this frame; null otherwise. Linear over
+    // a handful of registries — index it only when a profile says so.
+    [[nodiscard]] Registry* Find(RegistryId id) const
+    {
+        if (!id.IsValid())
+            return nullptr;
+        for (Registry* registry : Participating)
+            if (registry->Id == id)
+                return registry;
+        return nullptr;
+    }
+
+    // Generational liveness through the view: true only when the ref's
+    // registry participates this frame and the entity is alive in it.
+    [[nodiscard]] bool IsAlive(EntityRef ref) const
+    {
+        const Registry* registry = Find(ref.Registry);
+        return registry != nullptr && registry->Components.IsAlive(ref.Entity);
+    }
 };

--- a/engine/include/world/registry/FrameRegistryView.h
+++ b/engine/include/world/registry/FrameRegistryView.h
@@ -4,18 +4,35 @@
 #include <world/registry/Registry.h>
 #include <span>
 
+// Domain-scoped lookup for simulation code. Callers must choose the span whose
+// participation contract they actually need instead of resolving against the
+// union of every active domain.
+[[nodiscard]] inline Registry* FindRegistry(
+    std::span<Registry* const> registries,
+    RegistryId id)
+{
+    if (!id.IsValid())
+        return nullptr;
+    for (Registry* registry : registries)
+        if (registry->Id == id)
+            return registry;
+    return nullptr;
+}
+
+[[nodiscard]] inline bool IsAliveIn(
+    std::span<Registry* const> registries,
+    EntityRef ref)
+{
+    const Registry* registry = FindRegistry(registries, ref.Registry);
+    return registry != nullptr && registry->Components.IsAlive(ref.Entity);
+}
+
 //=============================================================================
 // FrameRegistryView
 //
 // The frame's iteration view: which registries each domain visits this frame,
 // built once at ScheduleTicks from drain-point-stable lifecycle state. Spans
 // never contain null entries and stay valid until EndFrameView.
-//
-// Resolution is deliberately view-scoped: Find answers only for registries
-// participating this frame, which is the correct default for simulation code —
-// a dormant or detached registry is unresolvable, exactly as if it were gone.
-// Residency-transition consumers get live pointers in their change records;
-// tools and lifecycle orchestration use ZoneRuntime::FindRegistry.
 //=============================================================================
 struct FrameRegistryView
 {
@@ -26,27 +43,19 @@ struct FrameRegistryView
     std::span<Registry*> Logic;
     std::span<Registry*> Audio;
 
-    // Global plus every zone in at least one span this frame, in span order
-    // (global first, zones in attach order).
+    // Global plus every zone in at least one span this frame, in stable order.
     std::span<Registry* const> Participating;
 
-    // Resolve a registry participating this frame; null otherwise. Linear over
-    // a handful of registries — index it only when a profile says so.
-    [[nodiscard]] Registry* Find(RegistryId id) const
+    // Explicitly domain-agnostic resolution for systems that truly operate over
+    // the union. Physics, logic, audio, and rendering code should instead call
+    // FindRegistry with the matching domain span.
+    [[nodiscard]] Registry* FindParticipating(RegistryId id) const
     {
-        if (!id.IsValid())
-            return nullptr;
-        for (Registry* registry : Participating)
-            if (registry->Id == id)
-                return registry;
-        return nullptr;
+        return FindRegistry(Participating, id);
     }
 
-    // Generational liveness through the view: true only when the ref's
-    // registry participates this frame and the entity is alive in it.
-    [[nodiscard]] bool IsAlive(EntityRef ref) const
+    [[nodiscard]] bool IsAliveParticipating(EntityRef ref) const
     {
-        const Registry* registry = Find(ref.Registry);
-        return registry != nullptr && registry->Components.IsAlive(ref.Entity);
+        return IsAliveIn(Participating, ref);
     }
 };

--- a/engine/include/zone/RegistryResidency.h
+++ b/engine/include/zone/RegistryResidency.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdint>
+#include <world/registry/RegistryId.h>
+#include <zone/ZoneParticipation.h>
+
+struct Registry;
+
+//=============================================================================
+// Registry residency transitions
+//
+// ZoneRuntime records one change per registry whose attachment or
+// participation mutated during the drain window, coalesced to first-observed
+// Previous and final Current (intermediate states were never observable to
+// any frame). The batch is processed once per rendered frame in the
+// RegistryResidency phase — after async commits apply lifecycle requests,
+// before the frame view is built — so retained backend state (bodies, movers,
+// constraints, voices) reacts to lifecycle before any frame span can observe
+// the registry, and a Detaching registry gets its final visit while it and
+// all of its resources are still alive. Destruction happens only after the
+// batch is processed.
+//=============================================================================
+
+enum class RegistryResidencyChangeKind : uint8_t
+{
+    // Newly attached this window. Current carries the initial participation;
+    // attach-then-SetParticipation in one window coalesces into this.
+    Attached,
+
+    ParticipationChanged,
+
+    // DestroyZone was requested. Instance stays valid (readable, resources
+    // alive) until the batch has been processed; the registry is destroyed
+    // immediately afterward.
+    Detaching,
+};
+
+struct RegistryResidencyChange
+{
+    RegistryResidencyChangeKind Kind = RegistryResidencyChangeKind::ParticipationChanged;
+
+    RegistryId Id;
+    Registry* Instance = nullptr; // valid while the batch is processed
+
+    ZoneParticipation Previous;
+    ZoneParticipation Current;
+};

--- a/engine/include/zone/WorldPartitionRuntime.h
+++ b/engine/include/zone/WorldPartitionRuntime.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <span>
@@ -12,66 +13,64 @@
 #include <zone/ZoneDemand.h>
 #include <zone/ZoneRuntime.h>
 
-// How one zone's cooked refs become a registry. The game owns this knowledge
-// (component registration, scene deserialization, collision restore); the
-// policy layer only decides WHEN a zone loads.
 struct ZoneLoadRecipe
 {
     AsyncZoneLoader::BuildFn      Build;
     AsyncZoneLoader::FinalizeFn   Finalize;
-    std::shared_ptr<AssetPreload> Preload;   // null when the zone preloads nothing
+    std::shared_ptr<AssetPreload> Preload;
 };
 
 using ZoneLoadRecipeFn = std::function<ZoneLoadRecipe(const ZoneHeader&)>;
 
-// The metadata and policy layer over ZoneRuntime: owns the cooked manifest and
-// decides desired residency; never deserializes scenes, never owns registries.
-// Single-threaded by contract: every method runs on the owner (main) thread.
+// Generational token for one runtime participation floor. Several independent
+// holders may lease the same zone; their minimum flags compose by union, and
+// release order does not matter. A stale token never releases a reused slot.
+struct ParticipationLeaseId
+{
+    static constexpr uint32_t kInvalid = 0xffffffffu;
+
+    uint32_t Index = kInvalid;
+    uint32_t Generation = 0;
+
+    [[nodiscard]] bool IsValid() const { return Index != kInvalid; }
+    friend bool operator==(ParticipationLeaseId, ParticipationLeaseId) = default;
+};
+
+// Metadata and policy layer over ZoneRuntime. It owns cooked streaming demand,
+// authored pins, and runtime participation leases; it never owns registries or
+// game entities. Single-threaded by contract.
 class WorldPartitionRuntime
 {
 public:
     WorldPartitionRuntime(ZoneLoadRecipeFn recipe, WorldPartitionStreamingConfig config);
 
-    // Cooked manifest in; adjacency index built here. Refuses (false, message
-    // in *error) when any zone lacks a CookedSceneRef or when validation
-    // reports any Error-severity record: a broken manifest fails at load time,
-    // not mid-traversal.
     bool LoadManifest(WorldPartitionManifest manifest, std::string* error);
     [[nodiscard]] bool HasManifest() const { return HasManifest_; }
-    [[nodiscard]] const WorldPartitionManifest& Manifest() const;   // asserts HasManifest
+    [[nodiscard]] const WorldPartitionManifest& Manifest() const;
 
-    // The one policy input. Position resolution: candidate zones are those
-    // whose Bounds contain the position; the current focus wins if it is a
-    // candidate (hysteresis at doorway thresholds); otherwise the
-    // smallest-volume candidate, ties broken by ascending zone id; no candidate
-    // keeps the previous focus (sticky: bounds gaps and overhangs are normal
-    // geometry, not focus changes).
     void SetFocus(Vec3d position);
-    // For when position is not meaningful (menus, scripted warps). Asserts the
-    // zone exists in the manifest.
     void SetFocus(ZoneId zone);
     [[nodiscard]] ZoneId FocusZone() const { return Focus_; }
 
+    // Authored/scripted long-lived floor. Existing semantics remain last-writer-
+    // wins because this API names one pin per zone.
     void PinZone(ZoneId zone, ZoneParticipation minimum);
     void UnpinZone(ZoneId zone);
 
-    // The active world-state gameplay tags (dotted names) gating RequiredTags
-    // edges. The game pushes the full set whenever its world state changes
-    // (quest flags, unlocks); demand reflows on the next Update.
+    // Runtime composable floor for relationships and transient work. Leases are
+    // game-held: a physics component does not silently retain zones. Unknown
+    // zones are rejected; stale release is a safe false result.
+    [[nodiscard]] ParticipationLeaseId AcquireParticipationLease(
+        ZoneId zone,
+        ZoneParticipation minimum);
+    bool ReleaseParticipationLease(ParticipationLeaseId lease);
+    [[nodiscard]] bool IsParticipationLeaseValid(ParticipationLeaseId lease) const;
+    [[nodiscard]] size_t ParticipationLeaseCount() const { return ActiveLeaseCount_; }
+
     void SetWorldTags(std::vector<std::string> tags);
 
-    // Once per frame from the owning game system. Computes demand, layers
-    // linger state, and diffs desired against resident plus in-flight: issues
-    // dormant BeginLoad through the recipe, SetParticipation changes,
-    // CancelLoad for undemanded in-flight loads, and RequestDestroy for zones
-    // whose linger expired (destruction lands at the next commit drain, never
-    // mid-frame: the in-flight frame view stays untouched). Never touches the
-    // focus zone's residency.
     void Update(double deltaSeconds, AsyncZoneLoader& loader, ZoneRuntime& zones);
 
-    // Why is this zone resident: rebuilt every Update, includes Lingering
-    // entries, ascending zone id. The surface the streaming telemetry writer
-    // serializes; coordinate there rather than duplicating a record type.
     [[nodiscard]] std::span<const ZoneDemandRecord> DemandRecords() const { return Records_; }
 
 private:
@@ -79,6 +78,14 @@ private:
     {
         ZoneId Zone;
         double Seconds = 0.0;
+    };
+
+    struct ParticipationLeaseSlot
+    {
+        uint32_t Generation = 1;
+        bool Alive = false;
+        ZoneId Zone;
+        ZoneParticipation Minimum;
     };
 
     [[nodiscard]] const ZoneHeader* FindHeader(ZoneId zone) const;
@@ -89,17 +96,14 @@ private:
     WorldPartitionIndex Index_;
     bool HasManifest_ = false;
     ZoneId Focus_;
-    // Last known focus position for proximity demand: the position handed to
-    // SetFocus(Vec3d), or the focus zone's bounds center after SetFocus(ZoneId).
     Vec3d FocusPosition_{};
     bool HasFocusPosition_ = false;
     std::vector<ZonePin> Pins_;
+    std::vector<ParticipationLeaseSlot> LeaseSlots_;
+    std::vector<uint32_t> FreeLeaseSlots_;
+    size_t ActiveLeaseCount_ = 0;
     std::vector<std::string> WorldTags_;
-    // Zones whose destruction is queued for the next drain; still resident
-    // until it runs, so Update must not re-request them.
     std::vector<ZoneId> PendingDestroys_;
-    // Zones this runtime has issued BeginLoad for and not yet seen attach or
-    // cancel; the enumerable half of AsyncZoneLoader::IsLoading.
     std::vector<ZoneId> Issued_;
     std::vector<LingerState> Lingering_;
     std::vector<ZoneDemandRecord> Records_;

--- a/engine/include/zone/WorldPartitionRuntime.h
+++ b/engine/include/zone/WorldPartitionRuntime.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -65,7 +66,13 @@ public:
         ZoneParticipation minimum);
     bool ReleaseParticipationLease(ParticipationLeaseId lease);
     [[nodiscard]] bool IsParticipationLeaseValid(ParticipationLeaseId lease) const;
-    [[nodiscard]] size_t ParticipationLeaseCount() const { return ActiveLeaseCount_; }
+
+    // Forced teardown overrides leases. The owner initiating that teardown must
+    // invalidate the affected zone's tokens before destroying it, so holders can
+    // observe the loss and stale tokens can never release a reused slot.
+    std::size_t InvalidateParticipationLeases(ZoneId zone);
+
+    [[nodiscard]] std::size_t ParticipationLeaseCount() const { return ActiveLeaseCount_; }
 
     void SetWorldTags(std::vector<std::string> tags);
 
@@ -101,7 +108,7 @@ private:
     std::vector<ZonePin> Pins_;
     std::vector<ParticipationLeaseSlot> LeaseSlots_;
     std::vector<uint32_t> FreeLeaseSlots_;
-    size_t ActiveLeaseCount_ = 0;
+    std::size_t ActiveLeaseCount_ = 0;
     std::vector<std::string> WorldTags_;
     std::vector<ZoneId> PendingDestroys_;
     std::vector<ZoneId> Issued_;

--- a/engine/include/zone/ZoneParticipation.h
+++ b/engine/include/zone/ZoneParticipation.h
@@ -10,4 +10,6 @@ struct ZoneParticipation
     // False means the zone is dormant: attached but invisible to every frame
     // span — it cannot affect simulation or presentation.
     [[nodiscard]] bool Any() const { return Visible || Physics || Logic || Audio; }
+
+    bool operator==(const ZoneParticipation&) const = default;
 };

--- a/engine/include/zone/ZoneRuntime.h
+++ b/engine/include/zone/ZoneRuntime.h
@@ -3,9 +3,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <span>
 #include <world/registry/FrameRegistryView.h>
 #include <world/registry/Registry.h>
 #include <vector>
+#include <zone/RegistryResidency.h>
 #include <zone/ZoneId.h>
 #include <zone/ZoneParticipation.h>
 
@@ -46,6 +48,15 @@ public:
 
     std::size_t ZoneCount() const;
 
+    // The residency-change batch accumulated since the last finalize, one
+    // coalesced entry per mutated registry (see RegistryResidency.h). The
+    // RegistryResidency frame phase processes it, then calls
+    // FinalizeResidencyProcessing, which destroys registries marked Detaching
+    // and clears the batch. Instance pointers in the batch are valid until
+    // that finalize call.
+    std::span<const RegistryResidencyChange> ResidencyChanges() const;
+    void FinalizeResidencyProcessing();
+
     // Intended for debug/tools/tests. Runtime systems should consume
     // FrameRegistryView instead of walking ZoneRuntime directly.
     template<typename Fn>
@@ -53,6 +64,8 @@ public:
     {
         for (const auto& loaded : Zones)
         {
+            if (loaded->Detaching)
+                continue;
             fn(loaded->Zone, *loaded->ZoneRegistry, loaded->Participation);
         }
     }
@@ -70,6 +83,13 @@ private:
         ZoneId Zone;
         std::unique_ptr<Registry> ZoneRegistry;
         ZoneParticipation Participation;
+
+        // DestroyZone marks instead of erasing: the registry stays owned and
+        // readable (reachable only through the residency batch) until
+        // FinalizeResidencyProcessing, so retained backend state gets its
+        // final visit while resources are alive. Detaching zones are invisible
+        // to every query and frame span.
+        bool Detaching = false;
     };
 
     LoadedZone* FindLoadedZone(ZoneId zone);
@@ -77,6 +97,13 @@ private:
 
     RegistryId AllocateRegistryId();
     void InvalidateFrameScratch();
+
+    RegistryResidencyChange* FindPendingChange(RegistryId id);
+    void RecordAttached(Registry* registry, ZoneParticipation participation);
+    void RecordParticipationChange(Registry* registry,
+                                   ZoneParticipation previous,
+                                   ZoneParticipation current);
+    void RecordDetaching(Registry* registry, ZoneParticipation previous);
 
     // True between BuildFrameView and EndFrameView: the window in which zone
     // lifecycle mutation would dangle span entries mid-frame.
@@ -91,6 +118,9 @@ private:
     std::vector<Registry*> PhysicsScratch;
     std::vector<Registry*> LogicScratch;
     std::vector<Registry*> AudioScratch;
+    std::vector<Registry*> ParticipatingScratch;
+
+    std::vector<RegistryResidencyChange> PendingChanges_;
 
     std::uint16_t NextRegistryIndex = 2;
 };

--- a/engine/include/zone/ZoneRuntime.h
+++ b/engine/include/zone/ZoneRuntime.h
@@ -49,20 +49,19 @@ public:
     std::size_t ZoneCount() const;
 
     // Pending changes accumulated since the previous residency phase. Intended
-    // for debug/tools/tests. Runtime dispatch must call BeginResidencyProcessing
-    // so handlers iterate a stable batch while any lifecycle mutations they
-    // trigger accumulate for the next frame.
+    // for debug/tools/tests. Runtime dispatch calls BeginResidencyProcessing so
+    // handlers iterate stable storage rather than the mutable pending vector.
     std::span<const RegistryResidencyChange> ResidencyChanges() const;
 
     // Swap the pending batch into stable processing storage. The returned span
-    // remains valid until FinalizeResidencyProcessing. Any attach, participation,
-    // or detach request raised by a residency handler is queued in a fresh
-    // pending batch and runs next frame instead of invalidating this span.
+    // remains valid until FinalizeResidencyProcessing. Registry lifecycle cannot
+    // mutate while handlers process this batch; any resulting work must be
+    // queued for a later drain point, preserving the invariant that backend
+    // residency is corrected before a new frame view observes lifecycle state.
     std::span<const RegistryResidencyChange> BeginResidencyProcessing();
 
-    // Destroy only registries whose Detaching transition was present in the
-    // processing batch, then clear that batch. Detaches requested during the
-    // phase remain alive and queued for the next residency visit.
+    // Destroy registries whose Detaching transition was processed, then clear
+    // the stable batch and reopen the drain-point mutation window.
     void FinalizeResidencyProcessing();
 
     // Intended for debug/tools/tests. Runtime systems should consume
@@ -79,9 +78,9 @@ public:
     }
 
     // The returned view is valid until EndFrameView. Zone lifecycle
-    // (CreateZone, AttachZone, DestroyZone) asserts that no view is live:
-    // mutations belong at the drain point, before the frame's view is built.
-    // Spans therefore never contain null entries.
+    // (CreateZone, AttachZone, DestroyZone, SetParticipation) asserts that no
+    // view or residency batch is live. Spans therefore never contain null
+    // entries or observe backend-uncorrected lifecycle state.
     FrameRegistryView BuildFrameView();
     void EndFrameView();
 
@@ -113,8 +112,9 @@ private:
                                    ZoneParticipation current);
     void RecordDetaching(Registry* registry, ZoneParticipation previous);
 
-    // True between BuildFrameView and EndFrameView: the window in which zone
-    // lifecycle mutation would dangle span entries mid-frame.
+    // Frame-view and residency processing are both read-stable windows. Registry
+    // lifecycle mutation is legal only outside them at an owner-thread drain
+    // point.
     bool FrameViewLive_ = false;
     bool ResidencyProcessing_ = false;
 

--- a/engine/include/zone/ZoneRuntime.h
+++ b/engine/include/zone/ZoneRuntime.h
@@ -48,13 +48,21 @@ public:
 
     std::size_t ZoneCount() const;
 
-    // The residency-change batch accumulated since the last finalize, one
-    // coalesced entry per mutated registry (see RegistryResidency.h). The
-    // RegistryResidency frame phase processes it, then calls
-    // FinalizeResidencyProcessing, which destroys registries marked Detaching
-    // and clears the batch. Instance pointers in the batch are valid until
-    // that finalize call.
+    // Pending changes accumulated since the previous residency phase. Intended
+    // for debug/tools/tests. Runtime dispatch must call BeginResidencyProcessing
+    // so handlers iterate a stable batch while any lifecycle mutations they
+    // trigger accumulate for the next frame.
     std::span<const RegistryResidencyChange> ResidencyChanges() const;
+
+    // Swap the pending batch into stable processing storage. The returned span
+    // remains valid until FinalizeResidencyProcessing. Any attach, participation,
+    // or detach request raised by a residency handler is queued in a fresh
+    // pending batch and runs next frame instead of invalidating this span.
+    std::span<const RegistryResidencyChange> BeginResidencyProcessing();
+
+    // Destroy only registries whose Detaching transition was present in the
+    // processing batch, then clear that batch. Detaches requested during the
+    // phase remain alive and queued for the next residency visit.
     void FinalizeResidencyProcessing();
 
     // Intended for debug/tools/tests. Runtime systems should consume
@@ -85,8 +93,8 @@ private:
         ZoneParticipation Participation;
 
         // DestroyZone marks instead of erasing: the registry stays owned and
-        // readable (reachable only through the residency batch) until
-        // FinalizeResidencyProcessing, so retained backend state gets its
+        // readable (reachable only through the residency batch) until its
+        // Detaching transition is processed, so retained backend state gets its
         // final visit while resources are alive. Detaching zones are invisible
         // to every query and frame span.
         bool Detaching = false;
@@ -108,6 +116,7 @@ private:
     // True between BuildFrameView and EndFrameView: the window in which zone
     // lifecycle mutation would dangle span entries mid-frame.
     bool FrameViewLive_ = false;
+    bool ResidencyProcessing_ = false;
 
     std::unique_ptr<Registry> GlobalRegistry;
     std::vector<std::unique_ptr<LoadedZone>> Zones;
@@ -121,6 +130,7 @@ private:
     std::vector<Registry*> ParticipatingScratch;
 
     std::vector<RegistryResidencyChange> PendingChanges_;
+    std::vector<RegistryResidencyChange> ProcessingChanges_;
 
     std::uint16_t NextRegistryIndex = 2;
 };

--- a/engine/src/app/EngineFramePhases.cpp
+++ b/engine/src/app/EngineFramePhases.cpp
@@ -113,6 +113,15 @@ void RegisterDefaultEngineFramePhases(Engine& engine, Game& game, FrameDriver& d
         engine.Tasks().DrainCompletions(budget);
     });
 
+    driver.Register(FramePhase::RegistryResidency, [&engine, &config](PhaseContext&) {
+        RegistryResidencyContext residency{
+            .Config = config,
+            .Changes = engine.Zones().ResidencyChanges(),
+        };
+        engine.Schedule().RunRegistryResidency(residency);
+        engine.Zones().FinalizeResidencyProcessing();
+    });
+
     driver.Register(FramePhase::ScheduleTicks, [&engine](PhaseContext& ctx) {
         ctx.Registries = engine.Schedule().BuildFrameView(engine.Zones());
         ctx.Runtime->ScheduleFixedTicks();

--- a/engine/src/app/EngineFramePhases.cpp
+++ b/engine/src/app/EngineFramePhases.cpp
@@ -116,7 +116,7 @@ void RegisterDefaultEngineFramePhases(Engine& engine, Game& game, FrameDriver& d
     driver.Register(FramePhase::RegistryResidency, [&engine, &config](PhaseContext&) {
         RegistryResidencyContext residency{
             .Config = config,
-            .Changes = engine.Zones().ResidencyChanges(),
+            .Changes = engine.Zones().BeginResidencyProcessing(),
         };
         engine.Schedule().RunRegistryResidency(residency);
         engine.Zones().FinalizeResidencyProcessing();

--- a/engine/src/app/EngineSchedule.cpp
+++ b/engine/src/app/EngineSchedule.cpp
@@ -9,6 +9,7 @@ FrameRegistryView EngineSchedule::BuildFrameView(ZoneRuntime& zones)
 
 void EngineSchedule::Init()
 {
+    TopoSort(RegistryResidencyEntries);
     TopoSort(FixedLogicEntries);
     TopoSort(PhysicsEntries);
     TopoSort(PostFixedEntries);
@@ -36,6 +37,7 @@ void EngineSchedule::Shutdown()
 
     Records.clear();
     TypeIndex.clear();
+    RegistryResidencyEntries.clear();
     FixedLogicEntries.clear();
     PhysicsEntries.clear();
     PostFixedEntries.clear();
@@ -44,6 +46,11 @@ void EngineSchedule::Shutdown()
     AudioEntries.clear();
     EndFrameEntries.clear();
     Initialized = false;
+}
+
+void EngineSchedule::RunRegistryResidency(RegistryResidencyContext& ctx)
+{
+    Run(RegistryResidencyEntries, ctx);
 }
 
 void EngineSchedule::RunFixedLogic(FixedLogicContext& ctx)

--- a/engine/src/physics/CharacterControllerSystem.cpp
+++ b/engine/src/physics/CharacterControllerSystem.cpp
@@ -24,10 +24,7 @@ void CharacterControllerSystem::Physics(PhysicsContext& ctx)
         if (!world.IsRegistered<CharacterController>())
             continue;
 
-        CharacterMoverPool& pool = world.HasResource<CharacterMoverPool>()
-            ? world.GetResource<CharacterMoverPool>()
-            : world.AddResource<CharacterMoverPool>(physics);
-
+        CharacterMoverPool& pool = reg->Resources.Ensure<CharacterMoverPool>(physics);
         pool.Reconcile(world);
         pool.Drive(world, dt, Gravity);
     }

--- a/engine/src/physics/CharacterMoverPool.cpp
+++ b/engine/src/physics/CharacterMoverPool.cpp
@@ -137,6 +137,24 @@ void CharacterMoverPool::Reconcile(World& world)
     LastStructuralVersion = world.StructuralVersion(); // post-flush value
 }
 
+void CharacterMoverPool::Evict(World& world)
+{
+    if (!Ready(world) || !S)
+        return;
+
+    State& state = *S;
+    for (uint32_t slot = 0; slot < state.Slots.size(); ++slot)
+    {
+        if (!state.Slots[slot].Mover)
+            continue;
+        const EntityId owner = state.Slots[slot].Owner;
+        if (world.IsAlive(owner) && world.HasComponent<CharacterMoverLink>(owner))
+            state.Commands.RemoveComponent<CharacterMoverLink>(owner);
+        state.Release(slot);
+    }
+    state.Commands.Flush();
+}
+
 void CharacterMoverPool::Drive(World& world, float dt, const Vec3d& gravity)
 {
     if (!Ready(world) || !S)

--- a/engine/src/physics/PhysicsQueries.cpp
+++ b/engine/src/physics/PhysicsQueries.cpp
@@ -13,7 +13,7 @@
 #include <Jolt/Physics/Collision/RayCast.h>
 #include <Jolt/Physics/Collision/ShapeCast.h>
 
-#include <physics/PhysicsScene.h> // UnpackEntity
+#include <physics/RigidBodyBinding.h> // UnpackEntity
 #include <physics/PhysicsWorld.h>
 
 namespace

--- a/engine/src/physics/PhysicsStepSystem.cpp
+++ b/engine/src/physics/PhysicsStepSystem.cpp
@@ -2,6 +2,7 @@
 
 #include <app/GameContexts.h>
 #include <ecs/World.h>
+#include <physics/CharacterMoverPool.h>
 #include <physics/RigidBodyBinding.h>
 #include <world/registry/Registry.h>
 
@@ -11,6 +12,24 @@ PhysicsStepSystem::PhysicsStepSystem()
 }
 
 PhysicsStepSystem::~PhysicsStepSystem() = default;
+
+void PhysicsStepSystem::RegistryResidency(RegistryResidencyContext& ctx)
+{
+    for (const RegistryResidencyChange& change : ctx.Changes)
+    {
+        // Only exits from the physics domain need work: Attached starts with
+        // no backend state, and entering restores through the ordinary
+        // reconcile. Detaching arrives here as Previous.Physics -> false.
+        if (!change.Previous.Physics || change.Current.Physics)
+            continue;
+
+        World& world = change.Instance->Components;
+        if (RigidBodyBinding* binding = change.Instance->Resources.TryGet<RigidBodyBinding>())
+            binding->Evict(world);
+        if (CharacterMoverPool* pool = change.Instance->Resources.TryGet<CharacterMoverPool>())
+            pool->Evict(world);
+    }
+}
 
 void PhysicsStepSystem::Physics(PhysicsContext& ctx)
 {

--- a/engine/src/physics/PhysicsStepSystem.cpp
+++ b/engine/src/physics/PhysicsStepSystem.cpp
@@ -4,6 +4,8 @@
 #include <ecs/World.h>
 #include <physics/CharacterMoverPool.h>
 #include <physics/RigidBodyBinding.h>
+#include <physics/components/CharacterController.h>
+#include <physics/components/Collider.h>
 #include <world/registry/Registry.h>
 
 PhysicsStepSystem::PhysicsStepSystem()
@@ -17,17 +19,52 @@ void PhysicsStepSystem::RegistryResidency(RegistryResidencyContext& ctx)
 {
     for (const RegistryResidencyChange& change : ctx.Changes)
     {
-        // Only exits from the physics domain need work: Attached starts with
-        // no backend state, and entering restores through the ordinary
-        // reconcile. Detaching arrives here as Previous.Physics -> false.
-        if (!change.Previous.Physics || change.Current.Physics)
-            continue;
+        Registry& registry = *change.Instance;
+        World& world = registry.Components;
 
-        World& world = change.Instance->Components;
-        if (RigidBodyBinding* binding = change.Instance->Resources.TryGet<RigidBodyBinding>())
-            binding->Evict(world);
-        if (CharacterMoverPool* pool = change.Instance->Resources.TryGet<CharacterMoverPool>())
-            pool->Evict(world);
+        // Detaching is an unconditional final visit. Do not infer that an
+        // attached-but-never-framed registry has no backend state: finalizers and
+        // tools may have materialized bindings before requesting destruction.
+        if (change.Kind == RegistryResidencyChangeKind::Detaching)
+        {
+            if (CharacterMoverPool* pool = registry.Resources.TryGet<CharacterMoverPool>())
+                pool->Evict(world);
+            if (RigidBodyBinding* binding = registry.Resources.TryGet<RigidBodyBinding>())
+                binding->Evict(world);
+            continue;
+        }
+
+        const bool wasPhysics = change.Previous.Physics;
+        const bool isPhysics = change.Current.Physics;
+
+        if (wasPhysics && !isPhysics)
+        {
+            if (CharacterMoverPool* pool = registry.Resources.TryGet<CharacterMoverPool>())
+                pool->Evict(world);
+            if (RigidBodyBinding* binding = registry.Resources.TryGet<RigidBodyBinding>())
+                binding->Evict(world);
+            continue;
+        }
+
+        if (!wasPhysics && isPhysics)
+        {
+            // Restore before the new frame view exposes the registry to physics.
+            // The ordinary reconcile remains the one creation path; residency
+            // simply runs it at the correct boundary instead of waiting for the
+            // first fixed tick.
+            if (world.IsRegistered<Collider>())
+            {
+                RigidBodyBinding& binding =
+                    registry.Resources.Ensure<RigidBodyBinding>(Simulation);
+                binding.SyncToPhysics(world);
+            }
+            if (world.IsRegistered<CharacterController>())
+            {
+                CharacterMoverPool& pool =
+                    registry.Resources.Ensure<CharacterMoverPool>(Simulation);
+                pool.Reconcile(world);
+            }
+        }
     }
 }
 

--- a/engine/src/physics/PhysicsStepSystem.cpp
+++ b/engine/src/physics/PhysicsStepSystem.cpp
@@ -2,18 +2,8 @@
 
 #include <app/GameContexts.h>
 #include <ecs/World.h>
-#include <physics/PhysicsScene.h>
+#include <physics/RigidBodyBinding.h>
 #include <world/registry/Registry.h>
-
-namespace
-{
-PhysicsScene& EnsureScene(World& world, PhysicsWorld& physics)
-{
-    if (world.HasResource<PhysicsScene>())
-        return world.GetResource<PhysicsScene>();
-    return world.AddResource<PhysicsScene>(physics);
-}
-} // namespace
 
 PhysicsStepSystem::PhysicsStepSystem()
 {
@@ -28,16 +18,15 @@ void PhysicsStepSystem::Physics(PhysicsContext& ctx)
 
     for (Registry* reg : ctx.ActiveRegistries)
     {
-        World& world = reg->Components;
-        EnsureScene(world, Simulation).SyncToPhysics(world);
+        RigidBodyBinding& binding = reg->Resources.Ensure<RigidBodyBinding>(Simulation);
+        binding.SyncToPhysics(reg->Components);
     }
 
     Simulation.Step(dt, CollisionSteps);
 
     for (Registry* reg : ctx.ActiveRegistries)
     {
-        World& world = reg->Components;
-        if (PhysicsScene* scene = world.TryGetResource<PhysicsScene>())
-            scene->SyncFromPhysics(world);
+        if (RigidBodyBinding* binding = reg->Resources.TryGet<RigidBodyBinding>())
+            binding->SyncFromPhysics(reg->Components);
     }
 }

--- a/engine/src/physics/PhysicsWorld.cpp
+++ b/engine/src/physics/PhysicsWorld.cpp
@@ -218,8 +218,32 @@ void PhysicsWorld::RemoveBody(PhysicsBodyId id)
 
     JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();
     const JPH::BodyID bid = ToJph(id);
+
+    // The backend does not wake contact partners on removal, so anything
+    // resting on this body would keep sleeping on phantom support — a crate
+    // stack when its base despawns, a ball on evicted zone geometry. Capture
+    // the bounds, remove, then wake everything that overlapped.
+    bool hadBounds = false;
+    JPH::AABox bounds;
+    {
+        JPH::BodyLockRead lock(Impl->System.GetBodyLockInterface(), bid);
+        if (lock.Succeeded())
+        {
+            bounds = lock.GetBody().GetWorldSpaceBounds();
+            hadBounds = true;
+        }
+    }
+
     bodies.RemoveBody(bid);
     bodies.DestroyBody(bid);
+
+    if (hadBounds)
+    {
+        bounds.ExpandBy(JPH::Vec3::sReplicate(0.1f));
+        const JPH::BroadPhaseLayerFilter allBroadPhase;
+        const JPH::ObjectLayerFilter allObjects;
+        bodies.ActivateBodiesInAABox(bounds, allBroadPhase, allObjects);
+    }
 }
 
 BodyTransform PhysicsWorld::GetBodyTransform(PhysicsBodyId id) const

--- a/engine/src/physics/PhysicsWorld.cpp
+++ b/engine/src/physics/PhysicsWorld.cpp
@@ -96,14 +96,21 @@ void PhysicsWorld::DriveConstraints(float dt)
         const Quatf desiredRot =
             (slot.Target.WorldFrame.Rotation * slot.FollowerLocalFrame.Rotation.Inverse())
                 .Normalized();
-        const Vec3d desiredPos =
-            slot.Target.WorldFrame.Position - desiredRot.RotateVector(slot.FollowerLocalFrame.Position);
+        const Vec3d followerOffset =
+            desiredRot.RotateVector(slot.FollowerLocalFrame.Position);
+        const Vec3d desiredPos = slot.Target.WorldFrame.Position - followerOffset;
+
+        // The target twist is defined at the driven frame origin. Convert it to
+        // the follower body center before applying it: v_frame = v_body + w x r.
+        const Vec3d bodyCenterFeedForward =
+            slot.Target.LinearVelocity
+            - slot.Target.AngularVelocity.Cross(followerOffset);
 
         if (slot.Target.Teleported)
         {
             bodies.SetPositionAndRotation(body, ToJphR(desiredPos), ToJph(desiredRot),
                                           JPH::EActivation::Activate);
-            bodies.SetLinearVelocity(body, ToJph(slot.Target.LinearVelocity));
+            bodies.SetLinearVelocity(body, ToJph(bodyCenterFeedForward));
             bodies.SetAngularVelocity(body, ToJph(slot.Target.AngularVelocity));
             slot.Telemetry = PhysicsConstraintTelemetry{};
             continue;
@@ -125,7 +132,7 @@ void PhysicsWorld::DriveConstraints(float dt)
         if (closingAngular > Impl->MaxDriveClosingAngularSpeed)
             closingAngular = Impl->MaxDriveClosingAngularSpeed;
 
-        const Vec3d velocity = closing + slot.Target.LinearVelocity;
+        const Vec3d velocity = closing + bodyCenterFeedForward;
         const Vec3d angularVelocity = axis * closingAngular + slot.Target.AngularVelocity;
 
         bodies.SetLinearVelocity(body, ToJph(velocity));

--- a/engine/src/physics/PhysicsWorld.cpp
+++ b/engine/src/physics/PhysicsWorld.cpp
@@ -68,8 +68,9 @@ void PhysicsWorld::Step(float dt, int collisionSteps)
 }
 
 // Locked velocity-drive prototype. The target pose is the frame at the start of
-// this step; its supplied velocity predicts motion through the step. The error
-// correction and feed-forward terms therefore each appear exactly once.
+// this step; its supplied velocity predicts motion through the step. The drive
+// closes error at the follower attachment frame, then derives the body-center
+// velocity that realizes that frame twist.
 void PhysicsWorld::DriveConstraints(float dt)
 {
     if (dt <= 0.0f)
@@ -96,21 +97,18 @@ void PhysicsWorld::DriveConstraints(float dt)
         const Quatf desiredRot =
             (slot.Target.WorldFrame.Rotation * slot.FollowerLocalFrame.Rotation.Inverse())
                 .Normalized();
-        const Vec3d followerOffset =
+        const Vec3d desiredOffset =
             desiredRot.RotateVector(slot.FollowerLocalFrame.Position);
-        const Vec3d desiredPos = slot.Target.WorldFrame.Position - followerOffset;
-
-        // The target twist is defined at the driven frame origin. Convert it to
-        // the follower body center before applying it: v_frame = v_body + w x r.
-        const Vec3d bodyCenterFeedForward =
-            slot.Target.LinearVelocity
-            - slot.Target.AngularVelocity.Cross(followerOffset);
+        const Vec3d desiredPos = slot.Target.WorldFrame.Position - desiredOffset;
 
         if (slot.Target.Teleported)
         {
+            const Vec3d bodyCenterVelocity =
+                slot.Target.LinearVelocity
+                - slot.Target.AngularVelocity.Cross(desiredOffset);
             bodies.SetPositionAndRotation(body, ToJphR(desiredPos), ToJph(desiredRot),
                                           JPH::EActivation::Activate);
-            bodies.SetLinearVelocity(body, ToJph(bodyCenterFeedForward));
+            bodies.SetLinearVelocity(body, ToJph(bodyCenterVelocity));
             bodies.SetAngularVelocity(body, ToJph(slot.Target.AngularVelocity));
             slot.Telemetry = PhysicsConstraintTelemetry{};
             continue;
@@ -118,12 +116,16 @@ void PhysicsWorld::DriveConstraints(float dt)
 
         const BodyTransform pose{ FromJphR(bodies.GetPosition(body)),
                                   FromJph(bodies.GetRotation(body)) };
+        const Vec3d actualOffset =
+            pose.Rotation.RotateVector(slot.FollowerLocalFrame.Position);
+        const Vec3d actualFramePosition = pose.Position + actualOffset;
+        const Vec3d framePositionError =
+            slot.Target.WorldFrame.Position - actualFramePosition;
 
-        const Vec3d positionError = desiredPos - pose.Position;
         Vec3d axis;
         const float angularError = DeltaAxisAngle(pose.Rotation, desiredRot, axis);
 
-        Vec3d closing = positionError * (1.0f / dt);
+        Vec3d closing = framePositionError * (1.0f / dt);
         const float closingSpeed = closing.Magnitude();
         if (closingSpeed > Impl->MaxDriveClosingSpeed)
             closing = closing * (Impl->MaxDriveClosingSpeed / closingSpeed);
@@ -132,15 +134,19 @@ void PhysicsWorld::DriveConstraints(float dt)
         if (closingAngular > Impl->MaxDriveClosingAngularSpeed)
             closingAngular = Impl->MaxDriveClosingAngularSpeed;
 
-        const Vec3d velocity = closing + bodyCenterFeedForward;
-        const Vec3d angularVelocity = axis * closingAngular + slot.Target.AngularVelocity;
+        const Vec3d angularVelocity =
+            axis * closingAngular + slot.Target.AngularVelocity;
+        const Vec3d desiredFrameVelocity =
+            closing + slot.Target.LinearVelocity;
+        const Vec3d bodyCenterVelocity =
+            desiredFrameVelocity - angularVelocity.Cross(actualOffset);
 
-        bodies.SetLinearVelocity(body, ToJph(velocity));
+        bodies.SetLinearVelocity(body, ToJph(bodyCenterVelocity));
         bodies.SetAngularVelocity(body, ToJph(angularVelocity));
 
-        slot.Telemetry.PositionError = positionError.Magnitude();
+        slot.Telemetry.PositionError = framePositionError.Magnitude();
         slot.Telemetry.AngularError = angularError;
-        slot.Telemetry.CommandedLinearSpeed = velocity.Magnitude();
+        slot.Telemetry.CommandedLinearSpeed = bodyCenterVelocity.Magnitude();
         slot.Telemetry.CommandedAngularSpeed = angularVelocity.Magnitude();
     }
 }

--- a/engine/src/physics/PhysicsWorld.cpp
+++ b/engine/src/physics/PhysicsWorld.cpp
@@ -42,8 +42,6 @@ void PhysicsWorld::SetShapeCache(const CollisionShapeCache* cache)
 
 namespace
 {
-// Shortest-arc axis-angle of the rotation carrying `from` onto `to`.
-// Returns the angle; writes the unit axis (zero vector for tiny angles).
 float DeltaAxisAngle(const Quatf& from, const Quatf& to, Vec3d& axisOut)
 {
     Quatf delta = (to * from.Inverse()).Normalized();
@@ -69,10 +67,9 @@ void PhysicsWorld::Step(float dt, int collisionSteps)
     Impl->System.Update(dt, collisionSteps, &Impl->Temp, &Impl->Jobs);
 }
 
-// The hidden realization: close the whole pose error within one step by
-// velocity, then let the solver resolve contacts, which is what keeps the
-// follower colliding normally and the relationship one-way. Telemetry records
-// the pre-drive error and the force/torque the velocity change amounts to.
+// Locked velocity-drive prototype. The target pose is the frame at the start of
+// this step; its supplied velocity predicts motion through the step. The error
+// correction and feed-forward terms therefore each appear exactly once.
 void PhysicsWorld::DriveConstraints(float dt)
 {
     if (dt <= 0.0f)
@@ -96,8 +93,6 @@ void PhysicsWorld::DriveConstraints(float dt)
 
         const JPH::BodyID body = ToJph(slot.Follower);
 
-        // Desired body pose from the target frame and the follower-local
-        // attachment frame: bodyRot * localRot = frameRot.
         const Quatf desiredRot =
             (slot.Target.WorldFrame.Rotation * slot.FollowerLocalFrame.Rotation.Inverse())
                 .Normalized();
@@ -121,9 +116,6 @@ void PhysicsWorld::DriveConstraints(float dt)
         Vec3d axis;
         const float angularError = DeltaAxisAngle(pose.Rotation, desiredRot, axis);
 
-        // The error-closing component is capped so a large error cannot
-        // command a speed discrete collision would tunnel at; the target
-        // frame's own velocity rides on top uncapped. See PhysicsWorldConfig.
         Vec3d closing = positionError * (1.0f / dt);
         const float closingSpeed = closing.Magnitude();
         if (closingSpeed > Impl->MaxDriveClosingSpeed)
@@ -136,28 +128,13 @@ void PhysicsWorld::DriveConstraints(float dt)
         const Vec3d velocity = closing + slot.Target.LinearVelocity;
         const Vec3d angularVelocity = axis * closingAngular + slot.Target.AngularVelocity;
 
-        const Vec3d previousVelocity = FromJph(bodies.GetLinearVelocity(body));
-        const Vec3d previousAngular = FromJph(bodies.GetAngularVelocity(body));
-
         bodies.SetLinearVelocity(body, ToJph(velocity));
         bodies.SetAngularVelocity(body, ToJph(angularVelocity));
 
-        float mass = 0.0f;
-        {
-            JPH::BodyLockRead lock(Impl->System.GetBodyLockInterface(), body);
-            if (lock.Succeeded() && lock.GetBody().GetMotionPropertiesUnchecked() != nullptr)
-            {
-                const float inverseMass =
-                    lock.GetBody().GetMotionPropertiesUnchecked()->GetInverseMass();
-                mass = inverseMass > 0.0f ? 1.0f / inverseMass : 0.0f;
-            }
-        }
-
         slot.Telemetry.PositionError = positionError.Magnitude();
         slot.Telemetry.AngularError = angularError;
-        slot.Telemetry.AppliedForce = mass * (velocity - previousVelocity).Magnitude() / dt;
-        slot.Telemetry.AppliedTorque =
-            mass * (angularVelocity - previousAngular).Magnitude() / dt;
+        slot.Telemetry.CommandedLinearSpeed = velocity.Magnitude();
+        slot.Telemetry.CommandedAngularSpeed = angularVelocity.Magnitude();
     }
 }
 
@@ -201,9 +178,6 @@ void PhysicsWorld::RemoveBody(PhysicsBodyId id)
     if (!id.IsValid())
         return;
 
-    // Dependent constraints are invalidated before the body goes, so a
-    // constraint can never reference a removed body. The ECS binding keeps its
-    // own records and observes the invalidation through IsConstraintValid.
     for (uint32_t i = 0; i < Impl->Constraints.size(); ++i)
     {
         DrivenPoseSlot& slot = Impl->Constraints[i];
@@ -219,10 +193,6 @@ void PhysicsWorld::RemoveBody(PhysicsBodyId id)
     JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();
     const JPH::BodyID bid = ToJph(id);
 
-    // The backend does not wake contact partners on removal, so anything
-    // resting on this body would keep sleeping on phantom support — a crate
-    // stack when its base despawns, a ball on evicted zone geometry. Capture
-    // the bounds, remove, then wake everything that overlapped.
     bool hadBounds = false;
     JPH::AABox bounds;
     {
@@ -283,6 +253,12 @@ void PhysicsWorld::SetAngularVelocity(PhysicsBodyId id, const Vec3d& velocity)
     bodies.SetAngularVelocity(ToJph(id), ToJph(velocity));
 }
 
+float PhysicsWorld::GetGravityScale(PhysicsBodyId id) const
+{
+    const JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();
+    return bodies.GetGravityFactor(ToJph(id));
+}
+
 void PhysicsWorld::SetGravityScale(PhysicsBodyId id, float scale)
 {
     JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();
@@ -302,6 +278,17 @@ PhysicsConstraintId PhysicsWorld::AddDrivenPoseConstraint(const DrivenPoseConstr
         || bodies.GetMotionType(ToJph(desc.Follower)) != JPH::EMotionType::Dynamic)
     {
         assert(false && "AddDrivenPoseConstraint: follower must be a live dynamic body");
+        return PhysicsConstraintId{};
+    }
+
+    const bool supported =
+        desc.LinearDrive.Response == PoseDriveResponse::Locked
+        && desc.AngularDrive.Response == PoseDriveResponse::Locked
+        && std::isinf(desc.LinearDrive.MaxForce)
+        && std::isinf(desc.AngularDrive.MaxTorque);
+    if (!supported)
+    {
+        assert(false && "AddDrivenPoseConstraint: spring and force/torque limits require P3");
         return PhysicsConstraintId{};
     }
 
@@ -334,9 +321,6 @@ PhysicsConstraintId PhysicsWorld::AddDrivenPoseConstraint(const DrivenPoseConstr
 
 void PhysicsWorld::RemoveConstraint(PhysicsConstraintId id)
 {
-    // Dead, stale, and already-invalidated handles are safe no-ops: cleanup
-    // paths (binding teardown, RemoveBody, registry destruction) cross in
-    // unspecified order.
     if (!IsConstraintValid(id))
         return;
 

--- a/engine/src/physics/PhysicsWorld.cpp
+++ b/engine/src/physics/PhysicsWorld.cpp
@@ -265,6 +265,12 @@ void PhysicsWorld::SetGravityScale(PhysicsBodyId id, float scale)
     bodies.SetGravityFactor(ToJph(id), scale);
 }
 
+bool PhysicsWorld::IsBodyActive(PhysicsBodyId id) const
+{
+    const JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();
+    return bodies.IsActive(ToJph(id));
+}
+
 void PhysicsWorld::WakeBody(PhysicsBodyId id)
 {
     JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();

--- a/engine/src/physics/PhysicsWorld.cpp
+++ b/engine/src/physics/PhysicsWorld.cpp
@@ -5,9 +5,13 @@
 #include "PhysicsWorldImpl.h"
 
 #include <Jolt/Physics/Body/BodyCreationSettings.h>
+#include <Jolt/Physics/Body/BodyLock.h>
 #include <Jolt/Physics/EActivation.h>
 
 #include <physics/CollisionShapeCache.h>
+
+#include <cassert>
+#include <cmath>
 
 PhysicsWorld::PhysicsWorld(const PhysicsWorldConfig& config)
     : Impl(nullptr)
@@ -23,6 +27,8 @@ PhysicsWorld::PhysicsWorld(const PhysicsWorldConfig& config)
         Impl->ObjectVsBroadPhase,
         Impl->ObjectVsObject);
     Impl->System.SetGravity(ToJph(config.Gravity));
+    Impl->MaxDriveClosingSpeed = config.MaxDriveClosingSpeed;
+    Impl->MaxDriveClosingAngularSpeed = config.MaxDriveClosingAngularSpeed;
 }
 
 PhysicsWorld::~PhysicsWorld() = default;
@@ -34,9 +40,125 @@ void PhysicsWorld::SetShapeCache(const CollisionShapeCache* cache)
     ShapeCache = cache;
 }
 
+namespace
+{
+// Shortest-arc axis-angle of the rotation carrying `from` onto `to`.
+// Returns the angle; writes the unit axis (zero vector for tiny angles).
+float DeltaAxisAngle(const Quatf& from, const Quatf& to, Vec3d& axisOut)
+{
+    Quatf delta = (to * from.Inverse()).Normalized();
+    if (delta.W < 0.0f)
+        delta = Quatf(-delta.X, -delta.Y, -delta.Z, -delta.W);
+
+    const float w = delta.W > 1.0f ? 1.0f : delta.W;
+    const float angle = 2.0f * std::acos(w);
+    const float s = std::sqrt(1.0f - w * w);
+    if (s < 1e-6f || angle < 1e-6f)
+    {
+        axisOut = Vec3d::Zero();
+        return 0.0f;
+    }
+    axisOut = Vec3d(delta.X / s, delta.Y / s, delta.Z / s);
+    return angle;
+}
+} // namespace
+
 void PhysicsWorld::Step(float dt, int collisionSteps)
 {
+    DriveConstraints(dt);
     Impl->System.Update(dt, collisionSteps, &Impl->Temp, &Impl->Jobs);
+}
+
+// The hidden realization: close the whole pose error within one step by
+// velocity, then let the solver resolve contacts, which is what keeps the
+// follower colliding normally and the relationship one-way. Telemetry records
+// the pre-drive error and the force/torque the velocity change amounts to.
+void PhysicsWorld::DriveConstraints(float dt)
+{
+    if (dt <= 0.0f)
+        return;
+
+    JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();
+
+    for (DrivenPoseSlot& slot : Impl->Constraints)
+    {
+        if (!slot.Alive)
+            continue;
+
+        if (!slot.Refreshed)
+        {
+            assert(false && "Driven pose constraint not refreshed since the last step: "
+                            "orchestration must SetDrivenPoseTarget every step.");
+            ++Impl->StaleRefreshes;
+            continue;
+        }
+        slot.Refreshed = false;
+
+        const JPH::BodyID body = ToJph(slot.Follower);
+
+        // Desired body pose from the target frame and the follower-local
+        // attachment frame: bodyRot * localRot = frameRot.
+        const Quatf desiredRot =
+            (slot.Target.WorldFrame.Rotation * slot.FollowerLocalFrame.Rotation.Inverse())
+                .Normalized();
+        const Vec3d desiredPos =
+            slot.Target.WorldFrame.Position - desiredRot.RotateVector(slot.FollowerLocalFrame.Position);
+
+        if (slot.Target.Teleported)
+        {
+            bodies.SetPositionAndRotation(body, ToJphR(desiredPos), ToJph(desiredRot),
+                                          JPH::EActivation::Activate);
+            bodies.SetLinearVelocity(body, ToJph(slot.Target.LinearVelocity));
+            bodies.SetAngularVelocity(body, ToJph(slot.Target.AngularVelocity));
+            slot.Telemetry = PhysicsConstraintTelemetry{};
+            continue;
+        }
+
+        const BodyTransform pose{ FromJphR(bodies.GetPosition(body)),
+                                  FromJph(bodies.GetRotation(body)) };
+
+        const Vec3d positionError = desiredPos - pose.Position;
+        Vec3d axis;
+        const float angularError = DeltaAxisAngle(pose.Rotation, desiredRot, axis);
+
+        // The error-closing component is capped so a large error cannot
+        // command a speed discrete collision would tunnel at; the target
+        // frame's own velocity rides on top uncapped. See PhysicsWorldConfig.
+        Vec3d closing = positionError * (1.0f / dt);
+        const float closingSpeed = closing.Magnitude();
+        if (closingSpeed > Impl->MaxDriveClosingSpeed)
+            closing = closing * (Impl->MaxDriveClosingSpeed / closingSpeed);
+
+        float closingAngular = angularError / dt;
+        if (closingAngular > Impl->MaxDriveClosingAngularSpeed)
+            closingAngular = Impl->MaxDriveClosingAngularSpeed;
+
+        const Vec3d velocity = closing + slot.Target.LinearVelocity;
+        const Vec3d angularVelocity = axis * closingAngular + slot.Target.AngularVelocity;
+
+        const Vec3d previousVelocity = FromJph(bodies.GetLinearVelocity(body));
+        const Vec3d previousAngular = FromJph(bodies.GetAngularVelocity(body));
+
+        bodies.SetLinearVelocity(body, ToJph(velocity));
+        bodies.SetAngularVelocity(body, ToJph(angularVelocity));
+
+        float mass = 0.0f;
+        {
+            JPH::BodyLockRead lock(Impl->System.GetBodyLockInterface(), body);
+            if (lock.Succeeded() && lock.GetBody().GetMotionPropertiesUnchecked() != nullptr)
+            {
+                const float inverseMass =
+                    lock.GetBody().GetMotionPropertiesUnchecked()->GetInverseMass();
+                mass = inverseMass > 0.0f ? 1.0f / inverseMass : 0.0f;
+            }
+        }
+
+        slot.Telemetry.PositionError = positionError.Magnitude();
+        slot.Telemetry.AngularError = angularError;
+        slot.Telemetry.AppliedForce = mass * (velocity - previousVelocity).Magnitude() / dt;
+        slot.Telemetry.AppliedTorque =
+            mass * (angularVelocity - previousAngular).Magnitude() / dt;
+    }
 }
 
 PhysicsBodyId PhysicsWorld::AddBody(const BodyDesc& desc)
@@ -78,6 +200,22 @@ void PhysicsWorld::RemoveBody(PhysicsBodyId id)
 {
     if (!id.IsValid())
         return;
+
+    // Dependent constraints are invalidated before the body goes, so a
+    // constraint can never reference a removed body. The ECS binding keeps its
+    // own records and observes the invalidation through IsConstraintValid.
+    for (uint32_t i = 0; i < Impl->Constraints.size(); ++i)
+    {
+        DrivenPoseSlot& slot = Impl->Constraints[i];
+        if (slot.Alive && slot.Follower == id)
+        {
+            slot.Alive = false;
+            ++slot.Generation;
+            Impl->FreeConstraintSlots.push_back(i);
+            --Impl->AliveConstraints;
+        }
+    }
+
     JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();
     const JPH::BodyID bid = ToJph(id);
     bodies.RemoveBody(bid);
@@ -131,6 +269,91 @@ void PhysicsWorld::WakeBody(PhysicsBodyId id)
 {
     JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();
     bodies.ActivateBody(ToJph(id));
+}
+
+PhysicsConstraintId PhysicsWorld::AddDrivenPoseConstraint(const DrivenPoseConstraintDesc& desc)
+{
+    const JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();
+    if (!desc.Follower.IsValid() || !bodies.IsAdded(ToJph(desc.Follower))
+        || bodies.GetMotionType(ToJph(desc.Follower)) != JPH::EMotionType::Dynamic)
+    {
+        assert(false && "AddDrivenPoseConstraint: follower must be a live dynamic body");
+        return PhysicsConstraintId{};
+    }
+
+    uint32_t index;
+    if (!Impl->FreeConstraintSlots.empty())
+    {
+        index = Impl->FreeConstraintSlots.back();
+        Impl->FreeConstraintSlots.pop_back();
+    }
+    else
+    {
+        index = static_cast<uint32_t>(Impl->Constraints.size());
+        Impl->Constraints.emplace_back();
+    }
+
+    DrivenPoseSlot& slot = Impl->Constraints[index];
+    slot.Alive = true;
+    slot.Follower = desc.Follower;
+    slot.FollowerLocalFrame = desc.FollowerLocalFrame;
+    slot.LinearDrive = desc.LinearDrive;
+    slot.AngularDrive = desc.AngularDrive;
+    slot.UserData = desc.UserData;
+    slot.Target = DrivenPoseTarget{};
+    slot.Refreshed = false;
+    slot.Telemetry = PhysicsConstraintTelemetry{};
+    ++Impl->AliveConstraints;
+
+    return PhysicsConstraintId{ index, slot.Generation };
+}
+
+void PhysicsWorld::RemoveConstraint(PhysicsConstraintId id)
+{
+    // Dead, stale, and already-invalidated handles are safe no-ops: cleanup
+    // paths (binding teardown, RemoveBody, registry destruction) cross in
+    // unspecified order.
+    if (!IsConstraintValid(id))
+        return;
+
+    DrivenPoseSlot& slot = Impl->Constraints[id.Index];
+    slot.Alive = false;
+    ++slot.Generation;
+    Impl->FreeConstraintSlots.push_back(id.Index);
+    --Impl->AliveConstraints;
+}
+
+bool PhysicsWorld::IsConstraintValid(PhysicsConstraintId id) const
+{
+    return id.IsValid() && id.Index < Impl->Constraints.size()
+        && Impl->Constraints[id.Index].Alive
+        && Impl->Constraints[id.Index].Generation == id.Generation;
+}
+
+void PhysicsWorld::SetDrivenPoseTarget(PhysicsConstraintId id, const DrivenPoseTarget& target)
+{
+    if (!IsConstraintValid(id))
+        return;
+    DrivenPoseSlot& slot = Impl->Constraints[id.Index];
+    slot.Target = target;
+    slot.Refreshed = true;
+}
+
+PhysicsConstraintTelemetry PhysicsWorld::GetConstraintTelemetry(PhysicsConstraintId id) const
+{
+    if (!IsConstraintValid(id))
+        return PhysicsConstraintTelemetry{};
+    return Impl->Constraints[id.Index].Telemetry;
+}
+
+uint32_t PhysicsWorld::ConstraintCount() const
+{
+    return Impl->AliveConstraints;
+}
+
+uint64_t PhysicsWorld::StaleRefreshCount() const
+{
+    return Impl->StaleRefreshes;
 }
 
 uint64_t PhysicsWorld::GetUserData(PhysicsBodyId id) const

--- a/engine/src/physics/PhysicsWorld.cpp
+++ b/engine/src/physics/PhysicsWorld.cpp
@@ -57,6 +57,9 @@ PhysicsBodyId PhysicsWorld::AddBody(const BodyDesc& desc)
         ToObjectLayer(desc.Layer));
     settings.mIsSensor = desc.IsTrigger;
     settings.mUserData = desc.UserData;
+    settings.mGravityFactor = desc.GravityScale;
+    settings.mLinearDamping = desc.LinearDamping;
+    settings.mAngularDamping = desc.AngularDamping;
     if (desc.Motion == BodyMotion::Dynamic && desc.Mass > 0.0f)
     {
         settings.mOverrideMassProperties = JPH::EOverrideMassProperties::CalculateInertia;
@@ -104,6 +107,30 @@ void PhysicsWorld::SetLinearVelocity(PhysicsBodyId id, const Vec3d& velocity)
 {
     JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();
     bodies.SetLinearVelocity(ToJph(id), ToJph(velocity));
+}
+
+Vec3d PhysicsWorld::GetAngularVelocity(PhysicsBodyId id) const
+{
+    const JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();
+    return FromJph(bodies.GetAngularVelocity(ToJph(id)));
+}
+
+void PhysicsWorld::SetAngularVelocity(PhysicsBodyId id, const Vec3d& velocity)
+{
+    JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();
+    bodies.SetAngularVelocity(ToJph(id), ToJph(velocity));
+}
+
+void PhysicsWorld::SetGravityScale(PhysicsBodyId id, float scale)
+{
+    JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();
+    bodies.SetGravityFactor(ToJph(id), scale);
+}
+
+void PhysicsWorld::WakeBody(PhysicsBodyId id)
+{
+    JPH::BodyInterface& bodies = Impl->System.GetBodyInterface();
+    bodies.ActivateBody(ToJph(id));
 }
 
 uint64_t PhysicsWorld::GetUserData(PhysicsBodyId id) const

--- a/engine/src/physics/PhysicsWorldImpl.h
+++ b/engine/src/physics/PhysicsWorldImpl.h
@@ -15,15 +15,41 @@
 #include <Jolt/Physics/Collision/Shape/SphereShape.h>
 #include <Jolt/Physics/PhysicsSystem.h>
 
+#include <vector>
+
 #include <math/Quat.h>
 #include <math/Vec.h>
 #include <physics/CollisionShape.h>
+#include <physics/PhysicsConstraintTypes.h>
 #include <physics/PhysicsTypes.h>
 #include "PhysicsLayers.h"
 
 // 16 MB of scratch for one Update. Ample for room-scale zones; the allocator
 // asserts rather than grows, which would surface here as a clear failure.
 inline constexpr unsigned int kPhysicsTempAllocatorBytes = 16u * 1024u * 1024u;
+
+// One driven pose constraint's backend-side record. The realization drives
+// the follower's velocities toward the desired frame before each step; the
+// solver then resolves contacts normally, which is what keeps collision
+// response intact and the relationship one-way. The realization is private to
+// the impl and swappable (a solver-side constraint against a hidden anchor is
+// the recorded alternative if compliance tuning demands it).
+struct DrivenPoseSlot
+{
+    uint32_t Generation = 1; // bumped at release; stale handles never resolve
+    bool Alive = false;
+
+    PhysicsBodyId Follower;
+    BodyTransform FollowerLocalFrame;
+    LinearPoseDriveSettings LinearDrive;
+    AngularPoseDriveSettings AngularDrive;
+    uint64_t UserData = 0;
+
+    DrivenPoseTarget Target;
+    bool Refreshed = false; // set by SetDrivenPoseTarget, cleared by Step
+
+    PhysicsConstraintTelemetry Telemetry;
+};
 
 struct PhysicsWorldImpl
 {
@@ -33,6 +59,18 @@ struct PhysicsWorldImpl
     ObjectVsBroadPhaseLayerFilterImpl ObjectVsBroadPhase;
     ObjectLayerPairFilterImpl ObjectVsObject;
     JPH::PhysicsSystem System;
+
+    // Slot table + free list; iteration in slot order keeps driving
+    // deterministic. Constraint counts are small (grabs, carries, machinery),
+    // so RemoveBody's dependent-constraint sweep is a plain scan.
+    std::vector<DrivenPoseSlot> Constraints;
+    std::vector<uint32_t> FreeConstraintSlots;
+    uint32_t AliveConstraints = 0;
+    uint64_t StaleRefreshes = 0;
+
+    // From PhysicsWorldConfig (see its comment on tunneling).
+    float MaxDriveClosingSpeed = 50.0f;
+    float MaxDriveClosingAngularSpeed = 30.0f;
 
     PhysicsWorldImpl()
         : Temp(kPhysicsTempAllocatorBytes)

--- a/engine/src/physics/RigidBodyBinding.cpp
+++ b/engine/src/physics/RigidBodyBinding.cpp
@@ -109,6 +109,12 @@ void RigidBodyBinding::Reconcile(World& world, SceneState& state)
         desc.IsTrigger = collider.IsTrigger;
         desc.Mass = body != nullptr ? body->Mass : 1.0f;
         desc.UserData = PackEntity(entity);
+        if (body != nullptr)
+        {
+            desc.GravityScale = body->GravityScale;
+            desc.LinearDamping = body->LinearDamping;
+            desc.AngularDamping = body->AngularDamping;
+        }
 
         const PhysicsBodyId id = Simulation->AddBody(desc);
         if (!id.IsValid())
@@ -116,7 +122,10 @@ void RigidBodyBinding::Reconcile(World& world, SceneState& state)
 
         Owned.push_back(BodyRecord{ entity, id });
         if (body != nullptr)
+        {
             Simulation->SetLinearVelocity(id, body->LinearVelocity);
+            Simulation->SetAngularVelocity(id, body->AngularVelocity);
+        }
         state.Commands.AddComponent<PhysicsBodyLink>(entity, PhysicsBodyLink{ id });
     });
 
@@ -166,9 +175,10 @@ void RigidBodyBinding::SyncToPhysics(World& world)
         LastStructuralVersion = world.StructuralVersion(); // post-flush value
     }
 
-    // Push authored transforms into kinematic bodies. Reads only (no version
-    // bump). Kinematic bodies are few; static colliders carry no RigidBody and
-    // so never match.
+    // Push authored state into the simulation. Reads only (no version bump).
+    // Kinematic bodies take their authored transform; dynamic bodies take
+    // GravityScale, so a runtime edit acts on the next tick. Static colliders
+    // carry no RigidBody and so never match.
     state.KinematicPush.ForEachChunk([&](auto& view)
     {
         const auto transforms = view.template Read<LocalTransform>();
@@ -176,10 +186,15 @@ void RigidBodyBinding::SyncToPhysics(World& world)
         const auto links = view.template Read<PhysicsBodyLink>();
         for (uint32_t i = 0; i < view.Count(); ++i)
         {
-            if (bodies[i].Motion != BodyMotion::Kinematic)
-                continue;
-            Simulation->SetBodyTransform(
-                links[i].Body, transforms[i].Value.Position, transforms[i].Value.Rotation);
+            if (bodies[i].Motion == BodyMotion::Kinematic)
+            {
+                Simulation->SetBodyTransform(
+                    links[i].Body, transforms[i].Value.Position, transforms[i].Value.Rotation);
+            }
+            else if (bodies[i].Motion == BodyMotion::Dynamic)
+            {
+                Simulation->SetGravityScale(links[i].Body, bodies[i].GravityScale);
+            }
         }
     });
 }
@@ -191,9 +206,9 @@ void RigidBodyBinding::SyncFromPhysics(World& world)
 
     SceneState& state = EnsureState(world);
 
-    // Write resolved transforms and velocity back for dynamic bodies. Contiguous
-    // column walk, no hashing. Static colliders (no RigidBody) and kinematic
-    // bodies (skipped) are not written.
+    // Write resolved transforms and velocities back for dynamic bodies.
+    // Contiguous column walk, no hashing. Static colliders (no RigidBody) and
+    // kinematic bodies (skipped) are not written.
     state.DynamicPull.ForEachChunk([&](auto& view)
     {
         auto transforms = view.template Write<LocalTransform>();
@@ -207,6 +222,7 @@ void RigidBodyBinding::SyncFromPhysics(World& world)
             transforms[i].Value.Position = pose.Position;
             transforms[i].Value.Rotation = pose.Rotation;
             bodies[i].LinearVelocity = Simulation->GetLinearVelocity(links[i].Body);
+            bodies[i].AngularVelocity = Simulation->GetAngularVelocity(links[i].Body);
         }
     });
 }

--- a/engine/src/physics/RigidBodyBinding.cpp
+++ b/engine/src/physics/RigidBodyBinding.cpp
@@ -1,6 +1,7 @@
 #include <physics/RigidBodyBinding.h>
 
 #include <cassert>
+#include <cmath>
 
 #include <ecs/CommandBuffer.h>
 #include <ecs/Query.h>
@@ -20,10 +21,6 @@ CollisionLayer DeriveLayer(BodyMotion motion, bool isTrigger)
     return motion == BodyMotion::Static ? CollisionLayer::Static : CollisionLayer::Moving;
 }
 
-// Place bodies at the entity's world pose. Propagation runs after physics, so a
-// top-level entity (the MVP case: brush cells, player, loose dynamics) has
-// LocalTransform == WorldTransform here; WorldTransform is preferred when present
-// for the parented case. Used only at body creation (the rare path).
 BodyTransform ReadPose(const World& world, EntityId entity)
 {
     if (world.IsRegistered<WorldTransform>())
@@ -35,9 +32,6 @@ BodyTransform ReadPose(const World& world, EntityId entity)
 }
 } // namespace
 
-// PIMPL: keeps Query.h out of the public header, matching the Jolt firewall
-// discipline. The queries are cached (built once, bound to this scene's World)
-// and the command buffer is reused (Flush clears it).
 struct RigidBodyBinding::SceneState
 {
     explicit SceneState(World& world)
@@ -59,18 +53,12 @@ RigidBodyBinding::RigidBodyBinding(PhysicsWorld& world)
 
 RigidBodyBinding::~RigidBodyBinding()
 {
-    // Safe without a lifetime guard: the world outlives this scene (zones are
-    // destroyed before the step system that owns the world).
     for (const BodyRecord& rec : Owned)
         Simulation->RemoveBody(rec.Body);
 }
 
 bool RigidBodyBinding::Ready(const World& world) const
 {
-    // The bridge needs colliders to bind, the link component to mark bound
-    // bodies, and a transform to place them. RigidBody gates the dynamic and
-    // kinematic queries; RegisterPhysicsComponents registers all of these
-    // together, so a configured zone passes and a bare World stays inert.
     return world.IsRegistered<Collider>() && world.IsRegistered<RigidBody>()
         && world.IsRegistered<PhysicsBodyLink>() && world.IsRegistered<LocalTransform>();
 }
@@ -85,11 +73,8 @@ RigidBodyBinding::SceneState& RigidBodyBinding::EnsureState(World& world)
 void RigidBodyBinding::Reconcile(World& world, SceneState& state)
 {
     ++ReconcileCount;
-    const World& readOnly = world; // const iteration: do not mark colliders changed
+    const World& readOnly = world;
 
-    // Create a body for every collider that does not have one yet. ForEachComponent
-    // yields the full (generational) EntityId the body's UserData and the Owned
-    // record need; the HasComponent skip keeps already-bound colliders untouched.
     readOnly.ForEachComponent<Collider>([&](EntityId entity, const Collider& collider)
     {
         if (world.HasComponent<PhysicsBodyLink>(entity))
@@ -129,10 +114,6 @@ void RigidBodyBinding::Reconcile(World& world, SceneState& state)
         state.Commands.AddComponent<PhysicsBodyLink>(entity, PhysicsBodyLink{ id });
     });
 
-    // Drop bodies whose entity was destroyed (no hook fired; the link vanished
-    // with the entity) or whose collider was removed. One sweep over Owned, so
-    // both cases are covered; only the collider-removed case still has a link to
-    // strip. O(bodies in this zone), paid only on structural-change frames.
     for (size_t i = 0; i < Owned.size();)
     {
         const EntityId entity = Owned[i].Entity;
@@ -157,9 +138,6 @@ void RigidBodyBinding::Reconcile(World& world, SceneState& state)
 
 void RigidBodyBinding::SyncToPhysics(World& world)
 {
-    // The likely misconfiguration: colliders registered but the runtime link
-    // forgotten, which would re-create every body each step. Loud in debug;
-    // a fully bare World (no colliders) stays silently inert.
     assert(!(world.IsRegistered<Collider>() && !world.IsRegistered<PhysicsBodyLink>())
            && "Collider registered without PhysicsBodyLink: call RegisterPhysicsComponents.");
 
@@ -172,13 +150,9 @@ void RigidBodyBinding::SyncToPhysics(World& world)
     if (version != LastStructuralVersion)
     {
         Reconcile(world, state);
-        LastStructuralVersion = world.StructuralVersion(); // post-flush value
+        LastStructuralVersion = world.StructuralVersion();
     }
 
-    // Push authored state into the simulation. Reads only (no version bump).
-    // Kinematic bodies take their authored transform; dynamic bodies take
-    // GravityScale, so a runtime edit acts on the next tick. Static colliders
-    // carry no RigidBody and so never match.
     state.KinematicPush.ForEachChunk([&](auto& view)
     {
         const auto transforms = view.template Read<LocalTransform>();
@@ -193,7 +167,15 @@ void RigidBodyBinding::SyncToPhysics(World& world)
             }
             else if (bodies[i].Motion == BodyMotion::Dynamic)
             {
-                Simulation->SetGravityScale(links[i].Body, bodies[i].GravityScale);
+                // SetGravityFactor does not wake a sleeping body. Compare the
+                // applied backend value so a runtime edit wakes exactly once,
+                // while unchanged bodies remain eligible for sleep.
+                const float applied = Simulation->GetGravityScale(links[i].Body);
+                if (std::abs(applied - bodies[i].GravityScale) > 1e-6f)
+                {
+                    Simulation->SetGravityScale(links[i].Body, bodies[i].GravityScale);
+                    Simulation->WakeBody(links[i].Body);
+                }
             }
         }
     });
@@ -204,7 +186,7 @@ void RigidBodyBinding::Evict(World& world)
     if (!Ready(world) || Owned.empty())
         return;
 
-    SyncFromPhysics(world); // capture transforms and velocities first
+    SyncFromPhysics(world);
 
     SceneState& state = EnsureState(world);
     for (const BodyRecord& rec : Owned)
@@ -224,9 +206,6 @@ void RigidBodyBinding::SyncFromPhysics(World& world)
 
     SceneState& state = EnsureState(world);
 
-    // Write resolved transforms and velocities back for dynamic bodies.
-    // Contiguous column walk, no hashing. Static colliders (no RigidBody) and
-    // kinematic bodies (skipped) are not written.
     state.DynamicPull.ForEachChunk([&](auto& view)
     {
         auto transforms = view.template Write<LocalTransform>();

--- a/engine/src/physics/RigidBodyBinding.cpp
+++ b/engine/src/physics/RigidBodyBinding.cpp
@@ -199,6 +199,24 @@ void RigidBodyBinding::SyncToPhysics(World& world)
     });
 }
 
+void RigidBodyBinding::Evict(World& world)
+{
+    if (!Ready(world) || Owned.empty())
+        return;
+
+    SyncFromPhysics(world); // capture transforms and velocities first
+
+    SceneState& state = EnsureState(world);
+    for (const BodyRecord& rec : Owned)
+    {
+        Simulation->RemoveBody(rec.Body);
+        if (world.IsAlive(rec.Entity) && world.HasComponent<PhysicsBodyLink>(rec.Entity))
+            state.Commands.RemoveComponent<PhysicsBodyLink>(rec.Entity);
+    }
+    Owned.clear();
+    state.Commands.Flush();
+}
+
 void RigidBodyBinding::SyncFromPhysics(World& world)
 {
     if (!Ready(world) || Owned.empty())

--- a/engine/src/physics/RigidBodyBinding.cpp
+++ b/engine/src/physics/RigidBodyBinding.cpp
@@ -1,4 +1,4 @@
-#include <physics/PhysicsScene.h>
+#include <physics/RigidBodyBinding.h>
 
 #include <cassert>
 
@@ -38,7 +38,7 @@ BodyTransform ReadPose(const World& world, EntityId entity)
 // PIMPL: keeps Query.h out of the public header, matching the Jolt firewall
 // discipline. The queries are cached (built once, bound to this scene's World)
 // and the command buffer is reused (Flush clears it).
-struct PhysicsScene::SceneState
+struct RigidBodyBinding::SceneState
 {
     explicit SceneState(World& world)
         : Commands(world)
@@ -52,12 +52,12 @@ struct PhysicsScene::SceneState
     Query<Write<LocalTransform>, Write<RigidBody>, Read<PhysicsBodyLink>> DynamicPull;
 };
 
-PhysicsScene::PhysicsScene(PhysicsWorld& world)
+RigidBodyBinding::RigidBodyBinding(PhysicsWorld& world)
     : Simulation(&world)
 {
 }
 
-PhysicsScene::~PhysicsScene()
+RigidBodyBinding::~RigidBodyBinding()
 {
     // Safe without a lifetime guard: the world outlives this scene (zones are
     // destroyed before the step system that owns the world).
@@ -65,7 +65,7 @@ PhysicsScene::~PhysicsScene()
         Simulation->RemoveBody(rec.Body);
 }
 
-bool PhysicsScene::Ready(const World& world) const
+bool RigidBodyBinding::Ready(const World& world) const
 {
     // The bridge needs colliders to bind, the link component to mark bound
     // bodies, and a transform to place them. RigidBody gates the dynamic and
@@ -75,14 +75,14 @@ bool PhysicsScene::Ready(const World& world) const
         && world.IsRegistered<PhysicsBodyLink>() && world.IsRegistered<LocalTransform>();
 }
 
-PhysicsScene::SceneState& PhysicsScene::EnsureState(World& world)
+RigidBodyBinding::SceneState& RigidBodyBinding::EnsureState(World& world)
 {
     if (!State)
         State = std::make_unique<SceneState>(world);
     return *State;
 }
 
-void PhysicsScene::Reconcile(World& world, SceneState& state)
+void RigidBodyBinding::Reconcile(World& world, SceneState& state)
 {
     ++ReconcileCount;
     const World& readOnly = world; // const iteration: do not mark colliders changed
@@ -146,7 +146,7 @@ void PhysicsScene::Reconcile(World& world, SceneState& state)
     state.Commands.Flush();
 }
 
-void PhysicsScene::SyncToPhysics(World& world)
+void RigidBodyBinding::SyncToPhysics(World& world)
 {
     // The likely misconfiguration: colliders registered but the runtime link
     // forgotten, which would re-create every body each step. Loud in debug;
@@ -184,7 +184,7 @@ void PhysicsScene::SyncToPhysics(World& world)
     });
 }
 
-void PhysicsScene::SyncFromPhysics(World& world)
+void RigidBodyBinding::SyncFromPhysics(World& world)
 {
     if (!Ready(world) || Owned.empty())
         return;

--- a/engine/src/runtime/FrameDriver.cpp
+++ b/engine/src/runtime/FrameDriver.cpp
@@ -8,6 +8,7 @@ const char* ToString(FramePhase phase)
     case FramePhase::ResolveLifecycle: return "ResolveLifecycle";
     case FramePhase::RebuildGraphics: return "RebuildGraphics";
     case FramePhase::DrainAsyncTasks: return "DrainAsyncTasks";
+    case FramePhase::RegistryResidency: return "RegistryResidency";
     case FramePhase::ScheduleTicks: return "ScheduleTicks";
     case FramePhase::Simulate: return "Simulate";
     case FramePhase::Update: return "Update";
@@ -86,6 +87,10 @@ void FrameDriver::StepOnce()
     InvokePhase(FramePhase::ResolveLifecycle, ctx);
     InvokePhase(FramePhase::RebuildGraphics, ctx);
     InvokePhase(FramePhase::DrainAsyncTasks, ctx);
+    // Residency runs every rendered frame — including zero-fixed-tick frames —
+    // so retained backend state reacts to lifecycle before the frame view can
+    // observe it, and Detaching registries get their final visit while alive.
+    InvokePhase(FramePhase::RegistryResidency, ctx);
     InvokePhase(FramePhase::ScheduleTicks, ctx);
 
     // Fixed-step simulation loop. Each fixed tick is its own mini-phase so

--- a/engine/src/zone/WorldPartitionRuntime.cpp
+++ b/engine/src/zone/WorldPartitionRuntime.cpp
@@ -183,6 +183,28 @@ bool WorldPartitionRuntime::IsParticipationLeaseValid(ParticipationLeaseId lease
         && LeaseSlots_[lease.Index].Generation == lease.Generation;
 }
 
+std::size_t WorldPartitionRuntime::InvalidateParticipationLeases(ZoneId zone)
+{
+    std::size_t invalidated = 0;
+    for (uint32_t index = 0; index < LeaseSlots_.size(); ++index)
+    {
+        ParticipationLeaseSlot& slot = LeaseSlots_[index];
+        if (!slot.Alive || slot.Zone != zone)
+            continue;
+
+        slot.Alive = false;
+        ++slot.Generation;
+        if (slot.Generation == 0)
+            ++slot.Generation;
+        slot.Zone = ZoneId{};
+        slot.Minimum = ZoneParticipation{};
+        FreeLeaseSlots_.push_back(index);
+        --ActiveLeaseCount_;
+        ++invalidated;
+    }
+    return invalidated;
+}
+
 void WorldPartitionRuntime::SetWorldTags(std::vector<std::string> tags)
 {
     WorldTags_ = std::move(tags);

--- a/engine/src/zone/WorldPartitionRuntime.cpp
+++ b/engine/src/zone/WorldPartitionRuntime.cpp
@@ -10,13 +10,11 @@
 
 namespace
 {
-
 bool SameParticipation(const ZoneParticipation& a, const ZoneParticipation& b)
 {
     return a.Visible == b.Visible && a.Physics == b.Physics && a.Logic == b.Logic
         && a.Audio == b.Audio;
 }
-
 } // namespace
 
 WorldPartitionRuntime::WorldPartitionRuntime(ZoneLoadRecipeFn recipe,
@@ -55,6 +53,23 @@ bool WorldPartitionRuntime::LoadManifest(WorldPartitionManifest manifest, std::s
     Focus_ = ZoneId{};
     HasFocusPosition_ = false;
     Pins_.clear();
+
+    // Reloading a manifest invalidates every outstanding lease without allowing
+    // an old token to alias a newly allocated slot in the same runtime object.
+    FreeLeaseSlots_.clear();
+    for (uint32_t i = 0; i < LeaseSlots_.size(); ++i)
+    {
+        ParticipationLeaseSlot& slot = LeaseSlots_[i];
+        slot.Alive = false;
+        ++slot.Generation;
+        if (slot.Generation == 0)
+            ++slot.Generation;
+        slot.Zone = ZoneId{};
+        slot.Minimum = ZoneParticipation{};
+        FreeLeaseSlots_.push_back(i);
+    }
+    ActiveLeaseCount_ = 0;
+
     PendingDestroys_.clear();
     Issued_.clear();
     Lingering_.clear();
@@ -114,6 +129,60 @@ void WorldPartitionRuntime::UnpinZone(ZoneId zone)
     std::erase_if(Pins_, [&](const ZonePin& pin) { return pin.Zone == zone; });
 }
 
+ParticipationLeaseId WorldPartitionRuntime::AcquireParticipationLease(
+    ZoneId zone,
+    ZoneParticipation minimum)
+{
+    if (!HasManifest_ || !zone.IsValid() || FindHeader(zone) == nullptr)
+    {
+        assert(false && "AcquireParticipationLease: zone must exist in the loaded manifest");
+        return ParticipationLeaseId{};
+    }
+
+    uint32_t index;
+    if (!FreeLeaseSlots_.empty())
+    {
+        index = FreeLeaseSlots_.back();
+        FreeLeaseSlots_.pop_back();
+    }
+    else
+    {
+        index = static_cast<uint32_t>(LeaseSlots_.size());
+        LeaseSlots_.push_back(ParticipationLeaseSlot{});
+    }
+
+    ParticipationLeaseSlot& slot = LeaseSlots_[index];
+    slot.Alive = true;
+    slot.Zone = zone;
+    slot.Minimum = minimum;
+    ++ActiveLeaseCount_;
+    return ParticipationLeaseId{ index, slot.Generation };
+}
+
+bool WorldPartitionRuntime::ReleaseParticipationLease(ParticipationLeaseId lease)
+{
+    if (!IsParticipationLeaseValid(lease))
+        return false;
+
+    ParticipationLeaseSlot& slot = LeaseSlots_[lease.Index];
+    slot.Alive = false;
+    ++slot.Generation;
+    if (slot.Generation == 0)
+        ++slot.Generation;
+    slot.Zone = ZoneId{};
+    slot.Minimum = ZoneParticipation{};
+    FreeLeaseSlots_.push_back(lease.Index);
+    --ActiveLeaseCount_;
+    return true;
+}
+
+bool WorldPartitionRuntime::IsParticipationLeaseValid(ParticipationLeaseId lease) const
+{
+    return lease.IsValid() && lease.Index < LeaseSlots_.size()
+        && LeaseSlots_[lease.Index].Alive
+        && LeaseSlots_[lease.Index].Generation == lease.Generation;
+}
+
 void WorldPartitionRuntime::SetWorldTags(std::vector<std::string> tags)
 {
     WorldTags_ = std::move(tags);
@@ -126,13 +195,20 @@ void WorldPartitionRuntime::Update(double deltaSeconds, AsyncZoneLoader& loader,
     std::vector<ZoneHopRank> ranks;
     if (HasManifest_ && Focus_.IsValid())
     {
-        // One resolved config for both calls: resolving only the demand call
-        // would demand zones past the base hop count that the ranks BFS never
-        // reaches, and rank-less zones sort last in load ordering.
         const WorldPartitionStreamingConfig resolved =
             ResolveRegionStreamingConfig(Manifest_, Focus_, Config_);
         ranks = ComputeZoneHopRanks(Manifest_, Index_, Focus_, resolved.HopCount, WorldTags_);
-        demand = ComputeZoneDemand(Manifest_, Index_, Focus_, Pins_, resolved,
+
+        // Leases use the existing pin-shaped pure demand input, but remain
+        // independently tokenized in the runtime. Duplicate entries are safe:
+        // ComputeZoneDemand ORs every floor onto the same zone.
+        std::vector<ZonePin> effectivePins = Pins_;
+        effectivePins.reserve(Pins_.size() + ActiveLeaseCount_);
+        for (const ParticipationLeaseSlot& lease : LeaseSlots_)
+            if (lease.Alive)
+                effectivePins.push_back(ZonePin{ lease.Zone, lease.Minimum });
+
+        demand = ComputeZoneDemand(Manifest_, Index_, Focus_, effectivePins, resolved,
                                    HasFocusPosition_ ? &FocusPosition_ : nullptr, WorldTags_);
     }
 
@@ -151,9 +227,6 @@ void WorldPartitionRuntime::Update(double deltaSeconds, AsyncZoneLoader& loader,
         return nullptr;
     };
 
-    // Load: desired zones neither loaded nor in flight, closest and
-    // highest-priority first into the single task queue. Pinned zones beyond
-    // hop range have no rank and sort last among equals.
     std::vector<const ZoneDemandRecord*> toLoad;
     for (const ZoneDemandRecord& record : demand)
         if (!zones.IsZoneLoaded(record.Zone) && !loader.IsLoading(record.Zone))
@@ -181,16 +254,11 @@ void WorldPartitionRuntime::Update(double deltaSeconds, AsyncZoneLoader& loader,
         if (header == nullptr)
             continue;
         ZoneLoadRecipe recipe = Recipe_(*header);
-        // Always dormant: participation flips after attach, so a mid-frame
-        // commit is invisible to every frame span and no discontinuity marks.
         loader.BeginLoad(record->Zone, std::move(recipe.Build), std::move(recipe.Finalize),
                          ZoneParticipation{}, std::move(recipe.Preload));
         Issued_.push_back(record->Zone);
     }
 
-    // Participation: loaded desired zones converge on their desired flags (the
-    // focus promotes to full; the previous focus demotes to dormant here in
-    // the same update, through its now-dormant neighbor demand).
     for (const ZoneDemandRecord& record : demand)
     {
         if (!zones.IsZoneLoaded(record.Zone))
@@ -199,9 +267,6 @@ void WorldPartitionRuntime::Update(double deltaSeconds, AsyncZoneLoader& loader,
             zones.SetParticipation(record.Zone, record.Desired);
     }
 
-    // Cancel undemanded in-flight loads. A false return means the build is
-    // mid-flight on the task thread: retried next update, reported Lingering
-    // meanwhile. Attached or cancelled entries leave the issued list.
     std::vector<ZoneId> stillPending;
     for (ZoneId zone : Issued_)
     {
@@ -213,10 +278,6 @@ void WorldPartitionRuntime::Update(double deltaSeconds, AsyncZoneLoader& loader,
     }
     Issued_ = std::move(stillPending);
 
-    // Linger and destroy: loaded, undesired, non-focus manifest zones (id
-    // order for determinism) accumulate linger time, sit dormant meanwhile,
-    // and are destroyed at or past the linger budget. Re-entering the desired
-    // set resets the clock (handled by the demand check dropping the state).
     std::erase_if(PendingDestroys_,
                   [&](ZoneId zone) { return !zones.IsZoneLoaded(zone); });
 
@@ -244,9 +305,6 @@ void WorldPartitionRuntime::Update(double deltaSeconds, AsyncZoneLoader& loader,
 
         if (state.Seconds >= Config_.LingerSeconds)
         {
-            // Destruction rides the drain (never mid-frame); the zone stays
-            // resident and reported until the commit runs, and must not be
-            // re-requested meanwhile.
             bool pending = false;
             for (ZoneId requested : PendingDestroys_)
                 pending |= requested == zone;
@@ -263,8 +321,6 @@ void WorldPartitionRuntime::Update(double deltaSeconds, AsyncZoneLoader& loader,
     }
     Lingering_ = std::move(lingering);
 
-    // Records: the demand set plus lingering zones (including uncancellable
-    // in-flight loads no longer demanded), ascending zone id.
     Records_ = std::move(demand);
     for (ZoneId zone : lingerRecords)
     {

--- a/engine/src/zone/ZoneRuntime.cpp
+++ b/engine/src/zone/ZoneRuntime.cpp
@@ -303,6 +303,8 @@ void ZoneRuntime::SetParticipation(ZoneId zone, ZoneParticipation participation)
 {
     assert(!ResidencyProcessing_
            && "SetParticipation during RegistryResidency: queue lifecycle work for a later drain point");
+    assert(!FrameViewLive_
+           && "SetParticipation with a live frame view: zone lifecycle is drain-point-only");
 
     LoadedZone* loaded = FindLoadedZone(zone);
     assert(loaded && "ZoneRuntime::SetParticipation: zone must be loaded");
@@ -326,6 +328,8 @@ FrameRegistryView ZoneRuntime::BuildFrameView()
 {
     assert(!ResidencyProcessing_
            && "BuildFrameView before FinalizeResidencyProcessing");
+    assert(!FrameViewLive_
+           && "BuildFrameView called before EndFrameView");
     FrameViewLive_ = true;
     InvalidateFrameScratch();
 
@@ -407,6 +411,7 @@ RegistryId ZoneRuntime::AllocateRegistryId()
 
 void ZoneRuntime::EndFrameView()
 {
+    assert(FrameViewLive_ && "EndFrameView called with no live frame view");
     FrameViewLive_ = false;
 }
 

--- a/engine/src/zone/ZoneRuntime.cpp
+++ b/engine/src/zone/ZoneRuntime.cpp
@@ -303,8 +303,13 @@ void ZoneRuntime::SetParticipation(ZoneId zone, ZoneParticipation participation)
 {
     assert(!ResidencyProcessing_
            && "SetParticipation during RegistryResidency: queue lifecycle work for a later drain point");
-    assert(!FrameViewLive_
-           && "SetParticipation with a live frame view: zone lifecycle is drain-point-only");
+
+    // Unlike structural lifecycle (create/attach/destroy), a participation
+    // change is legal while a frame view is live: no span pointer dangles, the
+    // built spans simply reflect the old sets for the rest of the frame, and
+    // the recorded change reaches a residency phase before the next view is
+    // built — so backends are corrected before any frame observes the new
+    // participation. The seamless dormant-preload activation relies on this.
 
     LoadedZone* loaded = FindLoadedZone(zone);
     assert(loaded && "ZoneRuntime::SetParticipation: zone must be loaded");

--- a/engine/src/zone/ZoneRuntime.cpp
+++ b/engine/src/zone/ZoneRuntime.cpp
@@ -43,6 +43,7 @@ Registry& ZoneRuntime::CreateZone(ZoneId zone)
 
     Registry* registryPtr = loaded->ZoneRegistry.get();
     Zones.push_back(std::move(loaded));
+    RecordAttached(registryPtr, ZoneParticipation{});
     return *registryPtr;
 }
 
@@ -72,6 +73,7 @@ Registry& ZoneRuntime::AttachZone(std::unique_ptr<Registry> registry,
 
     Registry* registryPtr = loaded->ZoneRegistry.get();
     Zones.push_back(std::move(loaded));
+    RecordAttached(registryPtr, participation);
     return *registryPtr;
 }
 
@@ -79,7 +81,7 @@ bool ZoneRuntime::DestroyZone(ZoneId zone)
 {
     auto it = std::find_if(Zones.begin(), Zones.end(),
         [zone](const std::unique_ptr<LoadedZone>& loaded) {
-            return loaded->Zone == zone;
+            return loaded->Zone == zone && !loaded->Detaching;
         });
 
     if (it == Zones.end())
@@ -88,8 +90,116 @@ bool ZoneRuntime::DestroyZone(ZoneId zone)
     assert(!FrameViewLive_
            && "DestroyZone with a live frame view: zone lifecycle is drain-point-only");
     InvalidateFrameScratch();
-    Zones.erase(it);
+
+    // Two-step destruction: mark and record now, erase in
+    // FinalizeResidencyProcessing after the residency phase has visited the
+    // registry with everything still alive. The zone is already invisible to
+    // queries and frame spans.
+    LoadedZone& detaching = **it;
+    detaching.Detaching = true;
+    RecordDetaching(detaching.ZoneRegistry.get(), detaching.Participation);
     return true;
+}
+
+std::span<const RegistryResidencyChange> ZoneRuntime::ResidencyChanges() const
+{
+    return { PendingChanges_.data(), PendingChanges_.size() };
+}
+
+void ZoneRuntime::FinalizeResidencyProcessing()
+{
+    assert(!FrameViewLive_
+           && "FinalizeResidencyProcessing with a live frame view: residency is drain-point-only");
+
+    std::erase_if(Zones, [](const std::unique_ptr<LoadedZone>& loaded) {
+        return loaded->Detaching;
+    });
+    PendingChanges_.clear();
+}
+
+RegistryResidencyChange* ZoneRuntime::FindPendingChange(RegistryId id)
+{
+    for (RegistryResidencyChange& change : PendingChanges_)
+        if (change.Id == id)
+            return &change;
+    return nullptr;
+}
+
+void ZoneRuntime::RecordAttached(Registry* registry, ZoneParticipation participation)
+{
+    assert(FindPendingChange(registry->Id) == nullptr
+           && "RecordAttached: registry ids are never reused within a window");
+    PendingChanges_.push_back(RegistryResidencyChange{
+        RegistryResidencyChangeKind::Attached,
+        registry->Id,
+        registry,
+        ZoneParticipation{},
+        participation,
+    });
+}
+
+void ZoneRuntime::RecordParticipationChange(Registry* registry,
+                                            ZoneParticipation previous,
+                                            ZoneParticipation current)
+{
+    RegistryResidencyChange* existing = FindPendingChange(registry->Id);
+    if (existing == nullptr)
+    {
+        PendingChanges_.push_back(RegistryResidencyChange{
+            RegistryResidencyChangeKind::ParticipationChanged,
+            registry->Id,
+            registry,
+            previous,
+            current,
+        });
+        return;
+    }
+
+    // Coalesce to first-observed Previous and final Current: intermediate
+    // states within one drain window were never observable to any frame.
+    existing->Current = current;
+
+    // A round trip (A -> B -> A) nets no change; drop the record so the
+    // residency phase never processes a transition that did not happen.
+    if (existing->Kind == RegistryResidencyChangeKind::ParticipationChanged
+        && existing->Previous == existing->Current)
+    {
+        const RegistryId id = existing->Id;
+        std::erase_if(PendingChanges_, [id](const RegistryResidencyChange& change) {
+            return change.Id == id;
+        });
+    }
+}
+
+void ZoneRuntime::RecordDetaching(Registry* registry, ZoneParticipation previous)
+{
+    RegistryResidencyChange* existing = FindPendingChange(registry->Id);
+    if (existing == nullptr)
+    {
+        PendingChanges_.push_back(RegistryResidencyChange{
+            RegistryResidencyChangeKind::Detaching,
+            registry->Id,
+            registry,
+            previous,
+            ZoneParticipation{},
+        });
+        return;
+    }
+
+    if (existing->Kind == RegistryResidencyChangeKind::Attached)
+    {
+        // Attached and destroyed inside one window: no frame ever observed the
+        // registry and nothing can hold backend state for it, so no change is
+        // emitted at all. The Detaching mark alone frees it at finalize.
+        const RegistryId id = existing->Id;
+        std::erase_if(PendingChanges_, [id](const RegistryResidencyChange& change) {
+            return change.Id == id;
+        });
+        return;
+    }
+
+    existing->Kind = RegistryResidencyChangeKind::Detaching;
+    existing->Current = ZoneParticipation{};
 }
 
 bool ZoneRuntime::IsZoneLoaded(ZoneId zone) const
@@ -120,7 +230,7 @@ Registry* ZoneRuntime::FindRegistry(RegistryId id)
     for (const auto& loaded : Zones)
     {
         assert(loaded->Zone == loaded->ZoneRegistry->Zone && "LoadedZone and Registry ZoneIds must match");
-        if (loaded->ZoneRegistry->Id == id)
+        if (!loaded->Detaching && loaded->ZoneRegistry->Id == id)
             return loaded->ZoneRegistry.get();
     }
 
@@ -138,7 +248,7 @@ const Registry* ZoneRuntime::FindRegistry(RegistryId id) const
     for (const auto& loaded : Zones)
     {
         assert(loaded->Zone == loaded->ZoneRegistry->Zone && "LoadedZone and Registry ZoneIds must match");
-        if (loaded->ZoneRegistry->Id == id)
+        if (!loaded->Detaching && loaded->ZoneRegistry->Id == id)
             return loaded->ZoneRegistry.get();
     }
 
@@ -156,12 +266,20 @@ void ZoneRuntime::SetParticipation(ZoneId zone, ZoneParticipation participation)
 {
     LoadedZone* loaded = FindLoadedZone(zone);
     assert(loaded && "ZoneRuntime::SetParticipation: zone must be loaded");
+
+    const ZoneParticipation previous = loaded->Participation;
     loaded->Participation = participation;
+    if (!(previous == participation))
+        RecordParticipationChange(loaded->ZoneRegistry.get(), previous, participation);
 }
 
 std::size_t ZoneRuntime::ZoneCount() const
 {
-    return Zones.size();
+    std::size_t count = 0;
+    for (const auto& loaded : Zones)
+        if (!loaded->Detaching)
+            ++count;
+    return count;
 }
 
 FrameRegistryView ZoneRuntime::BuildFrameView()
@@ -176,10 +294,13 @@ FrameRegistryView ZoneRuntime::BuildFrameView()
     PhysicsScratch.push_back(GlobalRegistry.get());
     LogicScratch.push_back(GlobalRegistry.get());
     AudioScratch.push_back(GlobalRegistry.get());
+    ParticipatingScratch.push_back(GlobalRegistry.get());
 
     for (const auto& loaded : Zones)
     {
         assert(loaded->Zone == loaded->ZoneRegistry->Zone && "LoadedZone and Registry ZoneIds must match");
+        if (loaded->Detaching)
+            continue;
 
         Registry* registry = loaded->ZoneRegistry.get();
         const ZoneParticipation& participation = loaded->Participation;
@@ -192,6 +313,8 @@ FrameRegistryView ZoneRuntime::BuildFrameView()
             LogicScratch.push_back(registry);
         if (participation.Audio)
             AudioScratch.push_back(registry);
+        if (participation.Any())
+            ParticipatingScratch.push_back(registry);
     }
 
     return FrameRegistryView{
@@ -199,7 +322,9 @@ FrameRegistryView ZoneRuntime::BuildFrameView()
         .Visible = std::span<Registry*>{ VisibleScratch.data(), VisibleScratch.size() },
         .Physics = std::span<Registry*>{ PhysicsScratch.data(), PhysicsScratch.size() },
         .Logic = std::span<Registry*>{ LogicScratch.data(), LogicScratch.size() },
-        .Audio = std::span<Registry*>{ AudioScratch.data(), AudioScratch.size() }
+        .Audio = std::span<Registry*>{ AudioScratch.data(), AudioScratch.size() },
+        .Participating = std::span<Registry* const>{ ParticipatingScratch.data(),
+                                                     ParticipatingScratch.size() }
     };
 }
 
@@ -208,7 +333,7 @@ ZoneRuntime::LoadedZone* ZoneRuntime::FindLoadedZone(ZoneId zone)
     for (const auto& loaded : Zones)
     {
         assert(loaded->Zone == loaded->ZoneRegistry->Zone && "LoadedZone and Registry ZoneIds must match");
-        if (loaded->Zone == zone)
+        if (!loaded->Detaching && loaded->Zone == zone)
             return loaded.get();
     }
 
@@ -220,7 +345,7 @@ const ZoneRuntime::LoadedZone* ZoneRuntime::FindLoadedZone(ZoneId zone) const
     for (const auto& loaded : Zones)
     {
         assert(loaded->Zone == loaded->ZoneRegistry->Zone && "LoadedZone and Registry ZoneIds must match");
-        if (loaded->Zone == zone)
+        if (!loaded->Detaching && loaded->Zone == zone)
             return loaded.get();
     }
 
@@ -246,9 +371,11 @@ void ZoneRuntime::InvalidateFrameScratch()
     std::fill(PhysicsScratch.begin(), PhysicsScratch.end(), nullptr);
     std::fill(LogicScratch.begin(), LogicScratch.end(), nullptr);
     std::fill(AudioScratch.begin(), AudioScratch.end(), nullptr);
+    std::fill(ParticipatingScratch.begin(), ParticipatingScratch.end(), nullptr);
 
     VisibleScratch.clear();
     PhysicsScratch.clear();
     LogicScratch.clear();
     AudioScratch.clear();
+    ParticipatingScratch.clear();
 }

--- a/engine/src/zone/ZoneRuntime.cpp
+++ b/engine/src/zone/ZoneRuntime.cpp
@@ -1,7 +1,7 @@
 #include <zone/ZoneRuntime.h>
 
-#include <cassert>
 #include <algorithm>
+#include <cassert>
 #include <limits>
 #include <span>
 
@@ -24,9 +24,10 @@ const Registry& ZoneRuntime::Global() const
 
 Registry& ZoneRuntime::CreateZone(ZoneId zone)
 {
+    assert(!ResidencyProcessing_
+           && "CreateZone during RegistryResidency: queue lifecycle work for a later drain point");
     assert(zone.IsValid() && "ZoneRuntime::CreateZone: zone id must be valid");
     assert(!FindLoadedZone(zone) && "ZoneRuntime::CreateZone: duplicate zone id");
-
     assert(!FrameViewLive_
            && "CreateZone with a live frame view: zone lifecycle is drain-point-only");
     InvalidateFrameScratch();
@@ -39,7 +40,8 @@ Registry& ZoneRuntime::CreateZone(ZoneId zone)
     loaded->ZoneRegistry = std::move(registry);
     loaded->Participation = {};
 
-    assert(loaded->Zone == loaded->ZoneRegistry->Zone && "LoadedZone and Registry ZoneIds must match");
+    assert(loaded->Zone == loaded->ZoneRegistry->Zone
+           && "LoadedZone and Registry ZoneIds must match");
 
     Registry* registryPtr = loaded->ZoneRegistry.get();
     Zones.push_back(std::move(loaded));
@@ -55,14 +57,21 @@ RegistryId ZoneRuntime::ReserveRegistryId()
 Registry& ZoneRuntime::AttachZone(std::unique_ptr<Registry> registry,
                                   ZoneParticipation participation)
 {
+    assert(!ResidencyProcessing_
+           && "AttachZone during RegistryResidency: queue lifecycle work for a later drain point");
     assert(!FrameViewLive_
            && "AttachZone with a live frame view: zone lifecycle is drain-point-only");
     assert(registry && "ZoneRuntime::AttachZone: registry must not be null");
-    assert(registry->Kind == RegistryKind::Zone && "ZoneRuntime::AttachZone: registry kind must be Zone");
-    assert(registry->Zone.IsValid() && "ZoneRuntime::AttachZone: registry must carry a valid ZoneId");
-    assert(registry->Id.IsValid() && "ZoneRuntime::AttachZone: registry id must be reserved via ReserveRegistryId");
-    assert(!FindLoadedZone(registry->Zone) && "ZoneRuntime::AttachZone: duplicate zone id");
-    assert(!FindRegistry(registry->Id) && "ZoneRuntime::AttachZone: duplicate registry id");
+    assert(registry->Kind == RegistryKind::Zone
+           && "ZoneRuntime::AttachZone: registry kind must be Zone");
+    assert(registry->Zone.IsValid()
+           && "ZoneRuntime::AttachZone: registry must carry a valid ZoneId");
+    assert(registry->Id.IsValid()
+           && "ZoneRuntime::AttachZone: registry id must be reserved via ReserveRegistryId");
+    assert(!FindLoadedZone(registry->Zone)
+           && "ZoneRuntime::AttachZone: duplicate zone id");
+    assert(!FindRegistry(registry->Id)
+           && "ZoneRuntime::AttachZone: duplicate registry id");
 
     InvalidateFrameScratch();
 
@@ -79,6 +88,9 @@ Registry& ZoneRuntime::AttachZone(std::unique_ptr<Registry> registry,
 
 bool ZoneRuntime::DestroyZone(ZoneId zone)
 {
+    assert(!ResidencyProcessing_
+           && "DestroyZone during RegistryResidency: queue lifecycle work for a later drain point");
+
     auto it = std::find_if(Zones.begin(), Zones.end(),
         [zone](const std::unique_ptr<LoadedZone>& loaded) {
             return loaded->Zone == zone && !loaded->Detaching;
@@ -125,9 +137,8 @@ void ZoneRuntime::FinalizeResidencyProcessing()
     assert(ResidencyProcessing_
            && "FinalizeResidencyProcessing called without BeginResidencyProcessing");
 
-    // Only destroy registries whose Detaching transition was in the stable batch
-    // just processed. A detach requested reentrantly during residency is queued
-    // in PendingChanges_ and stays alive until next frame's final visit.
+    // Every detaching registry in this stable batch received its final visit
+    // while alive. It is now safe to destroy the registry and its resources.
     std::erase_if(Zones, [this](const std::unique_ptr<LoadedZone>& loaded) {
         for (const RegistryResidencyChange& change : ProcessingChanges_)
         {
@@ -253,7 +264,8 @@ Registry* ZoneRuntime::FindRegistry(RegistryId id)
 
     for (const auto& loaded : Zones)
     {
-        assert(loaded->Zone == loaded->ZoneRegistry->Zone && "LoadedZone and Registry ZoneIds must match");
+        assert(loaded->Zone == loaded->ZoneRegistry->Zone
+               && "LoadedZone and Registry ZoneIds must match");
         if (!loaded->Detaching && loaded->ZoneRegistry->Id == id)
             return loaded->ZoneRegistry.get();
     }
@@ -271,7 +283,8 @@ const Registry* ZoneRuntime::FindRegistry(RegistryId id) const
 
     for (const auto& loaded : Zones)
     {
-        assert(loaded->Zone == loaded->ZoneRegistry->Zone && "LoadedZone and Registry ZoneIds must match");
+        assert(loaded->Zone == loaded->ZoneRegistry->Zone
+               && "LoadedZone and Registry ZoneIds must match");
         if (!loaded->Detaching && loaded->ZoneRegistry->Id == id)
             return loaded->ZoneRegistry.get();
     }
@@ -288,6 +301,9 @@ ZoneParticipation ZoneRuntime::GetParticipation(ZoneId zone) const
 
 void ZoneRuntime::SetParticipation(ZoneId zone, ZoneParticipation participation)
 {
+    assert(!ResidencyProcessing_
+           && "SetParticipation during RegistryResidency: queue lifecycle work for a later drain point");
+
     LoadedZone* loaded = FindLoadedZone(zone);
     assert(loaded && "ZoneRuntime::SetParticipation: zone must be loaded");
 
@@ -308,6 +324,8 @@ std::size_t ZoneRuntime::ZoneCount() const
 
 FrameRegistryView ZoneRuntime::BuildFrameView()
 {
+    assert(!ResidencyProcessing_
+           && "BuildFrameView before FinalizeResidencyProcessing");
     FrameViewLive_ = true;
     InvalidateFrameScratch();
 
@@ -322,7 +340,8 @@ FrameRegistryView ZoneRuntime::BuildFrameView()
 
     for (const auto& loaded : Zones)
     {
-        assert(loaded->Zone == loaded->ZoneRegistry->Zone && "LoadedZone and Registry ZoneIds must match");
+        assert(loaded->Zone == loaded->ZoneRegistry->Zone
+               && "LoadedZone and Registry ZoneIds must match");
         if (loaded->Detaching)
             continue;
 
@@ -356,7 +375,8 @@ ZoneRuntime::LoadedZone* ZoneRuntime::FindLoadedZone(ZoneId zone)
 {
     for (const auto& loaded : Zones)
     {
-        assert(loaded->Zone == loaded->ZoneRegistry->Zone && "LoadedZone and Registry ZoneIds must match");
+        assert(loaded->Zone == loaded->ZoneRegistry->Zone
+               && "LoadedZone and Registry ZoneIds must match");
         if (!loaded->Detaching && loaded->Zone == zone)
             return loaded.get();
     }
@@ -368,7 +388,8 @@ const ZoneRuntime::LoadedZone* ZoneRuntime::FindLoadedZone(ZoneId zone) const
 {
     for (const auto& loaded : Zones)
     {
-        assert(loaded->Zone == loaded->ZoneRegistry->Zone && "LoadedZone and Registry ZoneIds must match");
+        assert(loaded->Zone == loaded->ZoneRegistry->Zone
+               && "LoadedZone and Registry ZoneIds must match");
         if (!loaded->Detaching && loaded->Zone == zone)
             return loaded.get();
     }

--- a/engine/src/zone/ZoneRuntime.cpp
+++ b/engine/src/zone/ZoneRuntime.cpp
@@ -91,10 +91,9 @@ bool ZoneRuntime::DestroyZone(ZoneId zone)
            && "DestroyZone with a live frame view: zone lifecycle is drain-point-only");
     InvalidateFrameScratch();
 
-    // Two-step destruction: mark and record now, erase in
-    // FinalizeResidencyProcessing after the residency phase has visited the
-    // registry with everything still alive. The zone is already invisible to
-    // queries and frame spans.
+    // Two-step destruction: mark and record now. The registry is erased only
+    // after its Detaching change reaches a residency phase, so every backend
+    // owner gets a final visit while the registry and sibling resources live.
     LoadedZone& detaching = **it;
     detaching.Detaching = true;
     RecordDetaching(detaching.ZoneRegistry.get(), detaching.Participation);
@@ -106,15 +105,43 @@ std::span<const RegistryResidencyChange> ZoneRuntime::ResidencyChanges() const
     return { PendingChanges_.data(), PendingChanges_.size() };
 }
 
+std::span<const RegistryResidencyChange> ZoneRuntime::BeginResidencyProcessing()
+{
+    assert(!FrameViewLive_
+           && "BeginResidencyProcessing with a live frame view: residency is drain-point-only");
+    assert(!ResidencyProcessing_
+           && "BeginResidencyProcessing called before the previous batch was finalized");
+
+    ProcessingChanges_.clear();
+    ProcessingChanges_.swap(PendingChanges_);
+    ResidencyProcessing_ = true;
+    return { ProcessingChanges_.data(), ProcessingChanges_.size() };
+}
+
 void ZoneRuntime::FinalizeResidencyProcessing()
 {
     assert(!FrameViewLive_
            && "FinalizeResidencyProcessing with a live frame view: residency is drain-point-only");
+    assert(ResidencyProcessing_
+           && "FinalizeResidencyProcessing called without BeginResidencyProcessing");
 
-    std::erase_if(Zones, [](const std::unique_ptr<LoadedZone>& loaded) {
-        return loaded->Detaching;
+    // Only destroy registries whose Detaching transition was in the stable batch
+    // just processed. A detach requested reentrantly during residency is queued
+    // in PendingChanges_ and stays alive until next frame's final visit.
+    std::erase_if(Zones, [this](const std::unique_ptr<LoadedZone>& loaded) {
+        for (const RegistryResidencyChange& change : ProcessingChanges_)
+        {
+            if (change.Kind == RegistryResidencyChangeKind::Detaching
+                && change.Id == loaded->ZoneRegistry->Id)
+            {
+                return true;
+            }
+        }
+        return false;
     });
-    PendingChanges_.clear();
+
+    ProcessingChanges_.clear();
+    ResidencyProcessing_ = false;
 }
 
 RegistryResidencyChange* ZoneRuntime::FindPendingChange(RegistryId id)
@@ -188,14 +215,11 @@ void ZoneRuntime::RecordDetaching(Registry* registry, ZoneParticipation previous
 
     if (existing->Kind == RegistryResidencyChangeKind::Attached)
     {
-        // Attached and destroyed inside one window: no frame ever observed the
-        // registry and nothing can hold backend state for it, so no change is
-        // emitted at all. The Detaching mark alone frees it at finalize.
-        const RegistryId id = existing->Id;
-        std::erase_if(PendingChanges_, [id](const RegistryResidencyChange& change) {
-            return change.Id == id;
-        });
-        return;
+        // Finalizers run after AttachZone and before residency processing, so an
+        // attach-then-destroy registry may already own entities and backend
+        // resources. Preserve a Detaching visit rather than assuming there is
+        // nothing to clean up.
+        existing->Previous = existing->Current;
     }
 
     existing->Kind = RegistryResidencyChangeKind::Detaching;

--- a/test/core/TickEventChannelTests.cpp
+++ b/test/core/TickEventChannelTests.cpp
@@ -1,0 +1,121 @@
+// TickEventChannel<T> publication contract: BeginTick clears the previous
+// tick's events and promotes staged ones; staged events survive frames that
+// run zero ticks; consumers never observe half a tick.
+
+#include <core/event/TickEventChannel.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace
+{
+struct Ended
+{
+    int Id = 0;
+};
+} // namespace
+
+TEST(TickEventChannel, PublishIsVisibleWithinTheTick)
+{
+    TickEventChannel<Ended> channel;
+
+    channel.BeginTick();
+    channel.Publish(Ended{ 1 });
+    channel.Publish(Ended{ 2 });
+
+    ASSERT_EQ(channel.Size(), 2u);
+    EXPECT_EQ(channel.Items()[0].Id, 1);
+    EXPECT_EQ(channel.Items()[1].Id, 2);
+}
+
+TEST(TickEventChannel, BeginTickClearsThePreviousTick)
+{
+    TickEventChannel<Ended> channel;
+
+    channel.BeginTick();
+    channel.Publish(Ended{ 1 });
+    channel.BeginTick();
+
+    EXPECT_TRUE(channel.Empty());
+}
+
+TEST(TickEventChannel, StagedEventsSurfaceAtNextBeginTick)
+{
+    TickEventChannel<Ended> channel;
+
+    channel.Stage(Ended{ 7 });
+    EXPECT_TRUE(channel.Empty()) << "staged events must not be visible early";
+    EXPECT_EQ(channel.PendingCount(), 1u);
+
+    channel.BeginTick();
+
+    ASSERT_EQ(channel.Size(), 1u);
+    EXPECT_EQ(channel.Items()[0].Id, 7);
+    EXPECT_EQ(channel.PendingCount(), 0u);
+}
+
+TEST(TickEventChannel, StagedEventsSurviveZeroTickFrames)
+{
+    TickEventChannel<Ended> channel;
+
+    // A frame with no fixed ticks never calls BeginTick; the stage sits.
+    channel.Stage(Ended{ 3 });
+    channel.Stage(Ended{ 4 });
+
+    // Next frame that executes a tick sees both, ahead of that tick's own
+    // publications, in stage order.
+    channel.BeginTick();
+    channel.Publish(Ended{ 5 });
+
+    ASSERT_EQ(channel.Size(), 3u);
+    EXPECT_EQ(channel.Items()[0].Id, 3);
+    EXPECT_EQ(channel.Items()[1].Id, 4);
+    EXPECT_EQ(channel.Items()[2].Id, 5);
+}
+
+TEST(TickEventChannel, MultiTickFrameScopesEventsPerTick)
+{
+    TickEventChannel<Ended> channel;
+
+    channel.BeginTick();
+    channel.Publish(Ended{ 1 });
+    ASSERT_EQ(channel.Size(), 1u);
+
+    // Second tick of the same frame: tick one's events are gone. Frame-lane
+    // consumers reading after the frame see only the last tick.
+    channel.BeginTick();
+    channel.Publish(Ended{ 2 });
+
+    ASSERT_EQ(channel.Size(), 1u);
+    EXPECT_EQ(channel.Items()[0].Id, 2);
+}
+
+TEST(TickEventChannel, StageDuringTickHoldsUntilNextTick)
+{
+    TickEventChannel<Ended> channel;
+
+    channel.BeginTick();
+    channel.Publish(Ended{ 1 });
+    channel.Stage(Ended{ 2 }); // e.g. raised at a boundary mid-frame
+
+    ASSERT_EQ(channel.Size(), 1u);
+
+    channel.BeginTick();
+
+    ASSERT_EQ(channel.Size(), 1u);
+    EXPECT_EQ(channel.Items()[0].Id, 2);
+}
+
+TEST(TickEventChannel, MoveOnlyPayloadsCompile)
+{
+    TickEventChannel<std::string> channel;
+
+    channel.Stage(std::string("staged"));
+    channel.BeginTick();
+    channel.Publish(std::string("published"));
+
+    ASSERT_EQ(channel.Size(), 2u);
+    EXPECT_EQ(channel.Items()[0], "staged");
+    EXPECT_EQ(channel.Items()[1], "published");
+}

--- a/test/ecs/LifecycleHookTests.cpp
+++ b/test/ecs/LifecycleHookTests.cpp
@@ -1,0 +1,278 @@
+// The ComponentTraits lifecycle-hook contract: a hooked component leaving the
+// world fires OnRemove on every path — RemoveComponent, DestroyEntity, command
+// buffer, and World teardown — and teardown fires hooks while World resources
+// are still reachable, so retain/release components cannot leak their external
+// handles on unload.
+
+#include <ecs/CommandBuffer.h>
+#include <ecs/Ecs.h>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <vector>
+
+// ─── Test components ─────────────────────────────────────────────────────────
+
+static int              g_FirstAdds    = 0;
+static int              g_FirstRemoves = 0;
+static int              g_SecondRemoves = 0;
+static std::vector<int> g_RemoveOrder; // .Tag values in hook-fire order
+
+struct HookFirst  { int Tag = 0; };
+struct HookSecond { int Tag = 0; };
+struct PlainData  { float Value = 0.f; };
+
+template <>
+struct ComponentTraits<HookFirst>
+{
+    static void OnAdd(HookFirst& /*c*/, World& /*w*/, EntityId /*e*/)
+    {
+        ++g_FirstAdds;
+    }
+    static void OnRemove(const HookFirst& c, World& /*w*/, EntityId /*e*/)
+    {
+        ++g_FirstRemoves;
+        g_RemoveOrder.push_back(c.Tag);
+    }
+};
+
+template <>
+struct ComponentTraits<HookSecond>
+{
+    static void OnRemove(const HookSecond& c, World& /*w*/, EntityId /*e*/)
+    {
+        ++g_SecondRemoves;
+        g_RemoveOrder.push_back(c.Tag);
+    }
+};
+
+// Retain/release against a World resource, the StaticMeshComponent pattern.
+// MissedResource counts hook firings that could not reach the service — a
+// nonzero count means teardown destroyed resources before draining hooks.
+// RefReleases counts successful releases, so a teardown that fires no hooks
+// at all cannot pass vacuously.
+static int g_MissedResource = 0;
+static int g_RefReleases = 0;
+
+struct RefCountService
+{
+    std::array<int, 8> Counts{};
+};
+
+struct RefHandle { int Slot = 0; };
+
+template <>
+struct ComponentTraits<RefHandle>
+{
+    static void OnAdd(RefHandle& c, World& w, EntityId /*e*/)
+    {
+        if (auto* svc = w.TryGetResource<RefCountService>())
+            ++svc->Counts[c.Slot];
+        else
+            ++g_MissedResource;
+    }
+    static void OnRemove(const RefHandle& c, World& w, EntityId /*e*/)
+    {
+        if (auto* svc = w.TryGetResource<RefCountService>())
+        {
+            --svc->Counts[c.Slot];
+            ++g_RefReleases;
+        }
+        else
+        {
+            ++g_MissedResource;
+        }
+    }
+};
+
+SENCHA_DECLARE_COMPONENT_TYPE(HookFirst,  "test.lifecycle.hook_first");
+SENCHA_DECLARE_COMPONENT_TYPE(HookSecond, "test.lifecycle.hook_second");
+SENCHA_DECLARE_COMPONENT_TYPE(PlainData,  "test.lifecycle.plain");
+SENCHA_DECLARE_COMPONENT_TYPE(RefHandle,  "test.lifecycle.ref_handle");
+
+// ─── Fixture ─────────────────────────────────────────────────────────────────
+
+class LifecycleHookTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        g_FirstAdds     = 0;
+        g_FirstRemoves  = 0;
+        g_SecondRemoves = 0;
+        g_MissedResource = 0;
+        g_RemoveOrder.clear();
+
+        world.RegisterComponent<HookFirst>();
+        world.RegisterComponent<HookSecond>();
+        world.RegisterComponent<PlainData>();
+        world.RegisterComponent<RefHandle>();
+    }
+
+    World world;
+};
+
+// ─── Entity destruction ──────────────────────────────────────────────────────
+
+TEST_F(LifecycleHookTest, DestroyEntityFiresOnRemove)
+{
+    const EntityId e = world.CreateEntity();
+    world.AddComponent<HookFirst>(e, { 7 });
+
+    world.DestroyEntity(e);
+
+    EXPECT_EQ(g_FirstRemoves, 1);
+}
+
+TEST_F(LifecycleHookTest, DestroyEntityFiresHookedColumnsInRegistrationOrder)
+{
+    const EntityId e = world.CreateEntity();
+    // Added in reverse registration order; firing must follow registration
+    // (column) order, not add order, so repeated runs are deterministic.
+    world.AddComponent<HookSecond>(e, { 2 });
+    world.AddComponent<HookFirst>(e, { 1 });
+
+    world.DestroyEntity(e);
+
+    ASSERT_EQ(g_RemoveOrder.size(), 2u);
+    EXPECT_EQ(g_RemoveOrder[0], 1);
+    EXPECT_EQ(g_RemoveOrder[1], 2);
+}
+
+TEST_F(LifecycleHookTest, DestroyEntityMidChunkFiresTheDestroyedRowsValue)
+{
+    // Swap-and-pop moves the last row into the vacated slot; the hook must see
+    // the destroyed entity's component, not the moved neighbor's.
+    const EntityId a = world.CreateEntity();
+    const EntityId b = world.CreateEntity();
+    const EntityId c = world.CreateEntity();
+    world.AddComponent<HookFirst>(a, { 10 });
+    world.AddComponent<HookFirst>(b, { 20 });
+    world.AddComponent<HookFirst>(c, { 30 });
+    g_RemoveOrder.clear();
+    g_FirstRemoves = 0;
+
+    world.DestroyEntity(b);
+
+    ASSERT_EQ(g_FirstRemoves, 1);
+    EXPECT_EQ(g_RemoveOrder[0], 20);
+    EXPECT_TRUE(world.IsAlive(a));
+    EXPECT_TRUE(world.IsAlive(c));
+}
+
+TEST_F(LifecycleHookTest, DestroyEntityWithoutHookedComponentsFiresNothing)
+{
+    const EntityId e = world.CreateEntity();
+    world.AddComponent<PlainData>(e, { 1.f });
+
+    world.DestroyEntity(e);
+
+    EXPECT_EQ(g_FirstRemoves, 0);
+    EXPECT_EQ(g_SecondRemoves, 0);
+}
+
+TEST_F(LifecycleHookTest, RemoveComponentThenDestroyFiresOnce)
+{
+    const EntityId e = world.CreateEntity();
+    world.AddComponent<HookFirst>(e, { 5 });
+
+    world.RemoveComponent<HookFirst>(e);
+    EXPECT_EQ(g_FirstRemoves, 1);
+
+    world.DestroyEntity(e);
+    EXPECT_EQ(g_FirstRemoves, 1);
+}
+
+TEST_F(LifecycleHookTest, CommandBufferDestroyFiresOnRemoveAtFlush)
+{
+    const EntityId e = world.CreateEntity();
+    world.AddComponent<HookFirst>(e, { 3 });
+
+    CommandBuffer cmds(world);
+    cmds.DestroyEntity(e);
+    EXPECT_EQ(g_FirstRemoves, 0); // recorded, not yet executed
+
+    cmds.Flush();
+
+    EXPECT_EQ(g_FirstRemoves, 1);
+    EXPECT_FALSE(world.IsAlive(e));
+}
+
+// ─── World teardown ──────────────────────────────────────────────────────────
+
+TEST(LifecycleHookTeardown, WorldDestructionDrainsHooksBeforeResources)
+{
+    // The unload leak shape: components retain against a resource-owned
+    // service on add and release on remove. Scope exit must release every
+    // retain, and the service must still be alive when the hooks run.
+    {
+        World w;
+        w.RegisterComponent<RefHandle>();
+        auto& svc = w.AddResource<RefCountService>();
+        g_MissedResource = 0;
+        g_RefReleases = 0;
+
+        const EntityId a = w.CreateEntity();
+        const EntityId b = w.CreateEntity();
+        w.AddComponent<RefHandle>(a, { 0 });
+        w.AddComponent<RefHandle>(b, { 1 });
+        EXPECT_EQ(svc.Counts[0], 1);
+        EXPECT_EQ(svc.Counts[1], 1);
+
+        const EntityId c = w.CreateEntity();
+        w.AddComponent<RefHandle>(c, { 0 });
+        EXPECT_EQ(svc.Counts[0], 2);
+
+        // Sample on scope exit through the hooks themselves: if teardown
+        // reaches the service, every count returns to zero and nothing is
+        // recorded as missed.
+    }
+
+    EXPECT_EQ(g_RefReleases, 3)
+        << "teardown did not fire OnRemove for every live component";
+    EXPECT_EQ(g_MissedResource, 0)
+        << "OnRemove ran after World resources were destroyed";
+}
+
+TEST(LifecycleHookTeardown, WorldDestructionFiresOneRemovePerLiveComponent)
+{
+    g_FirstRemoves  = 0;
+    g_SecondRemoves = 0;
+    {
+        World w;
+        w.RegisterComponent<HookFirst>();
+        w.RegisterComponent<HookSecond>();
+
+        const EntityId a = w.CreateEntity();
+        w.AddComponent<HookFirst>(a, { 1 });
+        const EntityId b = w.CreateEntity();
+        w.AddComponent<HookFirst>(b, { 2 });
+        w.AddComponent<HookSecond>(b, { 3 });
+
+        // Destroyed-before-teardown entities must not fire again at teardown.
+        const EntityId dead = w.CreateEntity();
+        w.AddComponent<HookFirst>(dead, { 4 });
+        w.DestroyEntity(dead);
+        g_FirstRemoves = 0;
+        g_SecondRemoves = 0;
+    }
+
+    EXPECT_EQ(g_FirstRemoves, 2);
+    EXPECT_EQ(g_SecondRemoves, 1);
+}
+
+TEST(LifecycleHookTeardown, MoveAssignmentDrainsTargetHooks)
+{
+    g_FirstRemoves = 0;
+
+    World target;
+    target.RegisterComponent<HookFirst>();
+    const EntityId e = target.CreateEntity();
+    target.AddComponent<HookFirst>(e, { 9 });
+
+    World source;
+    target = std::move(source); // target's old state is torn down
+
+    EXPECT_EQ(g_FirstRemoves, 1);
+}

--- a/test/level_cook/BrushCollisionCookTests.cpp
+++ b/test/level_cook/BrushCollisionCookTests.cpp
@@ -1,6 +1,6 @@
 // End-to-end: an authored brush becomes walkable collision with zero collision
 // authoring. Cook a brush level -> a collision sidecar + per-cell .scol blobs ->
-// LoadZoneCollision spawns static colliders -> PhysicsScene makes static bodies
+// LoadZoneCollision spawns static colliders -> RigidBodyBinding makes static bodies
 // -> a downward ray hits the cooked brush. Headless: no AssetSystem, no graphics.
 
 #include "document/DocumentCook.h"
@@ -16,7 +16,7 @@
 #include <physics/CollisionShapeCache.h>
 #include <physics/PhysicsQueries.h>
 #include <physics/PhysicsRegistration.h>
-#include <physics/PhysicsScene.h>
+#include <physics/RigidBodyBinding.h>
 #include <physics/PhysicsWorld.h>
 #include <physics/ZoneCollisionLoader.h>
 #include <physics/components/Collider.h>
@@ -118,7 +118,7 @@ TEST_F(BrushCollisionCookTest, BrushBecomesWalkableCollision)
     EXPECT_EQ(cache.Count(), 1u);
 
     // The collider entity becomes a static body, and the brush is there to hit.
-    PhysicsScene scene(world);
+    RigidBodyBinding scene(world);
     scene.SyncToPhysics(ecs);
     EXPECT_EQ(scene.BodyCount(), 1u);
 

--- a/test/physics/CharacterMoverPoolTests.cpp
+++ b/test/physics/CharacterMoverPoolTests.cpp
@@ -1,5 +1,5 @@
 // CharacterMoverPool bridges CharacterController entities to CharacterMovers in a
-// dense pool (the character analogue of PhysicsScene). Tests drive it directly
+// dense pool (the character analogue of RigidBodyBinding). Tests drive it directly
 // with a bare ECS World; no engine frame harness, no Jolt headers.
 
 #include <gtest/gtest.h>

--- a/test/physics/CollisionCookTests.cpp
+++ b/test/physics/CollisionCookTests.cpp
@@ -17,7 +17,7 @@
 #include <physics/CollisionShapeCache.h>
 #include <physics/PhysicsQueries.h>
 #include <physics/PhysicsRegistration.h>
-#include <physics/PhysicsScene.h>
+#include <physics/RigidBodyBinding.h>
 #include <physics/PhysicsWorld.h>
 #include <physics/components/Collider.h>
 #include <physics/components/RigidBody.h>
@@ -81,7 +81,7 @@ TEST(CollisionCook, DynamicBodyRestsOnCookedFloorThroughScene)
     World ecs;
     ecs.RegisterComponent<LocalTransform>();
     RegisterPhysicsComponents(ecs);
-    PhysicsScene scene(world);
+    RigidBodyBinding scene(world);
 
     // Static floor entity carrying the cooked mesh shape (as a cooked scene would).
     const EntityId floor = ecs.CreateEntity();

--- a/test/physics/DrivenPoseOffsetVelocityTests.cpp
+++ b/test/physics/DrivenPoseOffsetVelocityTests.cpp
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+
+#include <physics/PhysicsWorld.h>
+
+TEST(PhysicsConstraint, OffCenterFollowerGetsBodyCenterFeedForward)
+{
+    constexpr float dt = 1.0f / 60.0f;
+
+    PhysicsWorld world;
+
+    BodyDesc body;
+    body.Shape = CollisionShape::MakeBox(Vec3d(0.25f, 0.25f, 0.25f));
+    body.Position = Vec3d(-1.0f, 5.0f, 0.0f);
+    body.Motion = BodyMotion::Dynamic;
+    body.Layer = CollisionLayer::Moving;
+    body.Mass = 1.0f;
+    body.GravityScale = 0.0f;
+    const PhysicsBodyId follower = world.AddBody(body);
+
+    DrivenPoseConstraintDesc desc;
+    desc.Follower = follower;
+    desc.FollowerLocalFrame.Position = Vec3d(1.0f, 0.0f, 0.0f);
+    const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
+    ASSERT_TRUE(constraint.IsValid());
+
+    DrivenPoseTarget target;
+    target.WorldFrame.Position = Vec3d(0.0f, 5.0f, 0.0f);
+    target.WorldFrame.Rotation = Quatf::Identity();
+    target.AngularVelocity = Vec3d(0.0f, 0.8f, 0.0f);
+
+    // At zero pose error, a +Y angular velocity around a frame one metre to the
+    // body's +X requires +Z body-center velocity: v_body = v_frame - w x r.
+    world.SetDrivenPoseTarget(constraint, target);
+    world.Step(dt);
+
+    EXPECT_NEAR(world.GetLinearVelocity(follower).X, 0.0f, 0.01f);
+    EXPECT_NEAR(world.GetLinearVelocity(follower).Z, 0.8f, 0.05f);
+    EXPECT_NEAR(
+        world.GetConstraintTelemetry(constraint).CommandedLinearSpeed,
+        0.8f,
+        0.05f);
+}

--- a/test/physics/GravityScaleWakeTests.cpp
+++ b/test/physics/GravityScaleWakeTests.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+
+#include <ecs/World.h>
+#include <physics/PhysicsRegistration.h>
+#include <physics/PhysicsWorld.h>
+#include <physics/RigidBodyBinding.h>
+#include <physics/components/Collider.h>
+#include <physics/components/PhysicsBodyLink.h>
+#include <physics/components/RigidBody.h>
+#include <world/transform/TransformComponents.h>
+
+TEST(RigidBodyBinding, GravityEditWakesSleepingBody)
+{
+    constexpr float dt = 1.0f / 60.0f;
+
+    PhysicsWorld physics;
+    World world;
+    world.RegisterComponent<LocalTransform>();
+    RegisterPhysicsComponents(world);
+    RigidBodyBinding binding(physics);
+
+    Transform3f transform;
+    transform.Position = Vec3d(0.0f, 5.0f, 0.0f);
+
+    const EntityId entity = world.CreateEntity();
+    world.AddComponent<LocalTransform>(entity, LocalTransform{ transform });
+    world.AddComponent<Collider>(
+        entity, Collider{ CollisionShape::MakeSphere(0.5f) });
+
+    RigidBody body;
+    body.Motion = BodyMotion::Dynamic;
+    body.GravityScale = 0.0f;
+    world.AddComponent<RigidBody>(entity, body);
+
+    binding.SyncToPhysics(world);
+    const PhysicsBodyLink* link = std::as_const(world).TryGet<PhysicsBodyLink>(entity);
+    ASSERT_NE(link, nullptr);
+
+    // A motionless zero-gravity body should naturally enter the sleep state.
+    for (int i = 0; i < 600 && physics.IsBodyActive(link->Body); ++i)
+    {
+        physics.Step(dt);
+        binding.SyncFromPhysics(world);
+    }
+    ASSERT_FALSE(physics.IsBodyActive(link->Body));
+
+    RigidBody* edited = world.TryGet<RigidBody>(entity);
+    ASSERT_NE(edited, nullptr);
+    edited->GravityScale = 1.0f;
+
+    binding.SyncToPhysics(world);
+    EXPECT_TRUE(physics.IsBodyActive(link->Body));
+
+    physics.Step(dt);
+    binding.SyncFromPhysics(world);
+    EXPECT_LT(std::as_const(world).TryGet<RigidBody>(entity)->LinearVelocity.Y, 0.0f);
+}

--- a/test/physics/GravityScaleWakeTests.cpp
+++ b/test/physics/GravityScaleWakeTests.cpp
@@ -9,6 +9,8 @@
 #include <physics/components/RigidBody.h>
 #include <world/transform/TransformComponents.h>
 
+#include <utility>
+
 TEST(RigidBodyBinding, GravityEditWakesSleepingBody)
 {
     constexpr float dt = 1.0f / 60.0f;

--- a/test/physics/PhysicsConstraintTests.cpp
+++ b/test/physics/PhysicsConstraintTests.cpp
@@ -1,0 +1,331 @@
+// Driven pose constraints at the PhysicsWorld facade: one-way locked driving
+// toward a per-step target frame with collision preserved, generational
+// handles that never resolve stale, and body-removal safety in either cleanup
+// order. Headless, no Jolt headers, explicit fixed stepping.
+
+#include <gtest/gtest.h>
+
+#include <physics/PhysicsWorld.h>
+
+#include <cmath>
+
+namespace
+{
+constexpr float kFixedDt = 1.0f / 60.0f;
+
+PhysicsBodyId AddFloor(PhysicsWorld& world)
+{
+    BodyDesc floor;
+    floor.Shape = CollisionShape::MakeBox(Vec3d(50.0f, 0.5f, 50.0f));
+    floor.Position = Vec3d(0.0f, 0.0f, 0.0f); // top surface at y = 0.5
+    floor.Motion = BodyMotion::Static;
+    floor.Layer = CollisionLayer::Static;
+    return world.AddBody(floor);
+}
+
+PhysicsBodyId AddDynamicBox(PhysicsWorld& world, const Vec3d& position, float gravityScale = 1.0f)
+{
+    BodyDesc box;
+    box.Shape = CollisionShape::MakeBox(Vec3d(0.25f, 0.25f, 0.25f));
+    box.Position = position;
+    box.Motion = BodyMotion::Dynamic;
+    box.Layer = CollisionLayer::Moving;
+    box.Mass = 1.0f;
+    box.GravityScale = gravityScale;
+    return world.AddBody(box);
+}
+
+DrivenPoseTarget FrameAt(const Vec3d& position, const Quatf& rotation = Quatf::Identity(),
+                         const Vec3d& linearVelocity = Vec3d::Zero(),
+                         const Vec3d& angularVelocity = Vec3d::Zero())
+{
+    DrivenPoseTarget target;
+    target.WorldFrame.Position = position;
+    target.WorldFrame.Rotation = rotation;
+    target.LinearVelocity = linearVelocity;
+    target.AngularVelocity = angularVelocity;
+    return target;
+}
+
+float Distance(const Vec3d& a, const Vec3d& b)
+{
+    return (a - b).Magnitude();
+}
+} // namespace
+
+// ─── Following ───────────────────────────────────────────────────────────────
+
+TEST(PhysicsConstraint, LockedPositionFollowsTranslatingFrame)
+{
+    PhysicsWorld world;
+    const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(0.0f, 5.0f, 0.0f), 0.0f);
+
+    DrivenPoseConstraintDesc desc;
+    desc.Follower = follower;
+    const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
+    ASSERT_TRUE(constraint.IsValid());
+
+    // The frame travels +X at 2 m/s; the follower must track it.
+    Vec3d framePos(0.0f, 5.0f, 0.0f);
+    const Vec3d frameVel(2.0f, 0.0f, 0.0f);
+    for (int i = 0; i < 120; ++i)
+    {
+        framePos = framePos + frameVel * kFixedDt;
+        world.SetDrivenPoseTarget(constraint, FrameAt(framePos, Quatf::Identity(), frameVel));
+        world.Step(kFixedDt);
+    }
+
+    EXPECT_LT(Distance(world.GetBodyTransform(follower).Position, framePos), 0.05f);
+    EXPECT_LT(world.GetConstraintTelemetry(constraint).PositionError, 0.05f);
+}
+
+TEST(PhysicsConstraint, LockedOrientationFollowsRotatingFrame)
+{
+    PhysicsWorld world;
+    const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(0.0f, 5.0f, 0.0f), 0.0f);
+
+    DrivenPoseConstraintDesc desc;
+    desc.Follower = follower;
+    const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
+
+    // The frame spins about Y at 1 rad/s.
+    const Vec3d spin(0.0f, 1.0f, 0.0f);
+    float angle = 0.0f;
+    for (int i = 0; i < 120; ++i)
+    {
+        angle += 1.0f * kFixedDt;
+        const Quatf frameRot = Quatf::FromAxisAngle(Vec3d(0.0f, 1.0f, 0.0f), angle);
+        world.SetDrivenPoseTarget(
+            constraint, FrameAt(Vec3d(0.0f, 5.0f, 0.0f), frameRot, Vec3d::Zero(), spin));
+        world.Step(kFixedDt);
+    }
+
+    EXPECT_LT(world.GetConstraintTelemetry(constraint).AngularError, 0.05f);
+    EXPECT_NEAR(world.GetAngularVelocity(follower).Y, 1.0f, 0.1f);
+}
+
+TEST(PhysicsConstraint, OffCenterFollowerTracesTheFrameRotation)
+{
+    PhysicsWorld world;
+    const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(-1.0f, 5.0f, 0.0f), 0.0f);
+
+    // The attachment frame sits 1 m from the body center along +X, so as the
+    // target frame spins about Y, the body center must orbit at radius 1.
+    DrivenPoseConstraintDesc desc;
+    desc.Follower = follower;
+    desc.FollowerLocalFrame.Position = Vec3d(1.0f, 0.0f, 0.0f);
+    const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
+
+    const Vec3d pivot(0.0f, 5.0f, 0.0f);
+    float angle = 0.0f;
+    for (int i = 0; i < 240; ++i)
+    {
+        angle += 0.8f * kFixedDt;
+        const Quatf frameRot = Quatf::FromAxisAngle(Vec3d(0.0f, 1.0f, 0.0f), angle);
+        world.SetDrivenPoseTarget(
+            constraint, FrameAt(pivot, frameRot, Vec3d::Zero(), Vec3d(0.0f, 0.8f, 0.0f)));
+        world.Step(kFixedDt);
+    }
+
+    // Body center stays one attachment-arm from the pivot while orbiting.
+    EXPECT_NEAR(Distance(world.GetBodyTransform(follower).Position, pivot), 1.0f, 0.05f);
+}
+
+TEST(PhysicsConstraint, SuspendedFollowerHoldsPoseWithoutGravity)
+{
+    PhysicsWorld world;
+    const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(0.0f, 5.0f, 0.0f), 0.0f);
+
+    DrivenPoseConstraintDesc desc;
+    desc.Follower = follower;
+    const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
+
+    for (int i = 0; i < 120; ++i)
+    {
+        world.SetDrivenPoseTarget(constraint, FrameAt(Vec3d(0.0f, 5.0f, 0.0f)));
+        world.Step(kFixedDt);
+    }
+
+    EXPECT_LT(Distance(world.GetBodyTransform(follower).Position, Vec3d(0.0f, 5.0f, 0.0f)), 0.01f);
+}
+
+TEST(PhysicsConstraint, FollowerStillCollidesWithWorldGeometry)
+{
+    PhysicsWorld world;
+    AddFloor(world);
+    const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(0.0f, 3.0f, 0.0f));
+
+    DrivenPoseConstraintDesc desc;
+    desc.Follower = follower;
+    const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
+
+    // Drive toward a frame below the floor; the solver must keep the box on
+    // top (floor top 0.5 + half extent 0.25) and telemetry must report the
+    // unclosed error instead of tunneling.
+    for (int i = 0; i < 180; ++i)
+    {
+        world.SetDrivenPoseTarget(constraint, FrameAt(Vec3d(0.0f, -2.0f, 0.0f)));
+        world.Step(kFixedDt);
+    }
+
+    EXPECT_GT(world.GetBodyTransform(follower).Position.Y, 0.6f);
+    EXPECT_GT(world.GetConstraintTelemetry(constraint).PositionError, 2.0f);
+}
+
+TEST(PhysicsConstraint, TeleportSnapsWithoutSyntheticVelocity)
+{
+    PhysicsWorld world;
+    const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(0.0f, 5.0f, 0.0f), 0.0f);
+
+    DrivenPoseConstraintDesc desc;
+    desc.Follower = follower;
+    const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
+
+    world.SetDrivenPoseTarget(constraint, FrameAt(Vec3d(0.0f, 5.0f, 0.0f)));
+    world.Step(kFixedDt);
+
+    DrivenPoseTarget far = FrameAt(Vec3d(100.0f, 5.0f, 0.0f));
+    far.Teleported = true;
+    world.SetDrivenPoseTarget(constraint, far);
+    world.Step(kFixedDt);
+
+    // Snapped to the frame, with the frame's (zero) velocity — not a
+    // 6000 m/s chase.
+    EXPECT_LT(Distance(world.GetBodyTransform(follower).Position, Vec3d(100.0f, 5.0f, 0.0f)), 0.01f);
+    EXPECT_LT(world.GetLinearVelocity(follower).Magnitude(), 0.01f);
+}
+
+// ─── Handles and lifecycle ───────────────────────────────────────────────────
+
+TEST(PhysicsConstraint, RemoveInvalidatesAndDeadHandleRemovalIsNoOp)
+{
+    PhysicsWorld world;
+    const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(0.0f, 5.0f, 0.0f));
+
+    DrivenPoseConstraintDesc desc;
+    desc.Follower = follower;
+    const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
+    EXPECT_TRUE(world.IsConstraintValid(constraint));
+    EXPECT_EQ(world.ConstraintCount(), 1u);
+
+    world.RemoveConstraint(constraint);
+    EXPECT_FALSE(world.IsConstraintValid(constraint));
+    EXPECT_EQ(world.ConstraintCount(), 0u);
+
+    world.RemoveConstraint(constraint); // dead handle: no-op, no double free
+    EXPECT_EQ(world.ConstraintCount(), 0u);
+}
+
+TEST(PhysicsConstraint, StaleGenerationNeverResolvesAfterSlotReuse)
+{
+    PhysicsWorld world;
+    const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(0.0f, 5.0f, 0.0f));
+
+    DrivenPoseConstraintDesc desc;
+    desc.Follower = follower;
+    const PhysicsConstraintId first = world.AddDrivenPoseConstraint(desc);
+    world.RemoveConstraint(first);
+
+    const PhysicsConstraintId second = world.AddDrivenPoseConstraint(desc);
+    ASSERT_EQ(second.Index, first.Index); // the slot was reused...
+    EXPECT_NE(second.Generation, first.Generation);
+
+    EXPECT_FALSE(world.IsConstraintValid(first)); // ...and the old handle is dead
+    EXPECT_TRUE(world.IsConstraintValid(second));
+
+    // A stale-handle target write must not leak onto the new constraint.
+    world.SetDrivenPoseTarget(first, FrameAt(Vec3d(9.0f, 9.0f, 9.0f)));
+    world.SetDrivenPoseTarget(second, FrameAt(Vec3d(0.0f, 5.0f, 0.0f)));
+    world.Step(kFixedDt);
+    EXPECT_LT(Distance(world.GetBodyTransform(follower).Position, Vec3d(0.0f, 5.0f, 0.0f)), 0.5f);
+}
+
+TEST(PhysicsConstraint, RemoveBodyInvalidatesDependentConstraints)
+{
+    PhysicsWorld world;
+    const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(0.0f, 5.0f, 0.0f));
+
+    DrivenPoseConstraintDesc desc;
+    desc.Follower = follower;
+    const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
+
+    world.RemoveBody(follower);
+    EXPECT_FALSE(world.IsConstraintValid(constraint));
+    EXPECT_EQ(world.ConstraintCount(), 0u);
+
+    world.RemoveConstraint(constraint); // the other cleanup order: no-op
+    world.Step(kFixedDt);               // and stepping is unaffected
+}
+
+TEST(PhysicsConstraint, CreateDestroyChurnLeaksNothing)
+{
+    PhysicsWorld world;
+    const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(0.0f, 5.0f, 0.0f), 0.0f);
+
+    for (int i = 0; i < 100; ++i)
+    {
+        DrivenPoseConstraintDesc desc;
+        desc.Follower = follower;
+        const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
+        ASSERT_TRUE(constraint.IsValid());
+        world.SetDrivenPoseTarget(constraint, FrameAt(Vec3d(0.0f, 5.0f, 0.0f)));
+        world.Step(kFixedDt);
+        world.RemoveConstraint(constraint);
+    }
+
+    EXPECT_EQ(world.ConstraintCount(), 0u);
+    EXPECT_EQ(world.StaleRefreshCount(), 0u);
+}
+
+#ifndef NDEBUG
+TEST(PhysicsConstraint, UnrefreshedConstraintAssertsInDebug)
+{
+    // The refresh contract: targets are per-step input. With residency
+    // transitions explicit, an unrefreshed live constraint can only be an
+    // orchestration bug.
+    EXPECT_DEATH(
+        {
+            PhysicsWorld world;
+            const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(0.0f, 5.0f, 0.0f));
+            DrivenPoseConstraintDesc desc;
+            desc.Follower = follower;
+            (void)world.AddDrivenPoseConstraint(desc);
+            world.Step(kFixedDt); // no SetDrivenPoseTarget since creation
+        },
+        "not refreshed");
+}
+#endif
+
+// ─── Determinism ─────────────────────────────────────────────────────────────
+
+TEST(PhysicsConstraint, DeterministicAcrossIdenticalRuns)
+{
+    auto run = [](Vec3d& out)
+    {
+        PhysicsWorld world;
+        AddFloor(world);
+        const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(0.1f, 3.0f, -0.2f));
+
+        DrivenPoseConstraintDesc desc;
+        desc.Follower = follower;
+        const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
+
+        Vec3d framePos(0.1f, 2.0f, -0.2f);
+        for (int i = 0; i < 120; ++i)
+        {
+            framePos = framePos + Vec3d(1.0f, 0.0f, 0.0f) * kFixedDt;
+            world.SetDrivenPoseTarget(
+                constraint, FrameAt(framePos, Quatf::Identity(), Vec3d(1.0f, 0.0f, 0.0f)));
+            world.Step(kFixedDt);
+        }
+        out = world.GetBodyTransform(follower).Position;
+    };
+
+    Vec3d a;
+    Vec3d b;
+    run(a);
+    run(b);
+    EXPECT_EQ(a.X, b.X);
+    EXPECT_EQ(a.Y, b.Y);
+    EXPECT_EQ(a.Z, b.Z);
+}

--- a/test/physics/PhysicsConstraintTests.cpp
+++ b/test/physics/PhysicsConstraintTests.cpp
@@ -1,7 +1,6 @@
-// Driven pose constraints at the PhysicsWorld facade: one-way locked driving
-// toward a per-step target frame with collision preserved, generational
-// handles that never resolve stale, and body-removal safety in either cleanup
-// order. Headless, no Jolt headers, explicit fixed stepping.
+// Driven pose constraints at the PhysicsWorld facade: one-way locked velocity
+// driving toward a start-of-step target frame, collision preserved,
+// generational handles, and body-removal safety in either cleanup order.
 
 #include <gtest/gtest.h>
 
@@ -17,7 +16,7 @@ PhysicsBodyId AddFloor(PhysicsWorld& world)
 {
     BodyDesc floor;
     floor.Shape = CollisionShape::MakeBox(Vec3d(50.0f, 0.5f, 50.0f));
-    floor.Position = Vec3d(0.0f, 0.0f, 0.0f); // top surface at y = 0.5
+    floor.Position = Vec3d(0.0f, 0.0f, 0.0f);
     floor.Motion = BodyMotion::Static;
     floor.Layer = CollisionLayer::Static;
     return world.AddBody(floor);
@@ -53,7 +52,26 @@ float Distance(const Vec3d& a, const Vec3d& b)
 }
 } // namespace
 
-// ─── Following ───────────────────────────────────────────────────────────────
+TEST(PhysicsConstraint, StartOfStepTargetDoesNotDoubleCountFeedForward)
+{
+    PhysicsWorld world;
+    const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(0.0f, 5.0f, 0.0f), 0.0f);
+
+    DrivenPoseConstraintDesc desc;
+    desc.Follower = follower;
+    const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
+    ASSERT_TRUE(constraint.IsValid());
+
+    const Vec3d frameVelocity(2.0f, 0.0f, 0.0f);
+    world.SetDrivenPoseTarget(
+        constraint,
+        FrameAt(Vec3d(0.0f, 5.0f, 0.0f), Quatf::Identity(), frameVelocity));
+    world.Step(kFixedDt);
+
+    const float expectedX = frameVelocity.X * kFixedDt;
+    EXPECT_NEAR(world.GetBodyTransform(follower).Position.X, expectedX, 0.01f);
+    EXPECT_NEAR(world.GetConstraintTelemetry(constraint).CommandedLinearSpeed, 2.0f, 0.01f);
+}
 
 TEST(PhysicsConstraint, LockedPositionFollowsTranslatingFrame)
 {
@@ -65,18 +83,17 @@ TEST(PhysicsConstraint, LockedPositionFollowsTranslatingFrame)
     const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
     ASSERT_TRUE(constraint.IsValid());
 
-    // The frame travels +X at 2 m/s; the follower must track it.
     Vec3d framePos(0.0f, 5.0f, 0.0f);
     const Vec3d frameVel(2.0f, 0.0f, 0.0f);
     for (int i = 0; i < 120; ++i)
     {
-        framePos = framePos + frameVel * kFixedDt;
         world.SetDrivenPoseTarget(constraint, FrameAt(framePos, Quatf::Identity(), frameVel));
         world.Step(kFixedDt);
+        framePos = framePos + frameVel * kFixedDt;
+        EXPECT_LT(Distance(world.GetBodyTransform(follower).Position, framePos), 0.02f);
     }
 
-    EXPECT_LT(Distance(world.GetBodyTransform(follower).Position, framePos), 0.05f);
-    EXPECT_LT(world.GetConstraintTelemetry(constraint).PositionError, 0.05f);
+    EXPECT_LT(world.GetConstraintTelemetry(constraint).PositionError, 0.02f);
 }
 
 TEST(PhysicsConstraint, LockedOrientationFollowsRotatingFrame)
@@ -88,20 +105,20 @@ TEST(PhysicsConstraint, LockedOrientationFollowsRotatingFrame)
     desc.Follower = follower;
     const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
 
-    // The frame spins about Y at 1 rad/s.
     const Vec3d spin(0.0f, 1.0f, 0.0f);
     float angle = 0.0f;
     for (int i = 0; i < 120; ++i)
     {
-        angle += 1.0f * kFixedDt;
         const Quatf frameRot = Quatf::FromAxisAngle(Vec3d(0.0f, 1.0f, 0.0f), angle);
         world.SetDrivenPoseTarget(
             constraint, FrameAt(Vec3d(0.0f, 5.0f, 0.0f), frameRot, Vec3d::Zero(), spin));
         world.Step(kFixedDt);
+        angle += kFixedDt;
     }
 
     EXPECT_LT(world.GetConstraintTelemetry(constraint).AngularError, 0.05f);
     EXPECT_NEAR(world.GetAngularVelocity(follower).Y, 1.0f, 0.1f);
+    EXPECT_NEAR(world.GetConstraintTelemetry(constraint).CommandedAngularSpeed, 1.0f, 0.1f);
 }
 
 TEST(PhysicsConstraint, OffCenterFollowerTracesTheFrameRotation)
@@ -109,8 +126,6 @@ TEST(PhysicsConstraint, OffCenterFollowerTracesTheFrameRotation)
     PhysicsWorld world;
     const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(-1.0f, 5.0f, 0.0f), 0.0f);
 
-    // The attachment frame sits 1 m from the body center along +X, so as the
-    // target frame spins about Y, the body center must orbit at radius 1.
     DrivenPoseConstraintDesc desc;
     desc.Follower = follower;
     desc.FollowerLocalFrame.Position = Vec3d(1.0f, 0.0f, 0.0f);
@@ -120,14 +135,13 @@ TEST(PhysicsConstraint, OffCenterFollowerTracesTheFrameRotation)
     float angle = 0.0f;
     for (int i = 0; i < 240; ++i)
     {
-        angle += 0.8f * kFixedDt;
         const Quatf frameRot = Quatf::FromAxisAngle(Vec3d(0.0f, 1.0f, 0.0f), angle);
         world.SetDrivenPoseTarget(
             constraint, FrameAt(pivot, frameRot, Vec3d::Zero(), Vec3d(0.0f, 0.8f, 0.0f)));
         world.Step(kFixedDt);
+        angle += 0.8f * kFixedDt;
     }
 
-    // Body center stays one attachment-arm from the pivot while orbiting.
     EXPECT_NEAR(Distance(world.GetBodyTransform(follower).Position, pivot), 1.0f, 0.05f);
 }
 
@@ -159,9 +173,6 @@ TEST(PhysicsConstraint, FollowerStillCollidesWithWorldGeometry)
     desc.Follower = follower;
     const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
 
-    // Drive toward a frame below the floor; the solver must keep the box on
-    // top (floor top 0.5 + half extent 0.25) and telemetry must report the
-    // unclosed error instead of tunneling.
     for (int i = 0; i < 180; ++i)
     {
         world.SetDrivenPoseTarget(constraint, FrameAt(Vec3d(0.0f, -2.0f, 0.0f)));
@@ -189,13 +200,9 @@ TEST(PhysicsConstraint, TeleportSnapsWithoutSyntheticVelocity)
     world.SetDrivenPoseTarget(constraint, far);
     world.Step(kFixedDt);
 
-    // Snapped to the frame, with the frame's (zero) velocity — not a
-    // 6000 m/s chase.
     EXPECT_LT(Distance(world.GetBodyTransform(follower).Position, Vec3d(100.0f, 5.0f, 0.0f)), 0.01f);
     EXPECT_LT(world.GetLinearVelocity(follower).Magnitude(), 0.01f);
 }
-
-// ─── Handles and lifecycle ───────────────────────────────────────────────────
 
 TEST(PhysicsConstraint, RemoveInvalidatesAndDeadHandleRemovalIsNoOp)
 {
@@ -212,7 +219,7 @@ TEST(PhysicsConstraint, RemoveInvalidatesAndDeadHandleRemovalIsNoOp)
     EXPECT_FALSE(world.IsConstraintValid(constraint));
     EXPECT_EQ(world.ConstraintCount(), 0u);
 
-    world.RemoveConstraint(constraint); // dead handle: no-op, no double free
+    world.RemoveConstraint(constraint);
     EXPECT_EQ(world.ConstraintCount(), 0u);
 }
 
@@ -227,13 +234,12 @@ TEST(PhysicsConstraint, StaleGenerationNeverResolvesAfterSlotReuse)
     world.RemoveConstraint(first);
 
     const PhysicsConstraintId second = world.AddDrivenPoseConstraint(desc);
-    ASSERT_EQ(second.Index, first.Index); // the slot was reused...
+    ASSERT_EQ(second.Index, first.Index);
     EXPECT_NE(second.Generation, first.Generation);
 
-    EXPECT_FALSE(world.IsConstraintValid(first)); // ...and the old handle is dead
+    EXPECT_FALSE(world.IsConstraintValid(first));
     EXPECT_TRUE(world.IsConstraintValid(second));
 
-    // A stale-handle target write must not leak onto the new constraint.
     world.SetDrivenPoseTarget(first, FrameAt(Vec3d(9.0f, 9.0f, 9.0f)));
     world.SetDrivenPoseTarget(second, FrameAt(Vec3d(0.0f, 5.0f, 0.0f)));
     world.Step(kFixedDt);
@@ -253,8 +259,8 @@ TEST(PhysicsConstraint, RemoveBodyInvalidatesDependentConstraints)
     EXPECT_FALSE(world.IsConstraintValid(constraint));
     EXPECT_EQ(world.ConstraintCount(), 0u);
 
-    world.RemoveConstraint(constraint); // the other cleanup order: no-op
-    world.Step(kFixedDt);               // and stepping is unaffected
+    world.RemoveConstraint(constraint);
+    world.Step(kFixedDt);
 }
 
 TEST(PhysicsConstraint, CreateDestroyChurnLeaksNothing)
@@ -280,9 +286,6 @@ TEST(PhysicsConstraint, CreateDestroyChurnLeaksNothing)
 #ifndef NDEBUG
 TEST(PhysicsConstraint, UnrefreshedConstraintAssertsInDebug)
 {
-    // The refresh contract: targets are per-step input. With residency
-    // transitions explicit, an unrefreshed live constraint can only be an
-    // orchestration bug.
     EXPECT_DEATH(
         {
             PhysicsWorld world;
@@ -290,13 +293,25 @@ TEST(PhysicsConstraint, UnrefreshedConstraintAssertsInDebug)
             DrivenPoseConstraintDesc desc;
             desc.Follower = follower;
             (void)world.AddDrivenPoseConstraint(desc);
-            world.Step(kFixedDt); // no SetDrivenPoseTarget since creation
+            world.Step(kFixedDt);
         },
         "not refreshed");
 }
-#endif
 
-// ─── Determinism ─────────────────────────────────────────────────────────────
+TEST(PhysicsConstraint, UnsupportedSpringAssertsInPrototype)
+{
+    EXPECT_DEATH(
+        {
+            PhysicsWorld world;
+            const PhysicsBodyId follower = AddDynamicBox(world, Vec3d(0.0f, 5.0f, 0.0f));
+            DrivenPoseConstraintDesc desc;
+            desc.Follower = follower;
+            desc.LinearDrive.Response = PoseDriveResponse::Spring;
+            (void)world.AddDrivenPoseConstraint(desc);
+        },
+        "require P3");
+}
+#endif
 
 TEST(PhysicsConstraint, DeterministicAcrossIdenticalRuns)
 {
@@ -311,12 +326,13 @@ TEST(PhysicsConstraint, DeterministicAcrossIdenticalRuns)
         const PhysicsConstraintId constraint = world.AddDrivenPoseConstraint(desc);
 
         Vec3d framePos(0.1f, 2.0f, -0.2f);
+        const Vec3d frameVelocity(1.0f, 0.0f, 0.0f);
         for (int i = 0; i < 120; ++i)
         {
-            framePos = framePos + Vec3d(1.0f, 0.0f, 0.0f) * kFixedDt;
             world.SetDrivenPoseTarget(
-                constraint, FrameAt(framePos, Quatf::Identity(), Vec3d(1.0f, 0.0f, 0.0f)));
+                constraint, FrameAt(framePos, Quatf::Identity(), frameVelocity));
             world.Step(kFixedDt);
+            framePos = framePos + frameVelocity * kFixedDt;
         }
         out = world.GetBodyTransform(follower).Position;
     };

--- a/test/physics/PhysicsQueryTests.cpp
+++ b/test/physics/PhysicsQueryTests.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include <physics/PhysicsQueries.h>
-#include <physics/PhysicsScene.h> // PackEntity
+#include <physics/RigidBodyBinding.h> // PackEntity
 #include <physics/PhysicsWorld.h>
 
 namespace

--- a/test/physics/PhysicsResidencyTests.cpp
+++ b/test/physics/PhysicsResidencyTests.cpp
@@ -1,0 +1,237 @@
+// The physics residency contract: dormant means zero backend presence. A
+// registry leaving the physics domain evicts its bodies and movers from the
+// shared simulation (no contacts, no solver cost), state is captured into
+// components, and returning restores through the ordinary reconcile with no
+// dedicated path. Headless; no Jolt headers.
+
+#include <gtest/gtest.h>
+
+#include <app/GameContexts.h>
+#include <ecs/World.h>
+#include <physics/CharacterMoverPool.h>
+#include <physics/PhysicsRegistration.h>
+#include <physics/PhysicsStepSystem.h>
+#include <physics/PhysicsWorld.h>
+#include <physics/RigidBodyBinding.h>
+#include <physics/components/CharacterController.h>
+#include <physics/components/CharacterMoverLink.h>
+#include <physics/components/Collider.h>
+#include <physics/components/PhysicsBodyLink.h>
+#include <physics/components/RigidBody.h>
+#include <world/registry/Registry.h>
+#include <world/transform/TransformComponents.h>
+
+namespace
+{
+constexpr float kFixedDt = 1.0f / 60.0f;
+
+void SetUpPhysics(World& world)
+{
+    world.RegisterComponent<LocalTransform>();
+    RegisterPhysicsComponents(world);
+}
+
+EntityId SpawnAt(World& world, const Vec3d& position)
+{
+    Transform3f t;
+    t.Position = position;
+    const EntityId e = world.CreateEntity();
+    world.AddComponent<LocalTransform>(e, LocalTransform{ t });
+    return e;
+}
+
+EntityId SpawnDynamicBall(World& world, const Vec3d& position)
+{
+    const EntityId e = SpawnAt(world, position);
+    world.AddComponent<Collider>(e, Collider{ CollisionShape::MakeSphere(0.5f) });
+    world.AddComponent<RigidBody>(e, RigidBody{ BodyMotion::Dynamic, 1.0f, Vec3d::Zero(), 1.0f });
+    return e;
+}
+
+void Tick(RigidBodyBinding& binding, World& ecs, PhysicsWorld& physics, int steps)
+{
+    for (int i = 0; i < steps; ++i)
+    {
+        binding.SyncToPhysics(ecs);
+        physics.Step(kFixedDt);
+        binding.SyncFromPhysics(ecs);
+    }
+}
+} // namespace
+
+TEST(PhysicsResidency, EvictRemovesBodiesAndCapturesState)
+{
+    PhysicsWorld physics;
+    World ecs;
+    SetUpPhysics(ecs);
+    RigidBodyBinding binding(physics);
+
+    const EntityId ball = SpawnDynamicBall(ecs, Vec3d(0.0f, 50.0f, 0.0f));
+    Tick(binding, ecs, physics, 30); // fall a while
+
+    binding.Evict(ecs);
+
+    EXPECT_EQ(physics.BodyCount(), 0u);
+    EXPECT_EQ(binding.BodyCount(), 0u);
+    EXPECT_FALSE(ecs.HasComponent<PhysicsBodyLink>(ball));
+
+    // State was captured: the component carries the fall, frozen.
+    const RigidBody* body = ecs.TryGet<RigidBody>(ball);
+    ASSERT_NE(body, nullptr);
+    EXPECT_LT(body->LinearVelocity.Y, -1.0f);
+    EXPECT_LT(ecs.TryGet<LocalTransform>(ball)->Value.Position.Y, 50.0f);
+}
+
+TEST(PhysicsResidency, ReconcileRestoresEvictedBodiesFaithfully)
+{
+    // Free fall has no solver-internal state, so an evict/restore mid-fall
+    // must continue on the uninterrupted trajectory.
+    auto run = [](bool interrupt, Vec3d& out)
+    {
+        PhysicsWorld physics;
+        World ecs;
+        SetUpPhysics(ecs);
+        RigidBodyBinding binding(physics);
+
+        const EntityId ball = SpawnDynamicBall(ecs, Vec3d(0.0f, 100.0f, 0.0f));
+        Tick(binding, ecs, physics, 60);
+
+        if (interrupt)
+        {
+            binding.Evict(ecs);
+            EXPECT_EQ(physics.BodyCount(), 0u);
+            // The next sync's reconcile is the restore path.
+        }
+
+        Tick(binding, ecs, physics, 60);
+        out = ecs.TryGet<LocalTransform>(ball)->Value.Position;
+    };
+
+    Vec3d uninterrupted;
+    Vec3d resumed;
+    run(false, uninterrupted);
+    run(true, resumed);
+
+    EXPECT_NEAR(resumed.Y, uninterrupted.Y, 0.01f);
+}
+
+TEST(PhysicsResidency, DormantGeometryStopsColliding)
+{
+    // Two registries sharing one simulation: a ball rests on a dormant-able
+    // zone's floor. Evicting the floor's registry must drop the ball —
+    // "cannot affect simulation" includes being stood on.
+    PhysicsWorld physics;
+
+    World floorZone;
+    SetUpPhysics(floorZone);
+    RigidBodyBinding floorBinding(physics);
+    const EntityId floor = SpawnAt(floorZone, Vec3d(0.0f, 0.0f, 0.0f));
+    floorZone.AddComponent<Collider>(
+        floor, Collider{ CollisionShape::MakeBox(Vec3d(50.0f, 0.5f, 50.0f)) });
+
+    World ballZone;
+    SetUpPhysics(ballZone);
+    RigidBodyBinding ballBinding(physics);
+    const EntityId ball = SpawnDynamicBall(ballZone, Vec3d(0.0f, 2.0f, 0.0f));
+
+    for (int i = 0; i < 240; ++i)
+    {
+        floorBinding.SyncToPhysics(floorZone);
+        ballBinding.SyncToPhysics(ballZone);
+        physics.Step(kFixedDt);
+        ballBinding.SyncFromPhysics(ballZone);
+    }
+    const float restY = ballZone.TryGet<LocalTransform>(ball)->Value.Position.Y;
+    EXPECT_NEAR(restY, 1.0f, 0.05f); // resting on the floor
+
+    floorBinding.Evict(floorZone); // the floor's zone goes dormant
+
+    for (int i = 0; i < 60; ++i)
+    {
+        ballBinding.SyncToPhysics(ballZone);
+        physics.Step(kFixedDt);
+        ballBinding.SyncFromPhysics(ballZone);
+    }
+
+    EXPECT_LT(ballZone.TryGet<LocalTransform>(ball)->Value.Position.Y, restY - 1.0f);
+}
+
+TEST(PhysicsResidency, MoverPoolEvictReleasesMoversAndReconcileRestores)
+{
+    PhysicsWorld physics;
+    World ecs;
+    SetUpPhysics(ecs);
+    CharacterMoverPool pool(physics);
+
+    Transform3f t;
+    t.Position = Vec3d(0.0f, 5.0f, 0.0f);
+    const EntityId player = ecs.CreateEntity();
+    ecs.AddComponent<LocalTransform>(player, LocalTransform{ t });
+    ecs.AddComponent<CharacterController>(player, CharacterController{});
+
+    pool.Reconcile(ecs);
+    EXPECT_EQ(pool.MoverCount(), 1u);
+
+    pool.Evict(ecs);
+    EXPECT_EQ(pool.MoverCount(), 0u);
+    EXPECT_FALSE(ecs.HasComponent<CharacterMoverLink>(player));
+
+    pool.Reconcile(ecs); // return: the ordinary reconcile is the restore
+    EXPECT_EQ(pool.MoverCount(), 1u);
+    EXPECT_TRUE(ecs.HasComponent<CharacterMoverLink>(player));
+}
+
+TEST(PhysicsResidency, StepSystemEvictsOnPhysicsDomainExit)
+{
+    PhysicsStepSystem step;
+    EngineConfig config;
+
+    Registry registry = MakeZoneRegistry(RegistryId{ 2, 1 }, ZoneId{ 1 });
+    SetUpPhysics(registry.Components);
+    SpawnDynamicBall(registry.Components, Vec3d(0.0f, 5.0f, 0.0f));
+
+    RigidBodyBinding& binding =
+        registry.Resources.Ensure<RigidBodyBinding>(step.GetSimulation());
+    binding.SyncToPhysics(registry.Components);
+    ASSERT_EQ(step.GetSimulation().BodyCount(), 1u);
+
+    // The zone leaves the physics domain (dormancy — and Detaching arrives
+    // with the same Previous/Current shape).
+    ZoneParticipation previous;
+    previous.Physics = true;
+    RegistryResidencyChange change{
+        RegistryResidencyChangeKind::ParticipationChanged,
+        registry.Id,
+        &registry,
+        previous,
+        ZoneParticipation{},
+    };
+    RegistryResidencyContext ctx{ config, std::span<const RegistryResidencyChange>{ &change, 1 } };
+    step.RegistryResidency(ctx);
+
+    EXPECT_EQ(step.GetSimulation().BodyCount(), 0u);
+    EXPECT_EQ(binding.BodyCount(), 0u);
+}
+
+TEST(PhysicsResidency, EvictRestoreCyclesAreStable)
+{
+    PhysicsWorld physics;
+    World ecs;
+    SetUpPhysics(ecs);
+    RigidBodyBinding binding(physics);
+
+    SpawnDynamicBall(ecs, Vec3d(0.0f, 5.0f, 0.0f));
+    ecs.TryGet<RigidBody>(ecs.GetAliveEntities()[0])->GravityScale = 0.0f;
+
+    for (int cycle = 0; cycle < 10; ++cycle)
+    {
+        Tick(binding, ecs, physics, 5);
+        EXPECT_EQ(physics.BodyCount(), 1u);
+        binding.Evict(ecs);
+        EXPECT_EQ(physics.BodyCount(), 0u);
+    }
+
+    Tick(binding, ecs, physics, 1);
+    EXPECT_EQ(physics.BodyCount(), 1u); // exactly one body, no duplicates
+    EXPECT_EQ(binding.BodyCount(), 1u);
+}

--- a/test/physics/PhysicsWorldTests.cpp
+++ b/test/physics/PhysicsWorldTests.cpp
@@ -126,3 +126,117 @@ TEST(PhysicsWorld, CarriesUserDataForQueryMapping)
 
     EXPECT_EQ(world.GetUserData(id), 0xABCDEF01u);
 }
+
+// ─── Full body state (angular velocity, gravity scale, damping, wake) ────────
+
+TEST(PhysicsWorld, AngularVelocityRoundTrips)
+{
+    PhysicsWorld world;
+    BodyDesc desc;
+    desc.Shape = CollisionShape::MakeSphere(0.5f);
+    desc.Position = Vec3d(0.0f, 5.0f, 0.0f);
+    desc.Motion = BodyMotion::Dynamic;
+    desc.Layer = CollisionLayer::Moving;
+    desc.GravityScale = 0.0f; // free space: nothing but the spin
+    const PhysicsBodyId body = world.AddBody(desc);
+    ASSERT_TRUE(body.IsValid());
+
+    world.SetAngularVelocity(body, Vec3d(0.0f, 3.0f, 0.0f));
+    const Quatf before = world.GetBodyTransform(body).Rotation;
+    world.Step(kFixedDt);
+
+    // One step of default damping trims a fraction of a percent.
+    EXPECT_NEAR(world.GetAngularVelocity(body).Y, 3.0f, 0.05f);
+    const Quatf after = world.GetBodyTransform(body).Rotation;
+    EXPECT_FALSE(before.X == after.X && before.Y == after.Y
+                 && before.Z == after.Z && before.W == after.W);
+}
+
+TEST(PhysicsWorld, GravityScaleZeroSuspendsBody)
+{
+    PhysicsWorld world;
+
+    BodyDesc desc;
+    desc.Shape = CollisionShape::MakeSphere(0.5f);
+    desc.Position = Vec3d(0.0f, 5.0f, 0.0f);
+    desc.Motion = BodyMotion::Dynamic;
+    desc.Layer = CollisionLayer::Moving;
+    desc.GravityScale = 0.0f;
+    const PhysicsBodyId suspended = world.AddBody(desc);
+
+    desc.Position = Vec3d(3.0f, 5.0f, 0.0f);
+    desc.GravityScale = 1.0f;
+    const PhysicsBodyId falling = world.AddBody(desc);
+
+    for (int i = 0; i < 60; ++i)
+        world.Step(kFixedDt);
+
+    EXPECT_NEAR(world.GetBodyTransform(suspended).Position.Y, 5.0f, 1e-3f);
+    EXPECT_LT(world.GetBodyTransform(falling).Position.Y, 4.0f);
+}
+
+TEST(PhysicsWorld, GravityScaleChangesActOnTheNextStep)
+{
+    PhysicsWorld world;
+    const PhysicsBodyId sphere = AddFallingSphere(world, 50.0f);
+
+    for (int i = 0; i < 30; ++i)
+        world.Step(kFixedDt);
+    const float fallingSpeed = world.GetLinearVelocity(sphere).Y;
+    EXPECT_LT(fallingSpeed, -1.0f); // it was genuinely falling
+
+    world.SetGravityScale(sphere, 0.0f);
+    world.Step(kFixedDt);
+
+    // No gravity this step: vertical speed only loses its damping fraction.
+    EXPECT_GT(world.GetLinearVelocity(sphere).Y, fallingSpeed * 1.001f);
+}
+
+TEST(PhysicsWorld, HighAngularDampingBrakesSpinFaster)
+{
+    PhysicsWorld world;
+
+    BodyDesc desc;
+    desc.Shape = CollisionShape::MakeSphere(0.5f);
+    desc.Position = Vec3d(0.0f, 5.0f, 0.0f);
+    desc.Motion = BodyMotion::Dynamic;
+    desc.Layer = CollisionLayer::Moving;
+    desc.GravityScale = 0.0f;
+    desc.AngularDamping = 0.05f;
+    const PhysicsBodyId lazy = world.AddBody(desc);
+
+    desc.Position = Vec3d(3.0f, 5.0f, 0.0f);
+    desc.AngularDamping = 5.0f;
+    const PhysicsBodyId braked = world.AddBody(desc);
+
+    world.SetAngularVelocity(lazy, Vec3d(0.0f, 10.0f, 0.0f));
+    world.SetAngularVelocity(braked, Vec3d(0.0f, 10.0f, 0.0f));
+    for (int i = 0; i < 60; ++i)
+        world.Step(kFixedDt);
+
+    EXPECT_GT(world.GetAngularVelocity(lazy).Y, 2.0f * world.GetAngularVelocity(braked).Y);
+}
+
+TEST(PhysicsWorld, WakeBodyMakesGravityChangesActOnSleptBodies)
+{
+    PhysicsWorld world;
+    AddFloor(world);
+    const PhysicsBodyId sphere = AddFallingSphere(world, 2.0f);
+
+    for (int i = 0; i < 300; ++i) // settle and fall asleep
+        world.Step(kFixedDt);
+    const float restY = world.GetBodyTransform(sphere).Position.Y;
+
+    // A gravity-scale write alone does not wake a sleeping body: even inverted
+    // gravity leaves it resting. (This stillness is also the proof it slept.)
+    world.SetGravityScale(sphere, -1.0f);
+    for (int i = 0; i < 30; ++i)
+        world.Step(kFixedDt);
+    EXPECT_NEAR(world.GetBodyTransform(sphere).Position.Y, restY, 1e-3f);
+
+    // An explicit wake makes the pending gravity change act.
+    world.WakeBody(sphere);
+    for (int i = 0; i < 30; ++i)
+        world.Step(kFixedDt);
+    EXPECT_GT(world.GetBodyTransform(sphere).Position.Y, restY + 0.1f);
+}

--- a/test/physics/RigidBodyBindingTests.cpp
+++ b/test/physics/RigidBodyBindingTests.cpp
@@ -1,16 +1,19 @@
-// PhysicsScene bridges ECS entities (Collider + optional RigidBody + transform)
+// RigidBodyBinding bridges ECS entities (Collider + optional RigidBody + transform)
 // to bodies in the shared PhysicsWorld. Tests drive the bridge directly with a
 // bare ECS World; no engine frame harness, no Jolt headers.
 
 #include <gtest/gtest.h>
 
+#include <app/GameContexts.h>
 #include <ecs/World.h>
 #include <physics/PhysicsRegistration.h>
-#include <physics/PhysicsScene.h>
+#include <physics/PhysicsStepSystem.h>
 #include <physics/PhysicsWorld.h>
+#include <physics/RigidBodyBinding.h>
 #include <physics/components/Collider.h>
 #include <physics/components/PhysicsBodyLink.h>
 #include <physics/components/RigidBody.h>
+#include <world/registry/Registry.h>
 #include <world/transform/TransformComponents.h>
 
 namespace
@@ -34,23 +37,23 @@ EntityId SpawnAt(World& world, const Vec3d& position)
     return e;
 }
 
-void Tick(PhysicsScene& scene, World& ecs, PhysicsWorld& physics, int steps)
+void Tick(RigidBodyBinding& binding, World& ecs, PhysicsWorld& physics, int steps)
 {
     for (int i = 0; i < steps; ++i)
     {
-        scene.SyncToPhysics(ecs);
+        binding.SyncToPhysics(ecs);
         physics.Step(kFixedDt);
-        scene.SyncFromPhysics(ecs);
+        binding.SyncFromPhysics(ecs);
     }
 }
 } // namespace
 
-TEST(PhysicsScene, DynamicEntityRestsOnStaticFloor)
+TEST(RigidBodyBinding, DynamicEntityRestsOnStaticFloor)
 {
     PhysicsWorld physics;
     World ecs;
     SetUpPhysics(ecs);
-    PhysicsScene& scene = ecs.AddResource<PhysicsScene>(physics);
+    RigidBodyBinding binding(physics);
 
     EntityId floor = SpawnAt(ecs, Vec3d(0.0f, 0.0f, 0.0f));
     ecs.AddComponent<Collider>(floor, Collider{ CollisionShape::MakeBox(Vec3d(50.0f, 0.5f, 50.0f)) });
@@ -59,124 +62,128 @@ TEST(PhysicsScene, DynamicEntityRestsOnStaticFloor)
     ecs.AddComponent<Collider>(ball, Collider{ CollisionShape::MakeSphere(0.5f) });
     ecs.AddComponent<RigidBody>(ball, RigidBody{ BodyMotion::Dynamic, 1.0f, Vec3d::Zero(), 1.0f });
 
-    Tick(scene, ecs, physics, 240);
+    Tick(binding, ecs, physics, 240);
 
-    EXPECT_EQ(scene.BodyCount(), 2u);
+    EXPECT_EQ(binding.BodyCount(), 2u);
     const LocalTransform* rest = ecs.TryGet<LocalTransform>(ball);
     ASSERT_NE(rest, nullptr);
     EXPECT_NEAR(rest->Value.Position.Y, 1.0f, 0.05f); // floor top 0.5 + radius 0.5
 }
 
-TEST(PhysicsScene, RemovingColliderRemovesBody)
+TEST(RigidBodyBinding, RemovingColliderRemovesBody)
 {
     PhysicsWorld physics;
     World ecs;
     SetUpPhysics(ecs);
-    PhysicsScene& scene = ecs.AddResource<PhysicsScene>(physics);
+    RigidBodyBinding binding(physics);
 
     EntityId box = SpawnAt(ecs, Vec3d(0.0f, 1.0f, 0.0f));
     ecs.AddComponent<Collider>(box, Collider{ CollisionShape::MakeBox(Vec3d(0.5f, 0.5f, 0.5f)) });
 
-    scene.SyncToPhysics(ecs);
-    EXPECT_EQ(scene.BodyCount(), 1u);
+    binding.SyncToPhysics(ecs);
+    EXPECT_EQ(binding.BodyCount(), 1u);
     EXPECT_EQ(physics.BodyCount(), 1u);
 
     ecs.RemoveComponent<Collider>(box);
-    scene.SyncToPhysics(ecs);
-    EXPECT_EQ(scene.BodyCount(), 0u);
+    binding.SyncToPhysics(ecs);
+    EXPECT_EQ(binding.BodyCount(), 0u);
     EXPECT_EQ(physics.BodyCount(), 0u);
 }
 
-TEST(PhysicsScene, DestructorRemovesBodiesFromSharedWorld)
+TEST(RigidBodyBinding, RegistryTeardownRemovesBodiesFromSharedWorld)
 {
+    // The unload path as it actually runs: the binding lives in
+    // Registry::Resources and dies with the registry, removing that
+    // registry's bodies from the shared world.
     PhysicsWorld physics;
 
     {
-        World ecs;
+        Registry registry = MakeZoneRegistry(RegistryId{ 2, 1 }, ZoneId{ 1 });
+        World& ecs = registry.Components;
         SetUpPhysics(ecs);
-        PhysicsScene& scene = ecs.AddResource<PhysicsScene>(physics);
+        RigidBodyBinding& binding = registry.Resources.Register<RigidBodyBinding>(physics);
 
         EntityId box = SpawnAt(ecs, Vec3d(0.0f, 1.0f, 0.0f));
         ecs.AddComponent<Collider>(box, Collider{ CollisionShape::MakeBox(Vec3d(0.5f, 0.5f, 0.5f)) });
-        scene.SyncToPhysics(ecs);
+        binding.SyncToPhysics(ecs);
         EXPECT_EQ(physics.BodyCount(), 1u); // body lives in the shared world
-    } // ecs (and its PhysicsScene resource) destroyed here: simulates zone unload
+    } // registry destroyed here: the real zone-unload teardown
 
     EXPECT_EQ(physics.BodyCount(), 0u);
 }
 
-TEST(PhysicsScene, KinematicBodyFollowsAuthoredTransform)
+TEST(RigidBodyBinding, KinematicBodyFollowsAuthoredTransform)
 {
     PhysicsWorld physics;
     World ecs;
     SetUpPhysics(ecs);
-    PhysicsScene& scene = ecs.AddResource<PhysicsScene>(physics);
+    RigidBodyBinding binding(physics);
 
     EntityId platform = SpawnAt(ecs, Vec3d(0.0f, 0.0f, 0.0f));
     ecs.AddComponent<Collider>(platform, Collider{ CollisionShape::MakeBox(Vec3d(1.0f, 0.25f, 1.0f)) });
     ecs.AddComponent<RigidBody>(platform, RigidBody{ BodyMotion::Kinematic, 1.0f, Vec3d::Zero(), 1.0f });
 
-    scene.SyncToPhysics(ecs);
+    binding.SyncToPhysics(ecs);
     physics.Step(kFixedDt);
 
     // Move the authored transform; the kinematic body should track it on sync.
     if (LocalTransform* lt = ecs.TryGet<LocalTransform>(platform))
         lt->Value.Position = Vec3d(0.0f, 2.0f, 0.0f);
-    scene.SyncToPhysics(ecs);
+    binding.SyncToPhysics(ecs);
 
     // Reconcile must not have created a second body for the moved platform.
-    EXPECT_EQ(scene.BodyCount(), 1u);
+    EXPECT_EQ(binding.BodyCount(), 1u);
 }
 
 // The reconcile gate: topology work runs only when the zone's structural version
 // changes. Moving bodies and stepping (data writes) must not retrigger it.
-TEST(PhysicsScene, ReconcileSkipsWhenNothingStructuralChanged)
+TEST(RigidBodyBinding, ReconcileSkipsWhenNothingStructuralChanged)
 {
     PhysicsWorld physics;
     World ecs;
     SetUpPhysics(ecs);
-    PhysicsScene& scene = ecs.AddResource<PhysicsScene>(physics);
+    RigidBodyBinding binding(physics);
 
     EntityId box = SpawnAt(ecs, Vec3d(0.0f, 1.0f, 0.0f));
     ecs.AddComponent<Collider>(box, Collider{ CollisionShape::MakeBox(Vec3d(0.5f, 0.5f, 0.5f)) });
 
-    scene.SyncToPhysics(ecs);
-    EXPECT_EQ(scene.ReconcilePasses(), 1u); // one pass to create the body
+    binding.SyncToPhysics(ecs);
+    EXPECT_EQ(binding.ReconcilePasses(), 1u); // one pass to create the body
 
     for (int i = 0; i < 10; ++i)
     {
-        scene.SyncToPhysics(ecs);
+        binding.SyncToPhysics(ecs);
         physics.Step(kFixedDt);
-        scene.SyncFromPhysics(ecs);
+        binding.SyncFromPhysics(ecs);
     }
-    EXPECT_EQ(scene.ReconcilePasses(), 1u); // steady state: gate held, no rescan
+    EXPECT_EQ(binding.ReconcilePasses(), 1u); // steady state: gate held, no rescan
 
     // A structural change (a new collider) advances the gate exactly once.
     EntityId box2 = SpawnAt(ecs, Vec3d(3.0f, 1.0f, 0.0f));
     ecs.AddComponent<Collider>(box2, Collider{ CollisionShape::MakeBox(Vec3d(0.5f, 0.5f, 0.5f)) });
-    scene.SyncToPhysics(ecs);
-    EXPECT_EQ(scene.ReconcilePasses(), 2u);
-    EXPECT_EQ(scene.BodyCount(), 2u);
+    binding.SyncToPhysics(ecs);
+    EXPECT_EQ(binding.ReconcilePasses(), 2u);
+    EXPECT_EQ(binding.BodyCount(), 2u);
 }
 
 // The runtime PhysicsBodyLink appears when the body is bound and is stripped when
 // the collider is removed; it is the per-frame sync's hash-free handle.
-TEST(PhysicsScene, BodyLinkTracksColliderLifetime)
+TEST(RigidBodyBinding, BodyLinkTracksColliderLifetime)
 {
     PhysicsWorld physics;
     World ecs;
     SetUpPhysics(ecs);
-    PhysicsScene& scene = ecs.AddResource<PhysicsScene>(physics);
+    RigidBodyBinding binding(physics);
 
     EntityId box = SpawnAt(ecs, Vec3d(0.0f, 1.0f, 0.0f));
     ecs.AddComponent<Collider>(box, Collider{ CollisionShape::MakeBox(Vec3d(0.5f, 0.5f, 0.5f)) });
     EXPECT_FALSE(ecs.HasComponent<PhysicsBodyLink>(box));
 
-    scene.SyncToPhysics(ecs);
+    binding.SyncToPhysics(ecs);
     EXPECT_TRUE(ecs.HasComponent<PhysicsBodyLink>(box));
 
     ecs.RemoveComponent<Collider>(box);
-    scene.SyncToPhysics(ecs);
+    binding.SyncToPhysics(ecs);
     EXPECT_FALSE(ecs.HasComponent<PhysicsBodyLink>(box));
 }
 
@@ -184,34 +191,34 @@ TEST(PhysicsScene, BodyLinkTracksColliderLifetime)
 // with it, so only the physics-side Owned record can report the dead body. The
 // reconcile sweep (gated on the structural-version bump that destroy causes)
 // removes it. This is the case the dense Owned vector exists for.
-TEST(PhysicsScene, DestroyingEntityRemovesBody)
+TEST(RigidBodyBinding, DestroyingEntityRemovesBody)
 {
     PhysicsWorld physics;
     World ecs;
     SetUpPhysics(ecs);
-    PhysicsScene& scene = ecs.AddResource<PhysicsScene>(physics);
+    RigidBodyBinding binding(physics);
 
     EntityId box = SpawnAt(ecs, Vec3d(0.0f, 1.0f, 0.0f));
     ecs.AddComponent<Collider>(box, Collider{ CollisionShape::MakeBox(Vec3d(0.5f, 0.5f, 0.5f)) });
-    scene.SyncToPhysics(ecs);
+    binding.SyncToPhysics(ecs);
     EXPECT_EQ(physics.BodyCount(), 1u);
 
     ecs.DestroyEntity(box);
-    scene.SyncToPhysics(ecs);
-    EXPECT_EQ(scene.BodyCount(), 0u);
+    binding.SyncToPhysics(ecs);
+    EXPECT_EQ(binding.BodyCount(), 0u);
     EXPECT_EQ(physics.BodyCount(), 0u);
 }
 
 // Same inputs on one build produce bit-identical results: the bridge iterates in
 // archetype/chunk/row order (not unordered-map order) and Jolt runs single-threaded.
-TEST(PhysicsScene, DeterministicAcrossIdenticalRuns)
+TEST(RigidBodyBinding, DeterministicAcrossIdenticalRuns)
 {
     auto run = [](Vec3d& out)
     {
         PhysicsWorld physics;
         World ecs;
         SetUpPhysics(ecs);
-        PhysicsScene& scene = ecs.AddResource<PhysicsScene>(physics);
+        RigidBodyBinding binding(physics);
 
         EntityId floor = SpawnAt(ecs, Vec3d(0.0f, 0.0f, 0.0f));
         ecs.AddComponent<Collider>(floor, Collider{ CollisionShape::MakeBox(Vec3d(50.0f, 0.5f, 50.0f)) });
@@ -221,9 +228,9 @@ TEST(PhysicsScene, DeterministicAcrossIdenticalRuns)
 
         for (int i = 0; i < 120; ++i)
         {
-            scene.SyncToPhysics(ecs);
+            binding.SyncToPhysics(ecs);
             physics.Step(kFixedDt);
-            scene.SyncFromPhysics(ecs);
+            binding.SyncFromPhysics(ecs);
         }
         out = ecs.TryGet<LocalTransform>(ball)->Value.Position;
     };
@@ -235,4 +242,35 @@ TEST(PhysicsScene, DeterministicAcrossIdenticalRuns)
     EXPECT_EQ(a.X, b.X);
     EXPECT_EQ(a.Y, b.Y);
     EXPECT_EQ(a.Z, b.Z);
+}
+
+// The step system stores bindings in Registry::Resources — the owner of
+// per-registry backend bindings — never in the ECS World's resource bag.
+TEST(RigidBodyBinding, StepSystemStoresBindingInRegistryResources)
+{
+    EngineConfig config;
+    RuntimeFrameLoop runtime;
+    InputFrame input;
+    PhysicsStepSystem step;
+
+    Registry registry = MakeZoneRegistry(RegistryId{ 2, 1 }, ZoneId{ 1 });
+    SetUpPhysics(registry.Components);
+    EntityId box = SpawnAt(registry.Components, Vec3d(0.0f, 1.0f, 0.0f));
+    registry.Components.AddComponent<Collider>(
+        box, Collider{ CollisionShape::MakeBox(Vec3d(0.5f, 0.5f, 0.5f)) });
+
+    Registry* registries[] = { &registry };
+    PhysicsContext ctx{
+        .Config = config,
+        .Runtime = runtime,
+        .Input = input,
+        .Time = FixedSimTime{},
+        .Registries = FrameRegistryView{},
+        .ActiveRegistries = std::span<Registry*>{ registries },
+    };
+    step.Physics(ctx);
+
+    EXPECT_TRUE(registry.Resources.Has<RigidBodyBinding>());
+    EXPECT_FALSE(registry.Components.HasResource<RigidBodyBinding>());
+    EXPECT_EQ(registry.Resources.Get<RigidBodyBinding>().BodyCount(), 1u);
 }

--- a/test/physics/RigidBodyBindingTests.cpp
+++ b/test/physics/RigidBodyBindingTests.cpp
@@ -187,10 +187,10 @@ TEST(RigidBodyBinding, BodyLinkTracksColliderLifetime)
     EXPECT_FALSE(ecs.HasComponent<PhysicsBodyLink>(box));
 }
 
-// Destroy robustness: DestroyEntity fires no hook and the entity's link vanishes
-// with it, so only the physics-side Owned record can report the dead body. The
-// reconcile sweep (gated on the structural-version bump that destroy causes)
-// removes it. This is the case the dense Owned vector exists for.
+// Destroy robustness: PhysicsBodyLink carries no lifecycle hook, so it vanishes
+// silently with the entity and only the physics-side Owned record can report the
+// dead body. The reconcile sweep (gated on the structural-version bump that
+// destroy causes) removes it. This is the case the dense Owned vector exists for.
 TEST(RigidBodyBinding, DestroyingEntityRemovesBody)
 {
     PhysicsWorld physics;
@@ -273,4 +273,53 @@ TEST(RigidBodyBinding, StepSystemStoresBindingInRegistryResources)
     EXPECT_TRUE(registry.Resources.Has<RigidBodyBinding>());
     EXPECT_FALSE(registry.Components.HasResource<RigidBodyBinding>());
     EXPECT_EQ(registry.Resources.Get<RigidBodyBinding>().BodyCount(), 1u);
+}
+
+// ─── Full body state through the ECS bridge ──────────────────────────────────
+
+TEST(RigidBodyBinding, AngularStateRoundTripsThroughComponents)
+{
+    PhysicsWorld physics;
+    World ecs;
+    SetUpPhysics(ecs);
+    RigidBodyBinding binding(physics);
+
+    EntityId top = SpawnAt(ecs, Vec3d(0.0f, 5.0f, 0.0f));
+    ecs.AddComponent<Collider>(top, Collider{ CollisionShape::MakeSphere(0.5f) });
+    RigidBody body;
+    body.Motion = BodyMotion::Dynamic;
+    body.GravityScale = 0.0f;               // spin in place
+    body.AngularVelocity = Vec3d(0.0f, 4.0f, 0.0f);
+    ecs.AddComponent<RigidBody>(top, body);
+
+    Tick(binding, ecs, physics, 10);
+
+    const RigidBody* pulled = ecs.TryGet<RigidBody>(top);
+    ASSERT_NE(pulled, nullptr);
+    EXPECT_NEAR(pulled->AngularVelocity.Y, 4.0f, 0.25f); // damping trims a little
+    const LocalTransform* lt = ecs.TryGet<LocalTransform>(top);
+    ASSERT_NE(lt, nullptr);
+    EXPECT_NEAR(lt->Value.Position.Y, 5.0f, 1e-3f); // gravity scale held it up
+}
+
+TEST(RigidBodyBinding, RuntimeGravityScaleEditActsNextTick)
+{
+    PhysicsWorld physics;
+    World ecs;
+    SetUpPhysics(ecs);
+    RigidBodyBinding binding(physics);
+
+    EntityId ball = SpawnAt(ecs, Vec3d(0.0f, 50.0f, 0.0f));
+    ecs.AddComponent<Collider>(ball, Collider{ CollisionShape::MakeSphere(0.5f) });
+    ecs.AddComponent<RigidBody>(ball, RigidBody{ BodyMotion::Dynamic, 1.0f, Vec3d::Zero(), 1.0f });
+
+    Tick(binding, ecs, physics, 30);
+    const float fallingSpeed = ecs.TryGet<RigidBody>(ball)->LinearVelocity.Y;
+    EXPECT_LT(fallingSpeed, -1.0f);
+
+    // The suspended-actor case: gameplay zeroes gravity on the live component.
+    ecs.TryGet<RigidBody>(ball)->GravityScale = 0.0f;
+    Tick(binding, ecs, physics, 1);
+
+    EXPECT_GT(ecs.TryGet<RigidBody>(ball)->LinearVelocity.Y, fallingSpeed * 1.001f);
 }

--- a/test/runtime/AsyncZoneLoadTests.cpp
+++ b/test/runtime/AsyncZoneLoadTests.cpp
@@ -60,6 +60,7 @@ TEST(ZoneRuntimeAttach, DetachedRegistryAttachesAndIsVisible)
     FrameRegistryView view = zones.BuildFrameView();
     ASSERT_EQ(view.Logic.size(), 2u);   // the global registry rides every span
     EXPECT_EQ(view.Logic[1], &attached);
+    zones.EndFrameView();
 }
 
 TEST(ZoneRuntimeAttach, ReservedIdsNeverCollideWithCreateZone)
@@ -189,11 +190,15 @@ TEST(AsyncZoneLoad, DormantPreloadAttachesSeamlessly)
     ASSERT_EQ(dormantView.Logic.size(), 1u);
     EXPECT_EQ(dormantView.Logic[0], &zones.Global());
 
-    // The player crosses the doorway: the game flips the room live.
+    // The player crosses the doorway: the game flips the room live mid-frame
+    // (legal for participation — no span pointer dangles; the change reaches
+    // the next residency phase before the next view reflects it).
     zones.SetParticipation(nextRoom, ZoneParticipation{ .Visible = true, .Logic = true });
+    zones.EndFrameView(); // the frame ends; the next view sees the live room
     FrameRegistryView liveView = zones.BuildFrameView();
     ASSERT_EQ(liveView.Logic.size(), 2u);
     EXPECT_EQ(liveView.Logic[1], zones.FindZone(nextRoom));
+    zones.EndFrameView();
 }
 
 TEST(AsyncZoneLoad, CancelBeforeWorkDropsTheLoad)

--- a/test/runtime/ParticipationLeaseTests.cpp
+++ b/test/runtime/ParticipationLeaseTests.cpp
@@ -1,0 +1,152 @@
+#include <gtest/gtest.h>
+
+#include <core/json/JsonParser.h>
+#include <jobs/AsyncTaskQueue.h>
+#include <runtime/RuntimeFrameLoop.h>
+#include <zone/AsyncZoneLoader.h>
+#include <zone/WorldPartitionRuntime.h>
+#include <zone/ZoneRuntime.h>
+
+namespace
+{
+constexpr ZoneId kFocus{ 0xa1 };
+constexpr ZoneId kLeased{ 0xa2 };
+
+constexpr const char* kManifestJson = R"({
+  "format_version": 1,
+  "name": "LeaseFixture",
+  "start_zone": "00000000000000a1",
+  "regions": [ { "id": "00000000000000b1", "name": "Fixture" } ],
+  "zones": [
+    { "id": "00000000000000a1", "name": "Focus", "region": "00000000000000b1",
+      "scene": "focus.level.json",
+      "bounds": { "min": [0, 0, 0], "max": [4, 4, 4] },
+      "cooked_scene": "focus.cooked.json" },
+    { "id": "00000000000000a2", "name": "Leased", "region": "00000000000000b1",
+      "scene": "leased.level.json",
+      "bounds": { "min": [10, 0, 0], "max": [14, 4, 4] },
+      "cooked_scene": "leased.cooked.json" }
+  ],
+  "transitions": []
+})";
+
+WorldPartitionManifest LeaseManifest()
+{
+    const auto json = JsonParse(kManifestJson);
+    EXPECT_TRUE(json.has_value());
+    std::string error;
+    const auto manifest = ReadWorldPartitionManifest(*json, &error);
+    EXPECT_TRUE(manifest.has_value()) << error;
+    return *manifest;
+}
+
+const ZoneDemandRecord* FindDemand(
+    std::span<const ZoneDemandRecord> records,
+    ZoneId zone)
+{
+    for (const ZoneDemandRecord& record : records)
+        if (record.Zone == zone)
+            return &record;
+    return nullptr;
+}
+
+struct LeaseFixture
+{
+    LeaseFixture()
+        : Tasks(0)
+        , Loader(Tasks, Zones, Runtime)
+        , Partition(
+            [](const ZoneHeader&) {
+                ZoneLoadRecipe recipe;
+                recipe.Build = [](Registry&) {};
+                return recipe;
+            },
+            WorldPartitionStreamingConfig{ .HopCount = 0, .LingerSeconds = 0.0 })
+    {
+        std::string error;
+        EXPECT_TRUE(Partition.LoadManifest(LeaseManifest(), &error)) << error;
+        Partition.SetFocus(kFocus);
+    }
+
+    void Update()
+    {
+        Partition.Update(0.0, Loader, Zones);
+    }
+
+    AsyncTaskQueue Tasks;
+    ZoneRuntime Zones;
+    RuntimeFrameLoop Runtime;
+    AsyncZoneLoader Loader;
+    WorldPartitionRuntime Partition;
+};
+} // namespace
+
+TEST(ParticipationLease, IndependentHoldersComposeAndReleaseIndependently)
+{
+    LeaseFixture fixture;
+
+    const ParticipationLeaseId physics = fixture.Partition.AcquireParticipationLease(
+        kLeased, ZoneParticipation{ .Physics = true });
+    const ParticipationLeaseId logic = fixture.Partition.AcquireParticipationLease(
+        kLeased, ZoneParticipation{ .Logic = true });
+
+    ASSERT_TRUE(physics.IsValid());
+    ASSERT_TRUE(logic.IsValid());
+    EXPECT_EQ(fixture.Partition.ParticipationLeaseCount(), 2u);
+
+    fixture.Update();
+    const ZoneDemandRecord* combined =
+        FindDemand(fixture.Partition.DemandRecords(), kLeased);
+    ASSERT_NE(combined, nullptr);
+    EXPECT_TRUE(combined->Desired.Physics);
+    EXPECT_TRUE(combined->Desired.Logic);
+
+    EXPECT_TRUE(fixture.Partition.ReleaseParticipationLease(physics));
+    fixture.Update();
+
+    const ZoneDemandRecord* logicOnly =
+        FindDemand(fixture.Partition.DemandRecords(), kLeased);
+    ASSERT_NE(logicOnly, nullptr);
+    EXPECT_FALSE(logicOnly->Desired.Physics);
+    EXPECT_TRUE(logicOnly->Desired.Logic);
+
+    EXPECT_TRUE(fixture.Partition.ReleaseParticipationLease(logic));
+    fixture.Update();
+    EXPECT_EQ(FindDemand(fixture.Partition.DemandRecords(), kLeased), nullptr);
+    EXPECT_EQ(fixture.Partition.ParticipationLeaseCount(), 0u);
+}
+
+TEST(ParticipationLease, StaleTokenCannotReleaseReusedSlot)
+{
+    LeaseFixture fixture;
+
+    const ParticipationLeaseId first = fixture.Partition.AcquireParticipationLease(
+        kLeased, ZoneParticipation{ .Physics = true });
+    ASSERT_TRUE(fixture.Partition.ReleaseParticipationLease(first));
+
+    const ParticipationLeaseId second = fixture.Partition.AcquireParticipationLease(
+        kLeased, ZoneParticipation{ .Logic = true });
+    ASSERT_EQ(first.Index, second.Index);
+    EXPECT_NE(first.Generation, second.Generation);
+
+    EXPECT_FALSE(fixture.Partition.IsParticipationLeaseValid(first));
+    EXPECT_TRUE(fixture.Partition.IsParticipationLeaseValid(second));
+    EXPECT_FALSE(fixture.Partition.ReleaseParticipationLease(first));
+    EXPECT_TRUE(fixture.Partition.IsParticipationLeaseValid(second));
+}
+
+TEST(ParticipationLease, ManifestReloadInvalidatesOutstandingTokens)
+{
+    LeaseFixture fixture;
+
+    const ParticipationLeaseId lease = fixture.Partition.AcquireParticipationLease(
+        kLeased, ZoneParticipation{ .Physics = true });
+    ASSERT_TRUE(fixture.Partition.IsParticipationLeaseValid(lease));
+
+    std::string error;
+    ASSERT_TRUE(fixture.Partition.LoadManifest(LeaseManifest(), &error)) << error;
+
+    EXPECT_FALSE(fixture.Partition.IsParticipationLeaseValid(lease));
+    EXPECT_FALSE(fixture.Partition.ReleaseParticipationLease(lease));
+    EXPECT_EQ(fixture.Partition.ParticipationLeaseCount(), 0u);
+}

--- a/test/runtime/ParticipationLeaseTests.cpp
+++ b/test/runtime/ParticipationLeaseTests.cpp
@@ -4,7 +4,6 @@
 #include <jobs/AsyncTaskQueue.h>
 #include <runtime/RuntimeFrameLoop.h>
 #include <zone/AsyncZoneLoader.h>
-#include <zone/WorldPartitionManifestJson.h>
 #include <zone/WorldPartitionRuntime.h>
 #include <zone/ZoneRuntime.h>
 

--- a/test/runtime/ParticipationLeaseTests.cpp
+++ b/test/runtime/ParticipationLeaseTests.cpp
@@ -4,6 +4,7 @@
 #include <jobs/AsyncTaskQueue.h>
 #include <runtime/RuntimeFrameLoop.h>
 #include <zone/AsyncZoneLoader.h>
+#include <zone/WorldPartitionManifestJson.h>
 #include <zone/WorldPartitionRuntime.h>
 #include <zone/ZoneRuntime.h>
 
@@ -133,6 +134,22 @@ TEST(ParticipationLease, StaleTokenCannotReleaseReusedSlot)
     EXPECT_TRUE(fixture.Partition.IsParticipationLeaseValid(second));
     EXPECT_FALSE(fixture.Partition.ReleaseParticipationLease(first));
     EXPECT_TRUE(fixture.Partition.IsParticipationLeaseValid(second));
+}
+
+TEST(ParticipationLease, ForcedTeardownInvalidatesAllZoneHolders)
+{
+    LeaseFixture fixture;
+
+    const ParticipationLeaseId physics = fixture.Partition.AcquireParticipationLease(
+        kLeased, ZoneParticipation{ .Physics = true });
+    const ParticipationLeaseId logic = fixture.Partition.AcquireParticipationLease(
+        kLeased, ZoneParticipation{ .Logic = true });
+
+    EXPECT_EQ(fixture.Partition.InvalidateParticipationLeases(kLeased), 2u);
+    EXPECT_FALSE(fixture.Partition.IsParticipationLeaseValid(physics));
+    EXPECT_FALSE(fixture.Partition.IsParticipationLeaseValid(logic));
+    EXPECT_FALSE(fixture.Partition.ReleaseParticipationLease(physics));
+    EXPECT_EQ(fixture.Partition.ParticipationLeaseCount(), 0u);
 }
 
 TEST(ParticipationLease, ManifestReloadInvalidatesOutstandingTokens)

--- a/test/runtime/RegistryResidencyTests.cpp
+++ b/test/runtime/RegistryResidencyTests.cpp
@@ -1,8 +1,6 @@
-// Registry residency transitions: every lifecycle mutation records one
-// coalesced change per registry per drain window; DestroyZone defers
-// destruction so the Detaching registry stays alive and readable through the
-// batch until FinalizeResidencyProcessing; queries and frame views never
-// observe a detaching registry.
+// Registry residency transitions: lifecycle mutations coalesce in a pending
+// batch; BeginResidencyProcessing swaps that batch into stable storage so
+// handlers can enqueue next-frame changes without invalidating their span.
 
 #include <gtest/gtest.h>
 
@@ -25,9 +23,13 @@ ZoneParticipation Full()
 {
     return ZoneParticipation{ true, true, true, true };
 }
-} // namespace
 
-// ─── Recording and coalescing ────────────────────────────────────────────────
+void ProcessResidency(ZoneRuntime& runtime)
+{
+    (void)runtime.BeginResidencyProcessing();
+    runtime.FinalizeResidencyProcessing();
+}
+} // namespace
 
 TEST(RegistryResidency, CreateZoneRecordsAttached)
 {
@@ -40,7 +42,7 @@ TEST(RegistryResidency, CreateZoneRecordsAttached)
     EXPECT_EQ(changes[0].Id, zone.Id);
     EXPECT_EQ(changes[0].Instance, &zone);
     EXPECT_FALSE(changes[0].Previous.Any());
-    EXPECT_FALSE(changes[0].Current.Any()); // dormant attach
+    EXPECT_FALSE(changes[0].Current.Any());
 }
 
 TEST(RegistryResidency, CreateThenSetParticipationCoalescesIntoAttached)
@@ -73,7 +75,7 @@ TEST(RegistryResidency, SetParticipationRecordsPreviousAndCurrent)
 {
     ZoneRuntime runtime;
     runtime.CreateZone(ZoneId{ 1 });
-    runtime.FinalizeResidencyProcessing(); // close the attach window
+    ProcessResidency(runtime);
 
     runtime.SetParticipation(ZoneId{ 1 }, Full());
 
@@ -89,7 +91,7 @@ TEST(RegistryResidency, RepeatedChangesCoalesceToFirstPreviousFinalCurrent)
     ZoneRuntime runtime;
     runtime.CreateZone(ZoneId{ 1 });
     runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
-    runtime.FinalizeResidencyProcessing();
+    ProcessResidency(runtime);
 
     runtime.SetParticipation(ZoneId{ 1 }, Full());
     runtime.SetParticipation(ZoneId{ 1 }, ZoneParticipation{});
@@ -105,10 +107,10 @@ TEST(RegistryResidency, ParticipationRoundTripDropsTheRecord)
     ZoneRuntime runtime;
     runtime.CreateZone(ZoneId{ 1 });
     runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
-    runtime.FinalizeResidencyProcessing();
+    ProcessResidency(runtime);
 
     runtime.SetParticipation(ZoneId{ 1 }, Full());
-    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly()); // back where it started
+    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
 
     EXPECT_TRUE(runtime.ResidencyChanges().empty());
 }
@@ -118,14 +120,42 @@ TEST(RegistryResidency, NoOpSetParticipationRecordsNothing)
     ZoneRuntime runtime;
     runtime.CreateZone(ZoneId{ 1 });
     runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
-    runtime.FinalizeResidencyProcessing();
+    ProcessResidency(runtime);
 
     runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
 
     EXPECT_TRUE(runtime.ResidencyChanges().empty());
 }
 
-// ─── Two-step destruction ────────────────────────────────────────────────────
+TEST(RegistryResidency, ProcessingBatchIsStableUnderReentrantMutation)
+{
+    ZoneRuntime runtime;
+    Registry& first = runtime.CreateZone(ZoneId{ 1 });
+    Registry& second = runtime.CreateZone(ZoneId{ 2 });
+    ProcessResidency(runtime);
+
+    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
+    const auto processing = runtime.BeginResidencyProcessing();
+    ASSERT_EQ(processing.size(), 1u);
+    EXPECT_EQ(processing[0].Id, first.Id);
+
+    runtime.SetParticipation(ZoneId{ 2 }, Full());
+
+    // The active span is unchanged; the new mutation lives in next frame's
+    // pending batch instead of reallocating or being cleared by finalization.
+    ASSERT_EQ(processing.size(), 1u);
+    EXPECT_EQ(processing[0].Id, first.Id);
+    ASSERT_EQ(runtime.ResidencyChanges().size(), 1u);
+    EXPECT_EQ(runtime.ResidencyChanges()[0].Id, second.Id);
+
+    runtime.FinalizeResidencyProcessing();
+    ASSERT_EQ(runtime.ResidencyChanges().size(), 1u);
+
+    const auto next = runtime.BeginResidencyProcessing();
+    ASSERT_EQ(next.size(), 1u);
+    EXPECT_EQ(next[0].Id, second.Id);
+    runtime.FinalizeResidencyProcessing();
+}
 
 TEST(RegistryResidency, DestroyZoneMarksDetachingAndDefersDestruction)
 {
@@ -134,25 +164,26 @@ TEST(RegistryResidency, DestroyZoneMarksDetachingAndDefersDestruction)
     runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
     const RegistryId id = zone.Id;
     const EntityId entity = zone.Components.CreateEntity();
-    runtime.FinalizeResidencyProcessing();
+    ProcessResidency(runtime);
 
     ASSERT_TRUE(runtime.DestroyZone(ZoneId{ 1 }));
 
-    // Invisible to every query immediately...
     EXPECT_FALSE(runtime.IsZoneLoaded(ZoneId{ 1 }));
     EXPECT_EQ(runtime.FindZone(ZoneId{ 1 }), nullptr);
     EXPECT_EQ(runtime.FindRegistry(id), nullptr);
     EXPECT_EQ(runtime.ZoneCount(), 0u);
 
-    // ...but alive and readable through the change record until finalize.
-    const auto changes = runtime.ResidencyChanges();
-    ASSERT_EQ(changes.size(), 1u);
-    EXPECT_EQ(changes[0].Kind, RegistryResidencyChangeKind::Detaching);
-    EXPECT_EQ(changes[0].Previous, LogicOnly());
-    EXPECT_FALSE(changes[0].Current.Any());
-    ASSERT_EQ(changes[0].Instance, &zone);
-    EXPECT_TRUE(changes[0].Instance->Components.IsAlive(entity));
+    const auto pending = runtime.ResidencyChanges();
+    ASSERT_EQ(pending.size(), 1u);
+    EXPECT_EQ(pending[0].Kind, RegistryResidencyChangeKind::Detaching);
+    EXPECT_EQ(pending[0].Previous, LogicOnly());
+    EXPECT_FALSE(pending[0].Current.Any());
+    ASSERT_EQ(pending[0].Instance, &zone);
+    EXPECT_TRUE(pending[0].Instance->Components.IsAlive(entity));
 
+    const auto processing = runtime.BeginResidencyProcessing();
+    ASSERT_EQ(processing.size(), 1u);
+    EXPECT_TRUE(processing[0].Instance->Components.IsAlive(entity));
     runtime.FinalizeResidencyProcessing();
     EXPECT_TRUE(runtime.ResidencyChanges().empty());
 }
@@ -162,7 +193,7 @@ TEST(RegistryResidency, ParticipationChangeThenDestroyCoalescesToDetaching)
     ZoneRuntime runtime;
     runtime.CreateZone(ZoneId{ 1 });
     runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
-    runtime.FinalizeResidencyProcessing();
+    ProcessResidency(runtime);
 
     runtime.SetParticipation(ZoneId{ 1 }, Full());
     runtime.DestroyZone(ZoneId{ 1 });
@@ -170,19 +201,23 @@ TEST(RegistryResidency, ParticipationChangeThenDestroyCoalescesToDetaching)
     const auto changes = runtime.ResidencyChanges();
     ASSERT_EQ(changes.size(), 1u);
     EXPECT_EQ(changes[0].Kind, RegistryResidencyChangeKind::Detaching);
-    EXPECT_EQ(changes[0].Previous, LogicOnly()); // first observed, not Full
+    EXPECT_EQ(changes[0].Previous, LogicOnly());
 }
 
-TEST(RegistryResidency, AttachAndDestroyInOneWindowEmitsNothing)
+TEST(RegistryResidency, AttachAndDestroyInOneWindowStillEmitsDetaching)
 {
     ZoneRuntime runtime;
-    runtime.CreateZone(ZoneId{ 1 });
+    Registry& zone = runtime.CreateZone(ZoneId{ 1 });
+    const RegistryId id = zone.Id;
     runtime.DestroyZone(ZoneId{ 1 });
 
-    EXPECT_TRUE(runtime.ResidencyChanges().empty());
-    EXPECT_EQ(runtime.ZoneCount(), 0u);
+    const auto changes = runtime.ResidencyChanges();
+    ASSERT_EQ(changes.size(), 1u);
+    EXPECT_EQ(changes[0].Kind, RegistryResidencyChangeKind::Detaching);
+    EXPECT_EQ(changes[0].Id, id);
+    EXPECT_EQ(changes[0].Instance, &zone);
 
-    runtime.FinalizeResidencyProcessing(); // frees the never-observed zone
+    ProcessResidency(runtime);
     EXPECT_FALSE(runtime.IsZoneLoaded(ZoneId{ 1 }));
 }
 
@@ -190,7 +225,7 @@ TEST(RegistryResidency, DoubleDestroyReturnsFalse)
 {
     ZoneRuntime runtime;
     runtime.CreateZone(ZoneId{ 1 });
-    runtime.FinalizeResidencyProcessing();
+    ProcessResidency(runtime);
 
     EXPECT_TRUE(runtime.DestroyZone(ZoneId{ 1 }));
     EXPECT_FALSE(runtime.DestroyZone(ZoneId{ 1 }));
@@ -201,7 +236,7 @@ TEST(RegistryResidency, ZoneIdIsReusableWhilePredecessorDetaches)
     ZoneRuntime runtime;
     Registry& first = runtime.CreateZone(ZoneId{ 1 });
     const RegistryId firstId = first.Id;
-    runtime.FinalizeResidencyProcessing();
+    ProcessResidency(runtime);
 
     runtime.DestroyZone(ZoneId{ 1 });
     Registry& second = runtime.CreateZone(ZoneId{ 1 });
@@ -217,8 +252,6 @@ TEST(RegistryResidency, ZoneIdIsReusableWhilePredecessorDetaches)
     EXPECT_EQ(changes[1].Id, second.Id);
 }
 
-// ─── Frame view resolution ───────────────────────────────────────────────────
-
 TEST(RegistryResidency, FrameViewExcludesDetachingAndResolvesParticipating)
 {
     ZoneRuntime runtime;
@@ -227,31 +260,44 @@ TEST(RegistryResidency, FrameViewExcludesDetachingAndResolvesParticipating)
     Registry& detaching = runtime.CreateZone(ZoneId{ 3 });
     runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
     runtime.SetParticipation(ZoneId{ 3 }, Full());
-    runtime.FinalizeResidencyProcessing();
+    ProcessResidency(runtime);
     runtime.DestroyZone(ZoneId{ 3 });
 
     FrameRegistryView view = runtime.BuildFrameView();
 
-    ASSERT_EQ(view.Participating.size(), 2u); // global + active
+    ASSERT_EQ(view.Participating.size(), 2u);
     EXPECT_EQ(view.Participating[0], &runtime.Global());
     EXPECT_EQ(view.Participating[1], &active);
 
-    EXPECT_EQ(view.Find(active.Id), &active);
-    EXPECT_EQ(view.Find(runtime.Global().Id), &runtime.Global());
-    EXPECT_EQ(view.Find(dormant.Id), nullptr);   // attached but dormant
-    EXPECT_EQ(view.Find(detaching.Id), nullptr);
-    EXPECT_EQ(view.Find(RegistryId::Invalid()), nullptr);
+    EXPECT_EQ(view.FindParticipating(active.Id), &active);
+    EXPECT_EQ(view.FindParticipating(runtime.Global().Id), &runtime.Global());
+    EXPECT_EQ(view.FindParticipating(dormant.Id), nullptr);
+    EXPECT_EQ(view.FindParticipating(detaching.Id), nullptr);
+    EXPECT_EQ(view.FindParticipating(RegistryId::Invalid()), nullptr);
 
     runtime.EndFrameView();
 }
 
-TEST(RegistryResidency, IsAliveResolvesThroughTheView)
+TEST(RegistryResidency, DomainScopedLookupDoesNotResolveOtherDomains)
+{
+    ZoneRuntime runtime;
+    Registry& logicOnly = runtime.CreateZone(ZoneId{ 1 });
+    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
+    ProcessResidency(runtime);
+
+    FrameRegistryView view = runtime.BuildFrameView();
+    EXPECT_EQ(FindRegistry(view.Logic, logicOnly.Id), &logicOnly);
+    EXPECT_EQ(FindRegistry(view.Physics, logicOnly.Id), nullptr);
+    runtime.EndFrameView();
+}
+
+TEST(RegistryResidency, IsAliveResolvesThroughChosenSpan)
 {
     ZoneRuntime runtime;
     Registry& active = runtime.CreateZone(ZoneId{ 1 });
     Registry& dormant = runtime.CreateZone(ZoneId{ 2 });
     runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
-    runtime.FinalizeResidencyProcessing();
+    ProcessResidency(runtime);
 
     const EntityId live = active.Components.CreateEntity();
     const EntityId dead = active.Components.CreateEntity();
@@ -260,10 +306,10 @@ TEST(RegistryResidency, IsAliveResolvesThroughTheView)
 
     FrameRegistryView view = runtime.BuildFrameView();
 
-    EXPECT_TRUE(view.IsAlive(EntityRef{ active.Id, live }));
-    EXPECT_FALSE(view.IsAlive(EntityRef{ active.Id, dead }));
-    EXPECT_FALSE(view.IsAlive(EntityRef{ dormant.Id, inDormant })); // unresolvable
-    EXPECT_FALSE(view.IsAlive(EntityRef{}));
+    EXPECT_TRUE(IsAliveIn(view.Logic, EntityRef{ active.Id, live }));
+    EXPECT_FALSE(IsAliveIn(view.Logic, EntityRef{ active.Id, dead }));
+    EXPECT_FALSE(IsAliveIn(view.Logic, EntityRef{ dormant.Id, inDormant }));
+    EXPECT_FALSE(IsAliveIn(view.Logic, EntityRef{}));
 
     runtime.EndFrameView();
 }

--- a/test/runtime/RegistryResidencyTests.cpp
+++ b/test/runtime/RegistryResidencyTests.cpp
@@ -1,6 +1,6 @@
 // Registry residency transitions: lifecycle mutations coalesce in a pending
-// batch; BeginResidencyProcessing swaps that batch into stable storage so
-// handlers can enqueue next-frame changes without invalidating their span.
+// batch; BeginResidencyProcessing swaps that batch into stable storage, and
+// lifecycle mutation is forbidden until the batch is finalized.
 
 #include <gtest/gtest.h>
 
@@ -127,35 +127,32 @@ TEST(RegistryResidency, NoOpSetParticipationRecordsNothing)
     EXPECT_TRUE(runtime.ResidencyChanges().empty());
 }
 
-TEST(RegistryResidency, ProcessingBatchIsStableUnderReentrantMutation)
+TEST(RegistryResidency, BeginMovesPendingIntoStableProcessingStorage)
 {
     ZoneRuntime runtime;
-    Registry& first = runtime.CreateZone(ZoneId{ 1 });
-    Registry& second = runtime.CreateZone(ZoneId{ 2 });
-    ProcessResidency(runtime);
+    Registry& zone = runtime.CreateZone(ZoneId{ 1 });
 
-    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
     const auto processing = runtime.BeginResidencyProcessing();
     ASSERT_EQ(processing.size(), 1u);
-    EXPECT_EQ(processing[0].Id, first.Id);
+    EXPECT_EQ(processing[0].Id, zone.Id);
+    EXPECT_TRUE(runtime.ResidencyChanges().empty());
 
-    runtime.SetParticipation(ZoneId{ 2 }, Full());
-
-    // The active span is unchanged; the new mutation lives in next frame's
-    // pending batch instead of reallocating or being cleared by finalization.
-    ASSERT_EQ(processing.size(), 1u);
-    EXPECT_EQ(processing[0].Id, first.Id);
-    ASSERT_EQ(runtime.ResidencyChanges().size(), 1u);
-    EXPECT_EQ(runtime.ResidencyChanges()[0].Id, second.Id);
-
-    runtime.FinalizeResidencyProcessing();
-    ASSERT_EQ(runtime.ResidencyChanges().size(), 1u);
-
-    const auto next = runtime.BeginResidencyProcessing();
-    ASSERT_EQ(next.size(), 1u);
-    EXPECT_EQ(next[0].Id, second.Id);
     runtime.FinalizeResidencyProcessing();
 }
+
+#ifndef NDEBUG
+TEST(RegistryResidency, LifecycleMutationDuringResidencyAsserts)
+{
+    EXPECT_DEATH(
+        {
+            ZoneRuntime runtime;
+            runtime.CreateZone(ZoneId{ 1 });
+            (void)runtime.BeginResidencyProcessing();
+            runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
+        },
+        "during RegistryResidency");
+}
+#endif
 
 TEST(RegistryResidency, DestroyZoneMarksDetachingAndDefersDestruction)
 {

--- a/test/runtime/RegistryResidencyTests.cpp
+++ b/test/runtime/RegistryResidencyTests.cpp
@@ -1,0 +1,269 @@
+// Registry residency transitions: every lifecycle mutation records one
+// coalesced change per registry per drain window; DestroyZone defers
+// destruction so the Detaching registry stays alive and readable through the
+// batch until FinalizeResidencyProcessing; queries and frame views never
+// observe a detaching registry.
+
+#include <gtest/gtest.h>
+
+#include <world/registry/EntityRef.h>
+#include <world/registry/Registry.h>
+#include <zone/RegistryResidency.h>
+#include <zone/ZoneId.h>
+#include <zone/ZoneRuntime.h>
+
+namespace
+{
+ZoneParticipation LogicOnly()
+{
+    ZoneParticipation p;
+    p.Logic = true;
+    return p;
+}
+
+ZoneParticipation Full()
+{
+    return ZoneParticipation{ true, true, true, true };
+}
+} // namespace
+
+// ─── Recording and coalescing ────────────────────────────────────────────────
+
+TEST(RegistryResidency, CreateZoneRecordsAttached)
+{
+    ZoneRuntime runtime;
+    Registry& zone = runtime.CreateZone(ZoneId{ 1 });
+
+    const auto changes = runtime.ResidencyChanges();
+    ASSERT_EQ(changes.size(), 1u);
+    EXPECT_EQ(changes[0].Kind, RegistryResidencyChangeKind::Attached);
+    EXPECT_EQ(changes[0].Id, zone.Id);
+    EXPECT_EQ(changes[0].Instance, &zone);
+    EXPECT_FALSE(changes[0].Previous.Any());
+    EXPECT_FALSE(changes[0].Current.Any()); // dormant attach
+}
+
+TEST(RegistryResidency, CreateThenSetParticipationCoalescesIntoAttached)
+{
+    ZoneRuntime runtime;
+    runtime.CreateZone(ZoneId{ 1 });
+    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
+
+    const auto changes = runtime.ResidencyChanges();
+    ASSERT_EQ(changes.size(), 1u);
+    EXPECT_EQ(changes[0].Kind, RegistryResidencyChangeKind::Attached);
+    EXPECT_EQ(changes[0].Current, LogicOnly());
+}
+
+TEST(RegistryResidency, AttachZoneRecordsInitialParticipation)
+{
+    ZoneRuntime runtime;
+    const RegistryId reserved = runtime.ReserveRegistryId();
+    auto registry = std::make_unique<Registry>(MakeZoneRegistry(reserved, ZoneId{ 4 }));
+    runtime.AttachZone(std::move(registry), Full());
+
+    const auto changes = runtime.ResidencyChanges();
+    ASSERT_EQ(changes.size(), 1u);
+    EXPECT_EQ(changes[0].Kind, RegistryResidencyChangeKind::Attached);
+    EXPECT_EQ(changes[0].Id, reserved);
+    EXPECT_EQ(changes[0].Current, Full());
+}
+
+TEST(RegistryResidency, SetParticipationRecordsPreviousAndCurrent)
+{
+    ZoneRuntime runtime;
+    runtime.CreateZone(ZoneId{ 1 });
+    runtime.FinalizeResidencyProcessing(); // close the attach window
+
+    runtime.SetParticipation(ZoneId{ 1 }, Full());
+
+    const auto changes = runtime.ResidencyChanges();
+    ASSERT_EQ(changes.size(), 1u);
+    EXPECT_EQ(changes[0].Kind, RegistryResidencyChangeKind::ParticipationChanged);
+    EXPECT_FALSE(changes[0].Previous.Any());
+    EXPECT_EQ(changes[0].Current, Full());
+}
+
+TEST(RegistryResidency, RepeatedChangesCoalesceToFirstPreviousFinalCurrent)
+{
+    ZoneRuntime runtime;
+    runtime.CreateZone(ZoneId{ 1 });
+    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
+    runtime.FinalizeResidencyProcessing();
+
+    runtime.SetParticipation(ZoneId{ 1 }, Full());
+    runtime.SetParticipation(ZoneId{ 1 }, ZoneParticipation{});
+
+    const auto changes = runtime.ResidencyChanges();
+    ASSERT_EQ(changes.size(), 1u);
+    EXPECT_EQ(changes[0].Previous, LogicOnly());
+    EXPECT_FALSE(changes[0].Current.Any());
+}
+
+TEST(RegistryResidency, ParticipationRoundTripDropsTheRecord)
+{
+    ZoneRuntime runtime;
+    runtime.CreateZone(ZoneId{ 1 });
+    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
+    runtime.FinalizeResidencyProcessing();
+
+    runtime.SetParticipation(ZoneId{ 1 }, Full());
+    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly()); // back where it started
+
+    EXPECT_TRUE(runtime.ResidencyChanges().empty());
+}
+
+TEST(RegistryResidency, NoOpSetParticipationRecordsNothing)
+{
+    ZoneRuntime runtime;
+    runtime.CreateZone(ZoneId{ 1 });
+    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
+    runtime.FinalizeResidencyProcessing();
+
+    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
+
+    EXPECT_TRUE(runtime.ResidencyChanges().empty());
+}
+
+// ─── Two-step destruction ────────────────────────────────────────────────────
+
+TEST(RegistryResidency, DestroyZoneMarksDetachingAndDefersDestruction)
+{
+    ZoneRuntime runtime;
+    Registry& zone = runtime.CreateZone(ZoneId{ 1 });
+    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
+    const RegistryId id = zone.Id;
+    const EntityId entity = zone.Components.CreateEntity();
+    runtime.FinalizeResidencyProcessing();
+
+    ASSERT_TRUE(runtime.DestroyZone(ZoneId{ 1 }));
+
+    // Invisible to every query immediately...
+    EXPECT_FALSE(runtime.IsZoneLoaded(ZoneId{ 1 }));
+    EXPECT_EQ(runtime.FindZone(ZoneId{ 1 }), nullptr);
+    EXPECT_EQ(runtime.FindRegistry(id), nullptr);
+    EXPECT_EQ(runtime.ZoneCount(), 0u);
+
+    // ...but alive and readable through the change record until finalize.
+    const auto changes = runtime.ResidencyChanges();
+    ASSERT_EQ(changes.size(), 1u);
+    EXPECT_EQ(changes[0].Kind, RegistryResidencyChangeKind::Detaching);
+    EXPECT_EQ(changes[0].Previous, LogicOnly());
+    EXPECT_FALSE(changes[0].Current.Any());
+    ASSERT_EQ(changes[0].Instance, &zone);
+    EXPECT_TRUE(changes[0].Instance->Components.IsAlive(entity));
+
+    runtime.FinalizeResidencyProcessing();
+    EXPECT_TRUE(runtime.ResidencyChanges().empty());
+}
+
+TEST(RegistryResidency, ParticipationChangeThenDestroyCoalescesToDetaching)
+{
+    ZoneRuntime runtime;
+    runtime.CreateZone(ZoneId{ 1 });
+    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
+    runtime.FinalizeResidencyProcessing();
+
+    runtime.SetParticipation(ZoneId{ 1 }, Full());
+    runtime.DestroyZone(ZoneId{ 1 });
+
+    const auto changes = runtime.ResidencyChanges();
+    ASSERT_EQ(changes.size(), 1u);
+    EXPECT_EQ(changes[0].Kind, RegistryResidencyChangeKind::Detaching);
+    EXPECT_EQ(changes[0].Previous, LogicOnly()); // first observed, not Full
+}
+
+TEST(RegistryResidency, AttachAndDestroyInOneWindowEmitsNothing)
+{
+    ZoneRuntime runtime;
+    runtime.CreateZone(ZoneId{ 1 });
+    runtime.DestroyZone(ZoneId{ 1 });
+
+    EXPECT_TRUE(runtime.ResidencyChanges().empty());
+    EXPECT_EQ(runtime.ZoneCount(), 0u);
+
+    runtime.FinalizeResidencyProcessing(); // frees the never-observed zone
+    EXPECT_FALSE(runtime.IsZoneLoaded(ZoneId{ 1 }));
+}
+
+TEST(RegistryResidency, DoubleDestroyReturnsFalse)
+{
+    ZoneRuntime runtime;
+    runtime.CreateZone(ZoneId{ 1 });
+    runtime.FinalizeResidencyProcessing();
+
+    EXPECT_TRUE(runtime.DestroyZone(ZoneId{ 1 }));
+    EXPECT_FALSE(runtime.DestroyZone(ZoneId{ 1 }));
+}
+
+TEST(RegistryResidency, ZoneIdIsReusableWhilePredecessorDetaches)
+{
+    ZoneRuntime runtime;
+    Registry& first = runtime.CreateZone(ZoneId{ 1 });
+    const RegistryId firstId = first.Id;
+    runtime.FinalizeResidencyProcessing();
+
+    runtime.DestroyZone(ZoneId{ 1 });
+    Registry& second = runtime.CreateZone(ZoneId{ 1 });
+
+    EXPECT_NE(second.Id, firstId);
+    EXPECT_EQ(runtime.FindZone(ZoneId{ 1 }), &second);
+
+    const auto changes = runtime.ResidencyChanges();
+    ASSERT_EQ(changes.size(), 2u);
+    EXPECT_EQ(changes[0].Kind, RegistryResidencyChangeKind::Detaching);
+    EXPECT_EQ(changes[0].Id, firstId);
+    EXPECT_EQ(changes[1].Kind, RegistryResidencyChangeKind::Attached);
+    EXPECT_EQ(changes[1].Id, second.Id);
+}
+
+// ─── Frame view resolution ───────────────────────────────────────────────────
+
+TEST(RegistryResidency, FrameViewExcludesDetachingAndResolvesParticipating)
+{
+    ZoneRuntime runtime;
+    Registry& active = runtime.CreateZone(ZoneId{ 1 });
+    Registry& dormant = runtime.CreateZone(ZoneId{ 2 });
+    Registry& detaching = runtime.CreateZone(ZoneId{ 3 });
+    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
+    runtime.SetParticipation(ZoneId{ 3 }, Full());
+    runtime.FinalizeResidencyProcessing();
+    runtime.DestroyZone(ZoneId{ 3 });
+
+    FrameRegistryView view = runtime.BuildFrameView();
+
+    ASSERT_EQ(view.Participating.size(), 2u); // global + active
+    EXPECT_EQ(view.Participating[0], &runtime.Global());
+    EXPECT_EQ(view.Participating[1], &active);
+
+    EXPECT_EQ(view.Find(active.Id), &active);
+    EXPECT_EQ(view.Find(runtime.Global().Id), &runtime.Global());
+    EXPECT_EQ(view.Find(dormant.Id), nullptr);   // attached but dormant
+    EXPECT_EQ(view.Find(detaching.Id), nullptr);
+    EXPECT_EQ(view.Find(RegistryId::Invalid()), nullptr);
+
+    runtime.EndFrameView();
+}
+
+TEST(RegistryResidency, IsAliveResolvesThroughTheView)
+{
+    ZoneRuntime runtime;
+    Registry& active = runtime.CreateZone(ZoneId{ 1 });
+    Registry& dormant = runtime.CreateZone(ZoneId{ 2 });
+    runtime.SetParticipation(ZoneId{ 1 }, LogicOnly());
+    runtime.FinalizeResidencyProcessing();
+
+    const EntityId live = active.Components.CreateEntity();
+    const EntityId dead = active.Components.CreateEntity();
+    active.Components.DestroyEntity(dead);
+    const EntityId inDormant = dormant.Components.CreateEntity();
+
+    FrameRegistryView view = runtime.BuildFrameView();
+
+    EXPECT_TRUE(view.IsAlive(EntityRef{ active.Id, live }));
+    EXPECT_FALSE(view.IsAlive(EntityRef{ active.Id, dead }));
+    EXPECT_FALSE(view.IsAlive(EntityRef{ dormant.Id, inDormant })); // unresolvable
+    EXPECT_FALSE(view.IsAlive(EntityRef{}));
+
+    runtime.EndFrameView();
+}


### PR DESCRIPTION
## What changed

- complete `ComponentTraits` removal hooks across entity destruction, command-buffer paths, and world teardown
- introduce explicit registry residency transitions and a drain-time `RegistryResidency` phase
- process residency through a stable read-only batch; lifecycle mutation is forbidden until the batch is finalized, preserving residency-before-view ordering
- preserve a final `Detaching` visit even for attach-then-destroy sequences
- move retained physics ownership into registry resources and rename `PhysicsScene` to `RigidBodyBinding`
- evict and restore rigid bodies and character movers when physics participation changes
- add domain-scoped registry resolution instead of resolving physics targets through the union of all participating domains
- add game-held, generational participation leases that compose by union, release independently, and can be explicitly invalidated for forced teardown
- add `TickEventChannel` for events staged outside a fixed step
- complete rigid-body angular velocity, damping, gravity synchronization, and waking on runtime gravity edits
- establish generational driven-pose handles and a locked velocity-drive prototype
- define driven target frames as start-of-step input, remove double-counted feed-forward tests, and replace false force/torque telemetry with honest commanded-speed diagnostics
- reject spring and finite force/torque settings until the P3 solver realization exists
- add residency, lifecycle, constraint, lease, physics-dormancy, and gravity-wake tests
- document the backend residency contract

## Architectural contract

Frame participation controls iteration. Registry residency transitions control retained backend state. Residency handlers operate over a stable read-only batch before frame-view construction. Active cross-registry relationships retain the participation they require through game-held leases. Destruction performs an explicit detach before RAII fallback cleanup.

Concrete backend object families remain separate registry resources. This does not create one binding per gameplay feature.

## Validation

This PR remains a draft while repository CI provides the authoritative Linux configure, build, and full test result.

I could not run a local checkout in the current environment because `gh` is unavailable and outbound Git access is blocked. Source-level verification was performed against the branch after each edit; CI results are authoritative before merge.