### PR TITLE
Name ProbeVolume in the asset type mapping

### DIFF
--- a/engine/include/core/assets/AssetRef.h
+++ b/engine/include/core/assets/AssetRef.h
@@ -8,7 +8,10 @@
 // AssetType
 //
 // Stable tag identifying what kind of asset an AssetRef points at.
-// Serialized as a string ("Mesh", "Material", ...) in text formats.
+// Serialized as a string ("StaticMesh", "Material", ...) in text formats:
+// scene fields, the cooked cache index, and document cook receipts. Every
+// value needs a name in both directions below, or artifacts carrying it
+// cannot be read back.
 //=============================================================================
 enum class AssetType : uint16_t
 {
@@ -46,6 +49,10 @@ enum class AssetArity : uint16_t
     List,
 };
 
+// Listed exhaustively rather than with a default arm: a new AssetType that
+// nobody names here would otherwise serialize as "Unknown" and be rejected on
+// read, which fails the whole cooked index or receipt containing it. -Wswitch
+// turns that into a compile-time warning instead.
 inline std::string_view AssetTypeToString(AssetType type)
 {
     switch (type)
@@ -61,8 +68,10 @@ inline std::string_view AssetTypeToString(AssetType type)
     case AssetType::AnimationClip: return "AnimationClip";
     case AssetType::SkinnedMesh: return "SkinnedMesh";
     case AssetType::Collision: return "Collision";
-    default:                  return "Unknown";
+    case AssetType::ProbeVolume: return "ProbeVolume";
+    case AssetType::Unknown:  break;
     }
+    return "Unknown";
 }
 
 inline bool AssetTypeFromString(std::string_view name, AssetType& out)
@@ -78,6 +87,7 @@ inline bool AssetTypeFromString(std::string_view name, AssetType& out)
     if (name == "AnimationClip") { out = AssetType::AnimationClip; return true; }
     if (name == "SkinnedMesh") { out = AssetType::SkinnedMesh; return true; }
     if (name == "Collision") { out = AssetType::Collision; return true; }
+    if (name == "ProbeVolume") { out = AssetType::ProbeVolume; return true; }
     return false;
 }
 

--- a/test/core/AssetTypeNameTests.cpp
+++ b/test/core/AssetTypeNameTests.cpp
@@ -1,0 +1,121 @@
+#include <assets/cook/CookedCache.h>
+#include <core/assets/AssetRef.h>
+#include <core/json/JsonValue.h>
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace
+{
+    // Every AssetType that names a real asset kind. Unknown is excluded on
+    // purpose: it is the "no type" sentinel and carries no round-trip
+    // contract. A new asset type that is missing here still trips -Wswitch in
+    // AssetTypeToString, which is the compile-time half of this guard.
+    constexpr AssetType kNamedAssetTypes[] = {
+        AssetType::StaticMesh,
+        AssetType::Material,
+        AssetType::Texture,
+        AssetType::Scene,
+        AssetType::Geometry,
+        AssetType::Audio,
+        AssetType::Script,
+        AssetType::Skeleton,
+        AssetType::AnimationClip,
+        AssetType::SkinnedMesh,
+        AssetType::Collision,
+        AssetType::ProbeVolume,
+    };
+
+    CookedSourceEntry MakeEntry(std::string sourceRel,
+                                std::string artifactRel,
+                                AssetType type)
+    {
+        CookedSourceEntry entry;
+        entry.SourceRelPath = std::move(sourceRel);
+        entry.InputFingerprint = 0xabcdef0123456789ULL;
+        entry.Artifacts.push_back(CookedArtifact{
+            "asset://" + artifactRel, artifactRel, type, 77 });
+        return entry;
+    }
+} // namespace
+
+// A type whose name does not survive the mapping is silently written as
+// "Unknown" and then rejected on read, so every named type must round trip.
+TEST(AssetTypeName, EveryNamedTypeRoundTripsThroughItsString)
+{
+    for (const AssetType type : kNamedAssetTypes)
+    {
+        const std::string_view name = AssetTypeToString(type);
+        EXPECT_NE(name, "Unknown")
+            << "AssetType " << static_cast<uint16_t>(type) << " has no name";
+
+        AssetType parsed = AssetType::Unknown;
+        ASSERT_TRUE(AssetTypeFromString(name, parsed))
+            << "name '" << name << "' does not parse back";
+        EXPECT_EQ(parsed, type);
+    }
+}
+
+// Catches a gap in the middle of the enum range as well as one at the end.
+TEST(AssetTypeName, EveryValueInTheDeclaredRangeIsNamed)
+{
+    const auto last = static_cast<uint16_t>(AssetType::ProbeVolume);
+    for (uint16_t raw = 1; raw <= last; ++raw)
+    {
+        const auto type = static_cast<AssetType>(raw);
+        EXPECT_NE(AssetTypeToString(type), "Unknown")
+            << "AssetType value " << raw << " is unnamed";
+    }
+}
+
+TEST(AssetTypeName, UnknownHasNoNameAndUnnamedTextDoesNotParse)
+{
+    EXPECT_EQ(AssetTypeToString(AssetType::Unknown), "Unknown");
+
+    AssetType parsed = AssetType::StaticMesh;
+    EXPECT_FALSE(AssetTypeFromString("Unknown", parsed));
+    EXPECT_FALSE(AssetTypeFromString("NotAnAssetType", parsed));
+    EXPECT_FALSE(AssetTypeFromString("", parsed));
+}
+
+TEST(CookedCacheIndexAssetTypes, ProbeVolumeArtifactSurvivesRoundTrip)
+{
+    CookedCacheIndex index;
+    index.Put(MakeEntry("levels/test.json",
+                        ".cooked/levels/test/probes.sprobe",
+                        AssetType::ProbeVolume));
+
+    CookedCacheIndex parsed;
+    std::string error;
+    ASSERT_TRUE(CookedCacheIndex::FromJson(index.ToJson(), parsed, &error)) << error;
+
+    const CookedSourceEntry* entry = parsed.Find("levels/test.json");
+    ASSERT_NE(entry, nullptr);
+    ASSERT_EQ(entry->Artifacts.size(), 1u);
+    EXPECT_EQ(entry->Artifacts.front().Type, AssetType::ProbeVolume);
+}
+
+// An unreadable artifact type fails the whole index parse, not just its own
+// entry, so one unnamed type discards every unrelated source with it and the
+// next cook rebuilds the world.
+TEST(CookedCacheIndexAssetTypes, ProbeVolumeEntryDoesNotDiscardUnrelatedSources)
+{
+    CookedCacheIndex index;
+    index.Put(MakeEntry("meshes/crate.gltf",
+                        ".cooked/meshes/crate.smesh",
+                        AssetType::StaticMesh));
+    index.Put(MakeEntry("levels/test.json",
+                        ".cooked/levels/test/probes.sprobe",
+                        AssetType::ProbeVolume));
+
+    CookedCacheIndex parsed;
+    std::string error;
+    ASSERT_TRUE(CookedCacheIndex::FromJson(index.ToJson(), parsed, &error)) << error;
+
+    EXPECT_EQ(parsed.Size(), 2u);
+    EXPECT_NE(parsed.Find("meshes/crate.gltf"), nullptr);
+    EXPECT_NE(parsed.Find("levels/test.json"), nullptr);
+}

