### PR TITLE
Freeze runtime World component schema

### DIFF
--- a/docs/ecs/world-component-schema.md
+++ b/docs/ecs/world-component-schema.md
@@ -1,0 +1,100 @@
+# World component schema
+
+Status: unified-runtime-world prerequisite.
+
+A unified runtime `World` must know the complete engine-plus-game component
+vocabulary before its first entity is created. Streamed zones cannot register
+component storage independently: they may load in any order, workers cannot
+mutate the live world, and registration order determines dense `ComponentId`
+values used by archetype signatures.
+
+`WorldComponentSchema` is the frozen registration recipe for one runtime game
+configuration.
+
+## Construction
+
+Engine and game setup add concrete component types in deterministic order:
+
+```cpp
+WorldComponentSchema schema;
+RegisterEngineRuntimeComponents(schema);
+game.RegisterRuntimeComponents(schema);
+schema.Seal();
+```
+
+Every runtime world for that game applies the sealed schema before creating an
+entity:
+
+```cpp
+World world;
+schema.Apply(world);
+```
+
+The schema stores:
+
+- stable `ComponentTypeId`;
+- stable diagnostic name;
+- size, alignment, and tag status;
+- a concrete registration operation for the component type.
+
+It is not a serializer registry, service locator, factory hierarchy, or dynamic
+plugin API. It is a concrete ordered recipe crossing the existing game-module
+boundary during startup.
+
+## Ordering and identity
+
+Stable `ComponentTypeId` values identify component contracts across modules and
+cooked data. Dense `ComponentId` values remain runtime indices assigned by the
+sealed schema's order.
+
+Applying one schema to independent worlds produces identical dense IDs. A world
+may already contain the exact same registration prefix, which supports existing
+editor and test setup during migration. A divergent prefix fails loudly.
+
+Cooked zone packages carry stable `ComponentTypeId` values. Import resolves them
+against the already-applied world schema. Unknown types fail before partial
+publication; import never registers a component.
+
+## Lifetime
+
+The schema has two states:
+
+- **building:** engine and game code may add component types;
+- **sealed:** immutable and applicable to worlds.
+
+Adding after seal, applying before seal, applying after entity creation, or
+applying against a different registration order is a contract violation.
+
+## Component budget
+
+The current runtime signature remains a fixed 256-bit value. The schema enforces
+that budget and exposes its current size and remaining capacity for startup
+diagnostics.
+
+This phase does not widen or replace the signature. Before the unified runtime
+world becomes the default host, the engine and target game must report their
+actual sealed schema size. The fixed signature remains only if that measurement
+leaves comfortable production headroom; widening is performed before content
+relies on the final runtime ABI.
+
+## Relationship to existing manifests
+
+`EngineSceneComponents` remains the authoritative list of engine components that
+serialize into scene documents. It is intentionally narrower than the runtime
+world schema, which must also include:
+
+- runtime-only engine components and links;
+- movement, camera, physics, abilities, and other framework components;
+- game-module components;
+- tags that may appear on persistent or streamed entities.
+
+Serializer registration and world-storage registration share stable component
+identities but remain separate responsibilities.
+
+## Phase boundary
+
+This mechanism does not yet change the `Game` ABI or runtime startup sequence.
+The next stacked integration phase will assemble one schema from engine and game
+registration hooks, apply it to the unified world before entity creation, and
+add component-count diagnostics. Streamed loading remains unchanged until the
+package-import phase.

--- a/engine/include/ecs/Ecs.h
+++ b/engine/include/ecs/Ecs.h
@@ -16,3 +16,4 @@
 #include <ecs/StoragePartitionId.h>
 #include <ecs/StoragePartitionSet.h>
 #include <ecs/World.h>
+#include <ecs/WorldComponentSchema.h>

