### PR TITLE
Filter cached ECS queries by storage partition

### DIFF
--- a/docs/ecs/storage-partition-queries.md
+++ b/docs/ecs/storage-partition-queries.md
@@ -1,0 +1,51 @@
+# Storage-partition query filtering
+
+Status: Phase 2 substrate for domain participation in the unified runtime world.
+
+`StoragePartitionSet` is a dense membership table over 16-bit
+`StoragePartitionId` values. It combines:
+
+- a packed word table for O(1) membership tests;
+- an insertion-ordered member list for deterministic domain iteration;
+- retained capacity across `Clear()` so frame-owned sets can be rebuilt without
+  allocation churn after reaching their steady resident-slot range.
+
+## Query paths
+
+Cached `Query` objects expose two paths:
+
+```cpp
+query.ForEachChunk(callback);
+query.ForEachChunkIn(activePartitions, callback);
+```
+
+The original unfiltered path instantiates an implementation with partition
+filtering disabled through `if constexpr`. It therefore gains no runtime
+membership branch.
+
+The filtered path checks `activePartitions.Contains(chunk.Partition)` once per
+non-empty chunk before evaluating `Changed<T>` filters or invoking the callback.
+It never checks partition membership per entity.
+
+A single cached query can serve several frame domains because the partition set
+is supplied per invocation rather than captured by the query:
+
+```cpp
+logicQuery.ForEachChunkIn(frame.Logic, runLogic);
+logicQuery.ForEachChunkIn(frame.Audio, inspectAudioRelevantLogic);
+```
+
+Archetype matching remains cached exactly as before. Partition changes and
+participation changes do not create archetypes or force query cache rebuilds.
+
+## Change tracking
+
+`Write<T>` bumps column versions only for chunks that pass the partition filter.
+`Changed<T>` and partition filtering compose: an inactive changed chunk is not
+visited, and an active unchanged chunk is not visited.
+
+## Scope boundary
+
+This phase provides the ECS query mechanism only. It does not yet replace
+`FrameRegistryView` or build Visible/Physics/Logic/Audio partition sets from
+`ZoneRuntime`; that integration belongs to the unified runtime-world phase.

--- a/engine/include/ecs/Ecs.h
+++ b/engine/include/ecs/Ecs.h
@@ -14,4 +14,5 @@
 #include <ecs/Query.h>
 #include <ecs/QueryAccessors.h>
 #include <ecs/StoragePartitionId.h>
+#include <ecs/StoragePartitionSet.h>
 #include <ecs/World.h>

--- a/engine/include/ecs/Query.h
+++ b/engine/include/ecs/Query.h
@@ -4,6 +4,7 @@
 #include <ecs/Chunk.h>
 #include <ecs/ComponentId.h>
 #include <ecs/QueryAccessors.h>
+#include <ecs/StoragePartitionSet.h>
 #include <ecs/World.h>
 
 #include <array>
@@ -11,6 +12,7 @@
 #include <cstdint>
 #include <span>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 // ─── compile-time accessor index ─────────────────────────────────────────────
@@ -46,6 +48,7 @@ struct ChunkView
 
     const EntityIndex* Entities() const { return RawChunk->EntityIndices(); }
     uint32_t           Count()    const { return RawChunk->RowCount; }
+    StoragePartitionId Partition() const { return RawChunk->Partition; }
 
     // Returns const span. Column version is NOT bumped (Read is non-mutating).
     template <typename T>
@@ -99,50 +102,32 @@ public:
         RebuildMatchingArchetypes();
     }
 
-    // Chunk-level iteration — primary entry point.
-    // F: void(ChunkView<Accessors...>&)
-    // referenceFrame: used by Changed<T> to determine "changed since when".
-    //   Pass 0 to match all chunks with any write in their history.
-    //   Pass world.CurrentFrame()-1 to match only chunks written last frame.
+    // Unfiltered chunk-level iteration. This remains the primary compatibility
+    // path and compiles without a partition-membership branch.
+    // referenceFrame is used only by Changed<T> accessors.
     template <typename F>
     void ForEachChunk(F&& fn, uint32_t referenceFrame = 0)
     {
-        // A referenceFrame is only meaningful to Changed<T> accessors. Passing
-        // one without any Changed<T> in the query silently filters nothing —
-        // see docs/ecs/decisions.md D4.5 for the bug this caught.
-        assert((referenceFrame == 0 || ChangedSig.any())
-               && "referenceFrame passed to a query with no Changed<T> accessor.");
+        ForEachChunkImpl<false>(
+            nullptr,
+            std::forward<F>(fn),
+            referenceFrame);
+    }
 