--- a/test/level_cook/CookReceiptTests.cpp
+++ b/test/level_cook/CookReceiptTests.cpp
@@ -52,3 +52,33 @@ TEST(CookReceiptTest, PutReplacesOnlyMatchingStep)
     EXPECT_EQ(FindCookStepReceipt(receipt, "b")->Version, 1u);
 }
 
+// A probe bake records its artifact in the receipt; if the type has no name
+// the receipt stops parsing entirely, so the next cook sees no prior steps
+// and reuse is unreachable for every step, not just the probe one.
+TEST(CookReceiptTest, ProbeVolumeArtifactRoundTrips)
+{
+    DocumentCookReceipt source;
+    source.Target = "levels/test.json";
+    source.PublishedProfileId = "full";
+    source.PublishedFingerprint = 0x0f0f0f0f0f0f0f0fULL;
+    source.Steps.push_back(CookStepReceipt{
+        .StepId = "irradiance_probes",
+        .Version = 1,
+        .InputFingerprint = 0x1111222233334444ULL,
+        .Artifacts = {
+            CookedArtifact{ "asset://levels/test/probes.sprobe",
+                            ".cooked/levels/test/probes.sprobe",
+                            AssetType::ProbeVolume, 512 },
+        },
+    });
+
+    DocumentCookReceipt parsed;
+    std::string error;
+    ASSERT_TRUE(ReadDocumentCookReceipt(WriteDocumentCookReceipt(source), parsed, &error))
+        << error;
+    ASSERT_EQ(parsed.Steps.size(), 1u);
+    ASSERT_EQ(parsed.Steps.front().Artifacts.size(), 1u);
+    EXPECT_EQ(parsed.Steps.front().Artifacts.front().Type, AssetType::ProbeVolume);
+    EXPECT_EQ(parsed.Steps.front().Artifacts.front().ContentHash, 512u);
+}
+


### PR DESCRIPTION
AssetType::ProbeVolume had no entry in AssetTypeToString or AssetTypeFromString, so a baked probe volume serialized as the literal string "Unknown" into both the cooked cache index and the document cook receipt. Neither reader accepts that name, and both treat an unreadable artifact type as a failure of the entire file rather than of one entry, so a single probe artifact discarded every unrelated source alongside it. Callers swallow the failure as a cold cache, which turned incremental cooking into a full rebuild and left the probe reuse path in DocumentPublicationPlan unreachable.

Existing indexes and receipts that already recorded "Unknown" still fail to parse and recook once, which is what they do today; the entry is rewritten with a real name after that.

AssetTypeToString now lists every enum value instead of falling through a default arm, so -Wswitch reports the next unnamed type at compile time.