--- a/engine/include/ecs/WorldComponentSchema.h
+++ b/engine/include/ecs/WorldComponentSchema.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <ecs/ComponentId.h>
+#include <ecs/ComponentTypeId.h>
+#include <ecs/World.h>
+
+#include <cassert>
+#include <cstddef>
+#include <span>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+// Frozen registration recipe for the complete component vocabulary of one
+// runtime World.
+//
+// Engine and game code add concrete component types during module setup, then
+// seal the schema. Any runtime World created from that game applies the same
+// ordered recipe before its first entity exists. Streamed content resolves
+// stable ComponentTypeId values against the resulting World; it never registers
+// storage on a worker or during import.
+class WorldComponentSchema
+{
+public:
+    struct Entry
+    {
+        ComponentTypeId Type;
+        std::string_view Name;
+        std::size_t Size = 0;
+        std::size_t Alignment = 1;
+        bool IsTag = false;
+
+    private:
+        using RegisterFn = ComponentId (*)(World&);
+        RegisterFn Register = nullptr;
+
+        friend class WorldComponentSchema;
+    };
+
+    template <typename T>
+    bool Add()
+    {
+        static_assert(std::is_trivially_copyable_v<T>,
+                      "WorldComponentSchema components must be trivially copyable.");
+        assert(!Sealed_ && "Cannot add components after WorldComponentSchema::Seal");
+
+        const ComponentTypeId type = ResolveComponentTypeId<T>();
+        const std::size_t size = std::is_empty_v<T> ? 0 : sizeof(T);
+        const std::size_t alignment = std::is_empty_v<T> ? 1 : alignof(T);
+        const bool isTag = std::is_empty_v<T>;
+
+        if (const Entry* existing = Find(type))
+        {
+            assert(existing->Size == size
+                   && existing->Alignment == alignment
+                   && existing->IsTag == isTag
+                   && "ComponentTypeId collision in WorldComponentSchema");
+            return false;
+        }
+
+        assert(Entries_.size() < MaxComponents
+               && "WorldComponentSchema exceeds the 256-component budget");
+
+        Entry entry;
+        entry.Type = type;
+        entry.Name = ResolveComponentName<T>();
+        entry.Size = size;
+        entry.Alignment = alignment;
+        entry.IsTag = isTag;
+        entry.Register = [](World& world) {
+            return world.RegisterComponent<T>();
+        };
+        Entries_.push_back(entry);
+        return true;
+    }
+
+    void Seal()
+    {
+        assert(!Sealed_ && "WorldComponentSchema already sealed");
+        assert(Entries_.size() <= MaxComponents);
+        Sealed_ = true;
+    }
+
+    // Applies the exact registration order. A World that already carries the
+    // same prefix is tolerated, which keeps editor/test construction flexible;
+    // any extra or differently ordered component makes the assigned id diverge
+    // and fails loudly.
+    void Apply(World& world) const
+    {
+        assert(Sealed_ && "Apply requires a sealed WorldComponentSchema");
+        for (std::size_t index = 0; index < Entries_.size(); ++index)
+        {
+            const ComponentId assigned = Entries_[index].Register(world);
+            assert(assigned == static_cast<ComponentId>(index)
+                   && "World component registration order differs from sealed schema");
+        }
+    }
+
+    [[nodiscard]] const Entry* Find(ComponentTypeId type) const
+    {
+        for (const Entry& entry : Entries_)
+            if (entry.Type == type)
+                return &entry;
+        return nullptr;
+    }
+
+    [[nodiscard]] bool Contains(ComponentTypeId type) const
+    {
+        return Find(type) != nullptr;
+    }
+
+    [[nodiscard]] bool IsSealed() const { return Sealed_; }
+    [[nodiscard]] std::size_t Size() const { return Entries_.size(); }
+    [[nodiscard]] std::size_t RemainingCapacity() const
+    {
+        return MaxComponents - Entries_.size();
+    }
+
+    [[nodiscard]] std::span<const Entry> Entries() const
+    {
+        return { Entries_.data(), Entries_.size() };
+    }
+
+private:
+    std::vector<Entry> Entries_;
+    bool Sealed_ = false;
+};