-        W->PushQueryScope();
-        RebuildIfStale();
-
-        const uint32_t frame = W->CurrentFrame();
-
-        for (uint32_t archIdx : MatchingArchetypes)
-        {
-            Archetype& arch = *W->GetArchetypes()[archIdx];
-            if (arch.Chunks.empty()) continue;
-
-            // Column indices are identical for all chunks in the same archetype —
-            // compute once per archetype, not per chunk. See decisions.md D0.6.
-            ChunkView<Accessors...> view;
-            view.Frame = frame;
-            PopulateColIndices(view, *arch.Chunks[0], std::index_sequence_for<Accessors...>{});
-
-            for (auto& chunkPtr : arch.Chunks)
-            {
-                Chunk& chunk = *chunkPtr;
-                if (chunk.IsEmpty()) continue;
-                if (!PassesChangedFilter(chunk, referenceFrame)) continue;
-
-                view.RawChunk = &chunk;
-                fn(view);
-
-                BumpWriteVersions(chunk, view, frame, std::index_sequence_for<Accessors...>{});
-            }
-        }
-
-        W->PopQueryScope();
+    // Partition-filtered chunk iteration. Membership is checked once per chunk,
+    // never once per entity. The set is supplied by the frame/domain owner and
+    // remains external to the cached query so one query can serve several
+    // participation domains without rebuilding archetype matches.
+    template <typename F>
+    void ForEachChunkIn(
+        const StoragePartitionSet& partitions,
+        F&& fn,
+        uint32_t referenceFrame = 0)
+    {
+        ForEachChunkImpl<true>(
+            &partitions,
+            std::forward<F>(fn),
+            referenceFrame);
     }
 
     void RebuildMatchingArchetypes()
@@ -170,6 +155,57 @@ private:
 
     std::vector<uint32_t> MatchingArchetypes;
     uint32_t              CachedArchetypeCount = 0;
+
+    template <bool FilterByPartition, typename F>
+    void ForEachChunkImpl(
+        const StoragePartitionSet* partitions,
+        F&& fn,
+        uint32_t referenceFrame)
+    {
+        // A referenceFrame is only meaningful to Changed<T> accessors. Passing
+        // one without any Changed<T> in the query silently filters nothing —
+        // see docs/ecs/decisions.md D4.5 for the bug this caught.
+        assert((referenceFrame == 0 || ChangedSig.any())
+               && "referenceFrame passed to a query with no Changed<T> accessor.");
+        if constexpr (FilterByPartition)
+            assert(partitions != nullptr);
+
+        W->PushQueryScope();
+        RebuildIfStale();
+
+        const uint32_t frame = W->CurrentFrame();
+
+        for (uint32_t archIdx : MatchingArchetypes)
+        {
+            Archetype& arch = *W->GetArchetypes()[archIdx];
+            if (arch.Chunks.empty()) continue;
+
+            // Column indices are identical for all chunks in the same archetype —
+            // compute once per archetype, not per chunk. See decisions.md D0.6.
+            ChunkView<Accessors...> view;
+            view.Frame = frame;
+            PopulateColIndices(view, *arch.Chunks[0], std::index_sequence_for<Accessors...>{});
+
+            for (auto& chunkPtr : arch.Chunks)
+            {
+                Chunk& chunk = *chunkPtr;
+                if (chunk.IsEmpty()) continue;
+                if constexpr (FilterByPartition)
+                {
+                    if (!partitions->Contains(chunk.Partition))
+                        continue;
+                }
+                if (!PassesChangedFilter(chunk, referenceFrame)) continue;
+
+                view.RawChunk = &chunk;
+                fn(view);
+
+                BumpWriteVersions(chunk, view, frame, std::index_sequence_for<Accessors...>{});
+            }
+        }
+
+        W->PopQueryScope();
+    }
 
     void BuildSignatures()
     {

--- a/engine/include/ecs/StoragePartitionSet.h
+++ b/engine/include/ecs/StoragePartitionSet.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <ecs/StoragePartitionId.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+// Dense membership set for storage-partition filtering.
+//
+// Contains() is one indexed word test per chunk. Members() preserves insertion
+// order for deterministic domain iteration and backend orchestration. Clear()
+// retains allocated storage so a frame-owned set can be rebuilt without churn.
+class StoragePartitionSet
+{
+public:
+    bool Add(StoragePartitionId partition)
+    {
+        EnsureWord(partition);
+        const std::size_t word = WordIndex(partition);
+        const std::uint64_t bit = Bit(partition);
+        if ((Words_[word] & bit) != 0)
+            return false;
+
+        Words_[word] |= bit;
+        Members_.push_back(partition);
+        return true;
+    }
+
+    bool Remove(StoragePartitionId partition)
+    {
+        const std::size_t word = WordIndex(partition);
+        if (word >= Words_.size())
+            return false;
+
+        const std::uint64_t bit = Bit(partition);
+        if ((Words_[word] & bit) == 0)
+            return false;
+
+        Words_[word] &= ~bit;
+        const auto found = std::find(Members_.begin(), Members_.end(), partition);
+        if (found != Members_.end())
+            Members_.erase(found);
+        return true;
+    }
+
+    [[nodiscard]] bool Contains(StoragePartitionId partition) const
+    {
+        const std::size_t word = WordIndex(partition);
+        return word < Words_.size() && (Words_[word] & Bit(partition)) != 0;
+    }
+
+    void Clear()
+    {
+        std::fill(Words_.begin(), Words_.end(), std::uint64_t{ 0 });
+        Members_.clear();
+    }
+
+    [[nodiscard]] bool Empty() const { return Members_.empty(); }
+    [[nodiscard]] std::size_t Size() const { return Members_.size(); }
+
+    [[nodiscard]] std::span<const StoragePartitionId> Members() const
+    {
+        return { Members_.data(), Members_.size() };
+    }
+
+private:
+    static constexpr std::size_t WordIndex(StoragePartitionId partition)
+    {
+        return static_cast<std::size_t>(partition.Value) / 64u;
+    }
+
+    static constexpr std::uint64_t Bit(StoragePartitionId partition)
+    {
+        return std::uint64_t{ 1 } << (partition.Value % 64u);
+    }
+
+    void EnsureWord(StoragePartitionId partition)
+    {
+        const std::size_t required = WordIndex(partition) + 1;
+        if (Words_.size() < required)
+            Words_.resize(required, std::uint64_t{ 0 });
+    }
+
+    std::vector<std::uint64_t> Words_;
+    std::vector<StoragePartitionId> Members_;
+};

--- a/test/ecs/StoragePartitionQueryTests.cpp
+++ b/test/ecs/StoragePartitionQueryTests.cpp
@@ -1,0 +1,246 @@
+#include <ecs/Ecs.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+struct PartitionQueryValue
+{
+    int Value = 0;
+};
+
+SENCHA_DECLARE_COMPONENT_TYPE(PartitionQueryValue, "test.partition_query_value");
+
+namespace
+{
+class StoragePartitionQueryTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        World_.RegisterComponent<PartitionQueryValue>();
+    }
+
+    EntityId Add(StoragePartitionId partition, int value)
+    {
+        const EntityId entity = World_.CreateEntity(partition);
+        World_.AddComponent<PartitionQueryValue>(
+            entity,
+            PartitionQueryValue{ value });
+        return entity;
+    }
+
+    World World_;
+};
+} // namespace
+
+TEST(StoragePartitionSet, MembershipAndIterationAreDeterministic)
+{
+    StoragePartitionSet partitions;
+    EXPECT_TRUE(partitions.Empty());
+
+    EXPECT_TRUE(partitions.Add(StoragePartitionId{ 9 }));
+    EXPECT_TRUE(partitions.Add(StoragePartitionId{ 2 }));
+    EXPECT_FALSE(partitions.Add(StoragePartitionId{ 9 }));
+
+    EXPECT_TRUE(partitions.Contains(StoragePartitionId{ 9 }));
+    EXPECT_TRUE(partitions.Contains(StoragePartitionId{ 2 }));
+    EXPECT_FALSE(partitions.Contains(StoragePartitionId{ 3 }));
+    ASSERT_EQ(partitions.Size(), 2u);
+    ASSERT_EQ(partitions.Members().size(), 2u);
+    EXPECT_EQ(partitions.Members()[0], StoragePartitionId{ 9 });
+    EXPECT_EQ(partitions.Members()[1], StoragePartitionId{ 2 });
+
+    EXPECT_TRUE(partitions.Remove(StoragePartitionId{ 9 }));
+    EXPECT_FALSE(partitions.Remove(StoragePartitionId{ 9 }));
+    ASSERT_EQ(partitions.Members().size(), 1u);
+    EXPECT_EQ(partitions.Members()[0], StoragePartitionId{ 2 });
+
+    partitions.Clear();
+    EXPECT_TRUE(partitions.Empty());
+    EXPECT_FALSE(partitions.Contains(StoragePartitionId{ 2 }));
+}
+
+TEST_F(StoragePartitionQueryTest, UnfilteredPathStillVisitsEveryPartition)
+{
+    Add(StoragePartitionId::Default(), 1);
+    Add(StoragePartitionId{ 1 }, 2);
+    Add(StoragePartitionId{ 2 }, 3);
+
+    Query<Read<PartitionQueryValue>> query(World_);
+    int count = 0;
+    int sum = 0;
+    query.ForEachChunk(
+        [&](auto& view)
+        {
+            const auto values = view.template Read<PartitionQueryValue>();
+            count += static_cast<int>(view.Count());
+            for (const PartitionQueryValue value : values)
+                sum += value.Value;
+        });
+
+    EXPECT_EQ(count, 3);
+    EXPECT_EQ(sum, 6);
+}
+
+TEST_F(StoragePartitionQueryTest, FilteredPathVisitsOnlySelectedPartitions)
+{
+    Add(StoragePartitionId::Default(), 1);
+    Add(StoragePartitionId{ 1 }, 10);
+    Add(StoragePartitionId{ 2 }, 100);
+
+    StoragePartitionSet active;
+    active.Add(StoragePartitionId{ 2 });
+
+    Query<Read<PartitionQueryValue>> query(World_);
+    int count = 0;
+    int sum = 0;
+    std::vector<StoragePartitionId> visited;
+    query.ForEachChunkIn(
+        active,
+        [&](auto& view)
+        {
+            visited.push_back(view.Partition());
+            const auto values = view.template Read<PartitionQueryValue>();
+            count += static_cast<int>(view.Count());
+            for (const PartitionQueryValue value : values)
+                sum += value.Value;
+        });
+
+    EXPECT_EQ(count, 1);
+    EXPECT_EQ(sum, 100);
+    ASSERT_EQ(visited.size(), 1u);
+    EXPECT_EQ(visited[0], StoragePartitionId{ 2 });
+}
+
+TEST_F(StoragePartitionQueryTest, EmptyPartitionSetVisitsNothing)
+{
+    Add(StoragePartitionId{ 1 }, 1);
+    Add(StoragePartitionId{ 2 }, 2);
+
+    StoragePartitionSet active;
+    Query<Read<PartitionQueryValue>> query(World_);
+    int count = 0;
+    query.ForEachChunkIn(
+        active,
+        [&](auto& view)
+        {
+            count += static_cast<int>(view.Count());
+        });
+
+    EXPECT_EQ(count, 0);
+}
+
+TEST_F(StoragePartitionQueryTest, OneCachedQueryCanServeDifferentDomainSets)
+{
+    Add(StoragePartitionId{ 1 }, 10);
+    Add(StoragePartitionId{ 2 }, 20);
+
+    Query<Read<PartitionQueryValue>> query(World_);
+    StoragePartitionSet active;
+
+    active.Add(StoragePartitionId{ 1 });
+    int first = 0;
+    query.ForEachChunkIn(
+        active,
+        [&](auto& view)
+        {
+            for (const PartitionQueryValue value :
+                 view.template Read<PartitionQueryValue>())
+            {
+                first += value.Value;
+            }
+        });
+
+    active.Clear();
+    active.Add(StoragePartitionId{ 2 });
+    int second = 0;
+    query.ForEachChunkIn(
+        active,
+        [&](auto& view)
+        {
+            for (const PartitionQueryValue value :
+                 view.template Read<PartitionQueryValue>())
+            {
+                second += value.Value;
+            }
+        });
+
+    EXPECT_EQ(first, 10);
+    EXPECT_EQ(second, 20);
+}
+
+TEST_F(StoragePartitionQueryTest, WriteVersionsBumpOnlyVisitedPartitions)
+{
+    Add(StoragePartitionId{ 1 }, 10);
+    Add(StoragePartitionId{ 2 }, 20);
+    World_.AdvanceFrame();
+
+    StoragePartitionSet active;
+    active.Add(StoragePartitionId{ 1 });
+
+    Query<Write<PartitionQueryValue>> query(World_);
+    query.ForEachChunkIn(
+        active,
+        [](auto&) {
+            // Conservative Write<T> semantics bump after the callback even when
+            // no row is modified.
+        });
+
+    const ComponentId valueId = World_.GetComponentId<PartitionQueryValue>();
+    for (const auto& archetype : World_.GetArchetypes())
+    {
+        if (!archetype->Signature.test(valueId))
+            continue;
+
+        for (const auto& chunk : archetype->Chunks)
+        {
+            if (chunk->IsEmpty())
+                continue;
+            const uint32_t column = chunk->FindColumn(valueId);
+            ASSERT_NE(column, UINT32_MAX);
+            if (chunk->Partition == StoragePartitionId{ 1 })
+                EXPECT_EQ(chunk->ColumnLastWrittenFrame(column), 1u);
+            else if (chunk->Partition == StoragePartitionId{ 2 })
+                EXPECT_EQ(chunk->ColumnLastWrittenFrame(column), 0u);
+        }
+    }
+}
+
+TEST_F(StoragePartitionQueryTest, ChangedAndPartitionFiltersCompose)
+{
+    const EntityId first = Add(StoragePartitionId{ 1 }, 10);
+    const EntityId second = Add(StoragePartitionId{ 2 }, 20);
+    (void)first;
+
+    World_.AdvanceFrame();
+    PartitionQueryValue* changed = World_.TryGet<PartitionQueryValue>(second);
+    ASSERT_NE(changed, nullptr);
+    changed->Value = 21;
+
+    Query<Read<PartitionQueryValue>, Changed<PartitionQueryValue>> query(World_);
+    StoragePartitionSet active;
+    active.Add(StoragePartitionId{ 1 });
+
+    int count = 0;
+    query.ForEachChunkIn(
+        active,
+        [&](auto& view)
+        {
+            count += static_cast<int>(view.Count());
+        },
+        0);
+    EXPECT_EQ(count, 0);
+
+    active.Clear();
+    active.Add(StoragePartitionId{ 2 });
+    query.ForEachChunkIn(
+        active,
+        [&](auto& view)
+        {
+            count += static_cast<int>(view.Count());
+        },
+        0);
+    EXPECT_EQ(count, 1);
+}


### PR DESCRIPTION
## Unified runtime world Phase 2

This stacked PR adds the hot-path participation mechanism on top of partition-owned ECS chunks.

- add `StoragePartitionSet`, a dense O(1) membership table with deterministic member order
- add `Query::ForEachChunkIn(partitions, callback)`
- check participation once per non-empty chunk, never once per entity
- retain the existing `ForEachChunk` path as a compile-time unfiltered instantiation with no added runtime branch
- allow one cached query to serve several domain sets without rebuilding archetype matches
- compose partition filtering correctly with `Changed<T>` and `Write<T>` version semantics
- expose the current chunk partition through `ChunkView::Partition()`
- add focused set, filtered-query, changed-filter, and write-version tests

## Validation

GitHub Actions run 342 passed the complete Linux/GCC/Vulkan engine build and the full serial test suite on head `b4cda04`.

## Stack

Targets verified Phase 1 PR #125 and should merge after it.

## Out of scope

This does not yet replace `FrameRegistryView` or map zone participation to partition sets. It provides the ECS mechanism that the unified runtime-zone integration will consume.