--- a/test/ecs/WorldComponentSchemaTests.cpp
+++ b/test/ecs/WorldComponentSchemaTests.cpp
@@ -1,0 +1,203 @@
+#include <ecs/Ecs.h>
+
+#include <gtest/gtest.h>
+
+struct SchemaPosition
+{
+    float X = 0.0f;
+    float Y = 0.0f;
+};
+
+struct SchemaVelocity
+{
+    float X = 0.0f;
+    float Y = 0.0f;
+};
+
+struct SchemaTag
+{
+};
+
+struct SchemaCollisionA
+{
+    std::uint32_t Value = 0;
+};
+
+struct SchemaCollisionB
+{
+    std::uint64_t Value = 0;
+};
+
+SENCHA_DECLARE_COMPONENT_TYPE(SchemaPosition, "test.schema_position");
+SENCHA_DECLARE_COMPONENT_TYPE(SchemaVelocity, "test.schema_velocity");
+SENCHA_DECLARE_COMPONENT_TYPE(SchemaTag, "test.schema_tag");
+SENCHA_DECLARE_COMPONENT_TYPE(SchemaCollisionA, "test.schema_collision");
+SENCHA_DECLARE_COMPONENT_TYPE(SchemaCollisionB, "test.schema_collision");
+
+TEST(WorldComponentSchema, AddRecordsOrderedStorageContracts)
+{
+    WorldComponentSchema schema;
+
+    EXPECT_TRUE(schema.Add<SchemaPosition>());
+    EXPECT_TRUE(schema.Add<SchemaTag>());
+    EXPECT_FALSE(schema.Add<SchemaPosition>());
+
+    ASSERT_EQ(schema.Size(), 2u);
+    ASSERT_EQ(schema.Entries().size(), 2u);
+
+    EXPECT_EQ(schema.Entries()[0].Type, ResolveComponentTypeId<SchemaPosition>());
+    EXPECT_EQ(schema.Entries()[0].Name, "test.schema_position");
+    EXPECT_EQ(schema.Entries()[0].Size, sizeof(SchemaPosition));
+    EXPECT_EQ(schema.Entries()[0].Alignment, alignof(SchemaPosition));
+    EXPECT_FALSE(schema.Entries()[0].IsTag);
+
+    EXPECT_EQ(schema.Entries()[1].Type, ResolveComponentTypeId<SchemaTag>());
+    EXPECT_EQ(schema.Entries()[1].Name, "test.schema_tag");
+    EXPECT_EQ(schema.Entries()[1].Size, 0u);
+    EXPECT_EQ(schema.Entries()[1].Alignment, 1u);
+    EXPECT_TRUE(schema.Entries()[1].IsTag);
+
+    EXPECT_TRUE(schema.Contains(ResolveComponentTypeId<SchemaPosition>()));
+    EXPECT_FALSE(schema.Contains(ResolveComponentTypeId<SchemaVelocity>()));
+    EXPECT_EQ(schema.RemainingCapacity(), MaxComponents - 2u);
+}
+
+TEST(WorldComponentSchema, SealAndApplyRegistersExactIds)
+{
+    WorldComponentSchema schema;
+    schema.Add<SchemaPosition>();
+    schema.Add<SchemaVelocity>();
+    schema.Add<SchemaTag>();
+    schema.Seal();
+
+    ASSERT_TRUE(schema.IsSealed());
+
+    World world;
+    schema.Apply(world);
+
+    EXPECT_EQ(world.GetComponentId<SchemaPosition>(), 0u);
+    EXPECT_EQ(world.GetComponentId<SchemaVelocity>(), 1u);
+    EXPECT_EQ(world.GetComponentId<SchemaTag>(), 2u);
+
+    const EntityId entity = world.CreateEntity();
+    world.AddComponent<SchemaPosition>(entity, { 4.0f, 5.0f });
+    world.AddComponent<SchemaTag>(entity);
+
+    EXPECT_TRUE(world.HasComponent<SchemaPosition>(entity));
+    EXPECT_TRUE(world.HasComponent<SchemaTag>(entity));
+}
+
+TEST(WorldComponentSchema, SameSchemaProducesSameIdsInIndependentWorlds)
+{
+    WorldComponentSchema schema;
+    schema.Add<SchemaPosition>();
+    schema.Add<SchemaVelocity>();
+    schema.Seal();
+
+    World first;
+    World second;
+    schema.Apply(first);
+    schema.Apply(second);
+
+    EXPECT_EQ(
+        first.GetComponentId<SchemaPosition>(),
+        second.GetComponentId<SchemaPosition>());
+    EXPECT_EQ(
+        first.GetComponentId<SchemaVelocity>(),
+        second.GetComponentId<SchemaVelocity>());
+}
+
+TEST(WorldComponentSchema, MatchingRegisteredPrefixIsAccepted)
+{
+    WorldComponentSchema schema;
+    schema.Add<SchemaPosition>();
+    schema.Add<SchemaVelocity>();
+    schema.Seal();
+
+    World world;
+    EXPECT_EQ(world.RegisterComponent<SchemaPosition>(), 0u);
+
+    schema.Apply(world);
+
+    EXPECT_EQ(world.GetComponentId<SchemaPosition>(), 0u);
+    EXPECT_EQ(world.GetComponentId<SchemaVelocity>(), 1u);
+}
+
+#ifndef NDEBUG
+TEST(WorldComponentSchema, ApplyingBeforeSealAsserts)
+{
+    EXPECT_DEATH(
+        {
+            WorldComponentSchema schema;
+            schema.Add<SchemaPosition>();
+            World world;
+            schema.Apply(world);
+        },
+        "sealed WorldComponentSchema");
+}
+
+TEST(WorldComponentSchema, AddingAfterSealAsserts)
+{
+    EXPECT_DEATH(
+        {
+            WorldComponentSchema schema;
+            schema.Add<SchemaPosition>();
+            schema.Seal();
+            (void)schema.Add<SchemaVelocity>();
+        },
+        "after WorldComponentSchema::Seal");
+}
+
+TEST(WorldComponentSchema, DivergentRegistrationOrderAsserts)
+{
+    EXPECT_DEATH(
+        {
+            WorldComponentSchema schema;
+            schema.Add<SchemaPosition>();
+            schema.Add<SchemaVelocity>();
+            schema.Seal();
+
+            World world;
+            world.RegisterComponent<SchemaVelocity>();
+            schema.Apply(world);
+        },
+        "registration order differs");
+}
+
+TEST(WorldComponentSchema, ApplyingAfterEntityCreationAsserts)
+{
+    EXPECT_DEATH(
+        {
+            WorldComponentSchema schema;
+            schema.Add<SchemaPosition>();
+            schema.Seal();
+
+            World world;
+            world.CreateEntity();
+            schema.Apply(world);
+        },
+        "registration after entity creation");
+}
+
+TEST(WorldComponentSchema, StableIdentityWithDifferentLayoutAsserts)
+{
+    EXPECT_DEATH(
+        {
+            WorldComponentSchema schema;
+            schema.Add<SchemaCollisionA>();
+            (void)schema.Add<SchemaCollisionB>();
+        },
+        "ComponentTypeId collision");
+}
+
+TEST(WorldComponentSchema, DoubleSealAsserts)
+{
+    EXPECT_DEATH(
+        {
+            WorldComponentSchema schema;
+            schema.Seal();
+            schema.Seal();
+        },
+        "already sealed");
+}
+#endif


### PR DESCRIPTION
## Unified runtime world prerequisite

A unified runtime `World` must receive the complete engine-plus-game component vocabulary before its first entity exists. Streamed zones may resolve stable component identities, but they may never register storage independently or in load order.

This stacked PR adds:

- concrete `WorldComponentSchema` storage recipes
- deterministic ordered component registration across independent worlds
- explicit build and sealed states
- stable identity, layout, tag, and 256-component-budget validation
- compatibility with an exact pre-registered prefix during migration
- loud failure on divergent registration order, post-entity application, or layout collision
- schema size and remaining-capacity diagnostics
- focused contract and assertion tests
- documentation separating runtime storage schema from scene serializer manifests

## Validation

GitHub Actions run 343 passed the complete Linux/GCC/Vulkan engine build and full serial test suite on head `1b62672`.

## Stack

Targets verified Phase 2 PR #126. The next stacked integration PR assembles the schema from engine and game-module startup hooks and seals it before `OnStart`.

## Out of scope

- no Game ABI integration in this mechanism PR
- no streamed package import
- no widening of the fixed 256-bit archetype signature without measured need
- no replacement of `ComponentSerializerRegistry`