### PR TITLE
Give each host its own component serializer registry

### DIFF
--- a/docs/core-systems-map.md
+++ b/docs/core-systems-map.md
@@ -232,7 +232,7 @@ Scene serialization is schema-driven:
   ODR note in that header.
 
 The set of serializable components is named once, in
-`world/ComponentManifest.h` (`EngineSceneComponents`). `InitSceneSerializer()`
+`world/ComponentManifest.h` (`EngineSceneComponents`). `RegisterEngineSceneSerializers()`
 and `InitializeSceneRegistry()` both fold over that list, so serializer
 registration and storage registration cannot drift apart. Each component's
 JSON key and chunk FourCC live on its own `TypeSchema<T>` (`Name`,

--- a/docs/ecs/component-registration-plan.md
+++ b/docs/ecs/component-registration-plan.md
@@ -4,7 +4,7 @@ Status: **implemented** (2026-06-12, branch `asset-pipelines`). All five steps
 landed; full suite green (807 tests). Two deviations from the original plan
 are recorded inline below, marked **Deviation**.
 Branch context: coordinate with Editor Phase 1 (it consumes
-`GetComponentSerializerEntries()` — that entry point did not change).
+the serializer entry list — that entry point did not change).
 
 ## Problem
 
@@ -16,10 +16,10 @@ Adding a serializable component today touches five files:
 | Trivially-copyable `static_assert` | the component's own header | ceremony, should be automatic |
 | FourCC chunk ID | `world/serialization/SceneFormat.h` | per-type fact living three directories from the type |
 | `ComponentStorageTraits<T>` specialization | `world/serialization/ComponentStorageTraits.h` | ~18 lines; 4 of 5 are identical boilerplate; drags `audio/` and `render/` includes into `world/serialization` |
-| `RegisterComponent<T>()` line | `SceneSerializer.cpp` `InitSceneSerializer()` | forget it → component **silently never serializes** |
+| `RegisterComponent<T>()` line | `SceneSerializer.cpp` `RegisterEngineSceneSerializers()` | forget it → component **silently never serializes** |
 | `RegisterComponent<T>()` line | `SceneRegistryInitialization.cpp` `InitializeSceneRegistry()` | forget it → loads still work, but programmatic `AddComponent` before the first load hits the registration-after-entity-creation assert (debug) / UB (release), order-dependent |
 
-Additional silent failure: `RegisterComponentSerializer` skips any serializer
+Additional silent failure: registering a serializer skips any serializer
 whose chunk ID **or** JSON key collides with an existing entry — no assert, no
 log. A genuine collision is indistinguishable from idempotent re-registration.
 
@@ -32,7 +32,7 @@ scene components is named in exactly one place.
 - **Wire format does not change.** Same FourCCs, same chunk layout, same JSON
   keys. Existing `.scene` files load unmodified. (This is what makes the
   refactor safe relative to the editor branch.)
-- `GetComponentSerializerEntries()` keeps its signature and semantics.
+- The serializer entry list keeps its semantics.
 - `World::RegisterComponent<T>` keeps its register-before-first-entity rule.
 - No static-initializer self-registration. The engine is a static library;
   registrar objects in unreferenced TUs get dead-stripped, init order is
@@ -104,7 +104,7 @@ void ForEachSceneComponent(Fn&& fn);   // fold over the tuple's types
 
 Consumers:
 
-- `InitSceneSerializer()` folds over the list calling `RegisterComponent<T>()`.
+- `RegisterEngineSceneSerializers()` folds over the list calling `RegisterComponent<T>()`.
 - `InitializeSceneRegistry` folds over the list calling
   `ComponentStorageTraits<T>::Register(registry)`. Using the traits (not raw
   `RegisterComponent`) is what keeps `WorldTransform`/`Parent` registered via
@@ -114,7 +114,7 @@ The two lists that could previously drift apart are now the same list, which
 removes the order-dependent registration bug class outright.
 
 Games extend, not edit: game-specific components keep using
-`RegisterComponent<T>()` after `InitSceneSerializer()` and registering storage
+`RegisterComponent<T>()` after `RegisterEngineSceneSerializers()` and registering storage
 in their own zone-builder hook. A game-side manifest helper is a follow-up if
 a real game needs it; don't build it speculatively.
 
@@ -124,9 +124,9 @@ a real game needs it; don't build it speculatively.
   `static_assert(std::is_trivially_copyable_v<T>)` — archetype chunks relocate
   with `memcpy`, so this is a structural requirement, enforced once. Delete
   the per-header asserts (e.g. `AudioCaptionComponent.h`).
-- `RegisterComponentSerializer` distinguishes the two collision cases:
+- Registration distinguishes the two collision cases:
   - chunk ID **and** JSON key both match an existing entry → idempotent
-    re-registration, skip silently (keeps `InitSceneSerializer()` re-entrant);
+    re-registration, skip silently (keeps `RegisterEngineSceneSerializers()` re-entrant);
   - only one matches → genuine collision: assert in debug, log error in
     release, refuse to register.
 

--- a/docs/plans/sencha-level-editor/02-module-topology-dll.md
+++ b/docs/plans/sencha-level-editor/02-module-topology-dll.md
@@ -355,8 +355,8 @@ public:
   - The free-function serializer global was refactored into an owned
     **`ComponentSerializerRegistry`** object
     ([ComponentSerializerRegistry.h](../../engine/include/world/serialization/ComponentSerializerRegistry.h));
-    the legacy `RegisterComponentSerializer`/`ClearComponentSerializers`/
-    `GetComponentSerializerEntries` free functions are now a thin shim over a process-default
+    the free functions that wrapped a process-default registry have since been
+    removed; each host owns a registry and passes it explicitly. Historically they shimmed a process-default
     instance, so existing callers are untouched while the object can be handed to a module.
   - ABI surface landed: [ModuleExport.h](../../engine/include/app/ModuleExport.h)
     (`SENCHA_GAME_EXPORT`, `SENCHA_GAME_ABI_VERSION`) and
@@ -435,7 +435,7 @@ public:
        **Owned by 04-** (first hard requirement: face material `AssetRef` editing); see the
        note there. Explicitly the property-metadata expansion deferred in 01-§7.
     2. **Editor uses the process-global serializer registry, not an owned instance.** S3's
-       `EditorApp`/`LevelDocument`/inspector route through `DefaultComponentSerializerRegistry()`
+       `EditorApp`/`LevelDocument`/inspector route through the editor's own registry
        and the free-function shim, contradicting §2.1 / 00-§2 ("game/editor never host
        engine-global state"). The owned `ComponentSerializerRegistry` exists but the editor
        doesn't own one yet. Invisible single-document/single-project; a hazard for

--- a/editor/kyusu/src/app/EditorServices.cpp
+++ b/editor/kyusu/src/app/EditorServices.cpp
@@ -905,7 +905,7 @@ void EditorServices::LoadGameModule()
 
     // The editor only borrows the module's component serializers (so it can edit
     // scenes containing game components); it never runs the game's lifecycle.
-    GameModule.Instance->OnRegisterComponents(DefaultComponentSerializerRegistry());
+    GameModule.Instance->OnRegisterComponents(EditorSceneSerializers());
     std::fprintf(stderr, "[editor] loaded game module '%s'\n", modulePath.c_str());
 }
 
@@ -930,6 +930,6 @@ void EditorServices::UnloadGameModule()
         return;
 
     // Retract the serializers while the module is still mapped, then unmap.
-    GameModule.Instance->OnUnregisterComponents(DefaultComponentSerializerRegistry());
+    GameModule.Instance->OnUnregisterComponents(EditorSceneSerializers());
     ModuleLoader.Unload(GameModule);
 }

--- a/editor/kyusu/src/authoring/EditorComponentAdapter.cpp
+++ b/editor/kyusu/src/authoring/EditorComponentAdapter.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include "document/DocumentSerialization.h"
 
 namespace
 {
@@ -107,7 +108,7 @@ EditorAffordanceService::EditorAffordanceService(
 
 void EditorComponentAdapterRegistry::ResolveEntries() const
 {
-    const auto& serializers = GetComponentSerializerEntries();
+    const auto& serializers = EditorSceneSerializers().Entries();
     if (ResolvedSerializerCount == serializers.size() && Resolved.size() == Adapters.size())
         return;
 

--- a/editor/kyusu/src/document/DocumentCookInput.cpp
+++ b/editor/kyusu/src/document/DocumentCookInput.cpp
@@ -28,6 +28,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include "DocumentSerialization.h"
 
 namespace
 {
@@ -222,7 +223,8 @@ JsonValue BuildPassthroughScene(const EditorDocument& document,
                                 std::unordered_map<EntityIndex, std::uint32_t>& sceneIndices)
 {
     SceneSerializationContext context(logging, assets);
-    JsonValue serialized = SaveSceneJson(document.GetRegistry(), context);
+    JsonValue serialized =
+        SaveSceneJson(document.GetRegistry(), EditorSceneSerializers(), context);
     const JsonValue* sourceEntities = serialized.Find("entities");
     const JsonValue* sourceHierarchy = serialized.Find("hierarchy");
     if (sourceEntities == nullptr || !sourceEntities->IsArray()

--- a/editor/kyusu/src/document/DocumentSerialization.cpp
+++ b/editor/kyusu/src/document/DocumentSerialization.cpp
@@ -100,6 +100,12 @@ struct ComponentStorageTraits<BakedBrushComponent>
 
 #include <world/serialization/SceneSerializer.h>
 
+ComponentSerializerRegistry& EditorSceneSerializers()
+{
+    static ComponentSerializerRegistry instance;
+    return instance;
+}
+
 void RegisterDocumentSerializers()
 {
     static bool registered = false;
@@ -107,10 +113,12 @@ void RegisterDocumentSerializers()
         return;
     registered = true;
 
+    ComponentSerializerRegistry& serializers = EditorSceneSerializers();
+
     // Engine components: LocalTransform, CameraComponent, StaticMeshComponent.
-    InitSceneSerializer();
+    RegisterEngineSceneSerializers(serializers);
 
     // Editor-only components.
-    RegisterComponent<BrushComponent>();
-    RegisterComponent<BakedBrushComponent>();
+    RegisterComponent<BrushComponent>(serializers);
+    RegisterComponent<BakedBrushComponent>(serializers);
 }

--- a/editor/kyusu/src/document/DocumentSerialization.h
+++ b/editor/kyusu/src/document/DocumentSerialization.h
@@ -1,5 +1,19 @@
 #pragma once
 
-// Registers the scene serializers used by editor documents. Idempotent;
-// call once at editor startup before any save or load.
+class ComponentSerializerRegistry;
+
+// The editor's component serializer set: the engine scene manifest plus the
+// authoring-only components (brushes) that never reach a cooked scene, plus
+// whatever the loaded game module registers.
+//
+// Owned by the editor application, not the engine -- the engine holds its own
+// registry for the runtime, and the two vocabularies are deliberately
+// different. Still reached through an accessor rather than threaded into each
+// consumer: the panels, the visual renderer, and the entity recipe read it
+// without holding a document, so giving them an explicit reference is a
+// separate change to their construction.
+[[nodiscard]] ComponentSerializerRegistry& EditorSceneSerializers();
+
+// Populates EditorSceneSerializers(). Idempotent; call once at editor startup
+// before any save or load.
 void RegisterDocumentSerializers();

--- a/editor/kyusu/src/document/EditorDocument.cpp
+++ b/editor/kyusu/src/document/EditorDocument.cpp
@@ -22,6 +22,7 @@
 #include <string_view>
 #include <utility>
 #include <vector>
+#include "DocumentSerialization.h"
 
 namespace
 {
@@ -91,7 +92,7 @@ EditorDocument::EditorDocument(LoggingProvider& logging)
     // Register storage for every serializer the registry knows — engine, editor,
     // and any game module loaded at startup — so game components are available
     // (and inspectable/addable) before any entity exists. Idempotent.
-    for (const auto& serializer : GetComponentSerializerEntries())
+    for (const auto& serializer : EditorSceneSerializers().Entries())
         serializer->RegisterStorage(Registry_);
 }
 
@@ -130,7 +131,7 @@ JsonValue EditorDocument::ToJson() const
     // Assets may be null (brush-only); the codec only touches it on asset fields,
     // of which a brush-only scene has none.
     SceneSerializationContext context(Logging, Assets);
-    JsonValue root = SaveSceneJson(Registry_, context);
+    JsonValue root = SaveSceneJson(Registry_, EditorSceneSerializers(), context);
     if (root.IsObject())
     {
         root.AsObject().emplace_back("brush_meshes", SerializeBrushMeshes(Scene.GetBrushMeshStore()));
@@ -149,7 +150,7 @@ bool EditorDocument::LoadFromJson(const JsonValue& root)
 
     SceneLoadError loadError;
     SceneSerializationContext context(Logging, Assets);
-    if (!LoadSceneJson(root, Registry_, context, &loadError))
+    if (!LoadSceneJson(root, Registry_, EditorSceneSerializers(), context, &loadError))
     {
         Scene.SyncFromRegistry();
         return false;
@@ -176,7 +177,7 @@ EntitySnapshot EditorDocument::CaptureEntity(EntityId entity) const
     // One object per present component, keyed by JsonKey(): the same per-entity
     // layout SaveSceneJson produces, so RestoreEntity round-trips it.
     JsonValue::Object components;
-    for (const auto& serializer : GetComponentSerializerEntries())
+    for (const auto& serializer : EditorSceneSerializers().Entries())
     {
         if (!serializer->HasComponent(entity, Registry_))
             continue;
@@ -222,7 +223,7 @@ EntityId EditorDocument::RestoreEntity(const EntitySnapshot& snapshot, bool fres
         for (const auto& [key, componentData] : snapshot.Components.AsObject())
         {
             IComponentSerializer* serializer = nullptr;
-            for (const auto& entry : GetComponentSerializerEntries())
+            for (const auto& entry : EditorSceneSerializers().Entries())
                 if (entry->JsonKey() == key)
                 {
                     serializer = entry.get();

--- a/editor/kyusu/src/document/EditorEntityRecipe.cpp
+++ b/editor/kyusu/src/document/EditorEntityRecipe.cpp
@@ -13,6 +13,7 @@
 #include <utility>
 #include <unordered_map>
 #include <unordered_set>
+#include "DocumentSerialization.h"
 
 namespace
 {
@@ -36,7 +37,7 @@ template <typename Component>
 void AppendComponent(EntitySnapshot& snapshot, Registry& registry, EntityId entity,
                      LoggingProvider& logging)
 {
-    for (const auto& serializer : GetComponentSerializerEntries())
+    for (const auto& serializer : EditorSceneSerializers().Entries())
     {
         if (serializer->TypeId() != ResolveComponentTypeId<Component>())
             continue;

--- a/editor/kyusu/src/render/ComponentVisualRenderer.cpp
+++ b/editor/kyusu/src/render/ComponentVisualRenderer.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <set>
 #include <vector>
+#include "document/DocumentSerialization.h"
 
 namespace
 {
@@ -89,7 +90,7 @@ void ComponentVisualRenderer::DrawViewport(const FrameContext& frame, const Edit
                      EditorTheme::ComponentVisual.Z * tint.Z,
                      EditorTheme::ComponentVisual.W * tint.W);
     const Registry& registry = scene.GetRegistry();
-    const auto& serializers = GetComponentSerializerEntries();
+    const auto& serializers = EditorSceneSerializers().Entries();
 
     std::vector<EditorLineVertex> vertices;
     for (EntityId entity : scene.GetAllEntities())

--- a/editor/kyusu/src/render/SceneRenderQueueBuilder.cpp
+++ b/editor/kyusu/src/render/SceneRenderQueueBuilder.cpp
@@ -37,6 +37,7 @@
 #include <optional>
 #include <sstream>
 #include <utility>
+#include "document/DocumentSerialization.h"
 
 namespace
 {
@@ -320,7 +321,7 @@ void SceneRenderQueueBuilder::SetLightmapPreview(const LightmapPreviewSource& so
                             nullptr, nullptr, nullptr, Textures);
     SceneSerializationContext context(Logging, &Assets);
     SceneLoadError loadError;
-    if (!LoadSceneJson(*json, *registry, context, &loadError))
+    if (!LoadSceneJson(*json, *registry, EditorSceneSerializers(), context, &loadError))
     {
         Log.Error("lightmap preview: scene load error: {}", loadError.Message);
         return;

--- a/editor/kyusu/src/ui/InspectorPanel.cpp
+++ b/editor/kyusu/src/ui/InspectorPanel.cpp
@@ -30,6 +30,7 @@
 #include <cstring>
 #include <memory>
 #include <string>
+#include "document/DocumentSerialization.h"
 
 namespace
 {
@@ -507,7 +508,7 @@ void InspectorPanel::DrawAddComponentMenu(EntityId entity)
     if (ImGui::BeginPopup("##add_component"))
     {
         bool anyAddable = false;
-        for (const auto& serializer : GetComponentSerializerEntries())
+        for (const auto& serializer : EditorSceneSerializers().Entries())
         {
             const ComponentId id = world.GetComponentIdByType(serializer->TypeId());
             if (id == InvalidComponentId || world.HasComponent(entity, id))
@@ -563,7 +564,7 @@ void InspectorPanel::OnDraw()
     // Registry-driven: every component the registry knows about, drawn by schema.
     // No component is named in editor code here.
     World& world = WorldDoc.FocusDocument().GetScene().GetRegistry().Components;
-    for (const auto& serializer : GetComponentSerializerEntries())
+    for (const auto& serializer : EditorSceneSerializers().Entries())
     {
         const ComponentId id = world.GetComponentIdByType(serializer->TypeId());
         if (id != InvalidComponentId && world.HasComponent(entity, id))

--- a/editor/kyusu/src/ui/SceneHierarchyPanel.cpp
+++ b/editor/kyusu/src/ui/SceneHierarchyPanel.cpp
@@ -24,6 +24,7 @@
 #include <span>
 #include <string>
 #include <vector>
+#include "document/DocumentSerialization.h"
 
 SceneHierarchyPanel::SceneHierarchyPanel(WorldDocument& world,
                                          SelectionService& selection, CommandStack& commands)
@@ -86,7 +87,7 @@ void SceneHierarchyPanel::OnDraw()
         // Registry-driven summary: the components present on this entity, named
         // by the serializer registry — no hard-coded component list.
         std::string summary;
-        for (const auto& serializer : GetComponentSerializerEntries())
+        for (const auto& serializer : EditorSceneSerializers().Entries())
         {
             const ComponentId id = world.GetComponentIdByType(serializer->TypeId());
             if (id == InvalidComponentId || !world.HasComponent(entity, id))

--- a/engine/include/app/Engine.h
+++ b/engine/include/app/Engine.h
@@ -12,6 +12,7 @@
 #include <runtime/FrameTrace.h>
 #include <runtime/RuntimeFrameLoop.h>
 #include <time/TimingHistory.h>
+#include <world/serialization/ComponentSerializerRegistry.h>
 
 #ifdef SENCHA_ENABLE_RENDER_PROFILING
 #include <profiling/RenderCapture.h>
@@ -133,6 +134,14 @@ public:
     [[nodiscard]] JobSystem& Jobs();
     [[nodiscard]] const JobSystem& Jobs() const;
 
+    // Which components this host can serialize: the engine scene manifest plus
+    // whatever the loaded game module registered through OnRegisterComponents.
+    // Zone loading and any other scene read/write takes this explicitly.
+    [[nodiscard]] const ComponentSerializerRegistry& SceneSerializers() const
+    {
+        return SceneSerializerRegistry;
+    }
+
     [[nodiscard]] DefaultRenderPipeline* GetRenderPipeline();
     [[nodiscard]] const DefaultRenderPipeline* GetRenderPipeline() const;
 
@@ -179,6 +188,7 @@ private:
     void CreateDebugOverlay();
 
     EngineConfig Configuration;
+    ComponentSerializerRegistry SceneSerializerRegistry;
     LoggingProvider LoggingState;
     std::unique_ptr<DebugService> DebugState;
     std::unique_ptr<ConsoleService> ConsoleState;

--- a/engine/include/app/ModuleExport.h
+++ b/engine/include/app/ModuleExport.h
@@ -31,5 +31,9 @@
 // EngineFramePhases.h registration free function, and made the frame-phase
 // accessors (Timing, Instrumentation, the profiling latch/publish pair)
 // private; IRenderFeature lost the unreachable Contribute slot; JobSystem
-// became the concrete pool and IWindow was removed.
-#define SENCHA_GAME_ABI_VERSION 6u
+// became the concrete pool and IWindow was removed. v7: the process-global
+// component serializer registry is gone -- each host owns one and the scene
+// save/load functions take it explicitly, so a module that reached for the
+// default registry no longer links. Game::OnRegisterComponents is unchanged;
+// the registry it receives is now the engine's own.
+#define SENCHA_GAME_ABI_VERSION 7u

--- a/engine/include/attributes/AttributeSetSerializer.h
+++ b/engine/include/attributes/AttributeSetSerializer.h
@@ -6,7 +6,9 @@
 // Registers an IComponentSerializer for AttributeSet with the scene serializer.
 // Attributes persist by name (see AttributeSerialization.h), resolved through
 // the AttributeRegistry stored as a world resource on the registry being
-// (de)serialized. Call once at startup, after InitSceneSerializer().
+// (de)serialized. Call once at startup, on the host's serializer registry.
 //=============================================================================
 
-void RegisterAttributeSerializer();
+class ComponentSerializerRegistry;
+
+void RegisterAttributeSerializer(ComponentSerializerRegistry& serializers);

--- a/engine/include/gameplay_tags/GameplayTagContainerSerializer.h
+++ b/engine/include/gameplay_tags/GameplayTagContainerSerializer.h
@@ -6,10 +6,12 @@
 // Registers an IComponentSerializer for GameplayTagContainer with the scene
 // serializer. Tags persist by name (see GameplayTagSerialization.h), resolved
 // through the GameplayTagRegistry stored as a world resource on the registry
-// being (de)serialized. Call once at startup, after InitSceneSerializer().
+// being (de)serialized. Call once at startup, on the host's serializer registry.
 //
 // This lives in the framework, not the engine manifest: the engine's
 // EngineSceneComponents must not name gameplay types.
 //=============================================================================
 
-void RegisterGameplayTagSerializer();
+class ComponentSerializerRegistry;
+
+void RegisterGameplayTagSerializer(ComponentSerializerRegistry& serializers);

--- a/engine/include/world/serialization/ComponentSerializerRegistry.h
+++ b/engine/include/world/serialization/ComponentSerializerRegistry.h
@@ -105,8 +105,3 @@ public:
 private:
     std::vector<std::unique_ptr<IComponentSerializer>> Entries_;
 };
-
-// The process-default instance behind the legacy free-function API in
-// SceneSerializer.h. New code (the module context) should take an explicit
-// ComponentSerializerRegistry& instead of reaching for this.
-ComponentSerializerRegistry& DefaultComponentSerializerRegistry();

--- a/engine/include/world/serialization/SceneSerializer.h
+++ b/engine/include/world/serialization/SceneSerializer.h
@@ -4,9 +4,11 @@
 #include <core/serialization/BinaryReader.h>
 #include <core/serialization/BinaryWriter.h>
 #include <world/serialization/ComponentSerializer.h>
+#include <world/serialization/ComponentSerializerRegistry.h>
 #include <world/serialization/IComponentSerializer.h>
 #include <world/serialization/SceneSerializationContext.h>
 
+#include <cassert>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -28,37 +30,59 @@ struct SceneLoadError
     std::string Message;
 };
 
-void RegisterComponentSerializer(std::unique_ptr<IComponentSerializer> serializer);
-void ClearComponentSerializers();
-void InitSceneSerializer();
+// Which components a scene can carry is a property of the host, not of the
+// process: the runtime's set is the engine manifest plus whatever the loaded
+// game module registers, an editor adds its authoring-only components, and a
+// test wants only what it declared. Each host owns a ComponentSerializerRegistry
+// and passes it in, so those sets cannot leak into each other and a test cannot
+// be perturbed by what ran before it.
 
 template <typename Component>
-void RegisterComponent()
+void RegisterComponent(ComponentSerializerRegistry& serializers)
 {
-    RegisterComponentSerializer(std::make_unique<ComponentSerializer<Component>>());
+    // Fail loud on a genuine collision: a component whose type id, chunk id, or
+    // JSON key is already taken would otherwise serialize as another component.
+    const auto result =
+        serializers.Register(std::make_unique<ComponentSerializer<Component>>());
+    assert(result != ComponentSerializerRegistry::RegisterResult::Rejected
+           && "Component serializer collision: ComponentTypeId, chunk ID, or JSON "
+              "key already registered by a different component");
+    (void)result;
 }
 
-[[nodiscard]] const std::vector<std::unique_ptr<IComponentSerializer>>& GetComponentSerializerEntries();
+// Registers every component in the engine's scene manifest.
+void RegisterEngineSceneSerializers(ComponentSerializerRegistry& serializers);
 
-[[nodiscard]] bool SaveSceneBinary(const Registry& registry, BinaryWriter& writer,
+[[nodiscard]] bool SaveSceneBinary(const Registry& registry,
+    const ComponentSerializerRegistry& serializers,
+    BinaryWriter& writer,
     SceneSaveError* error = nullptr);
 [[nodiscard]] bool SaveSceneBinary(const Registry& registry,
+    const ComponentSerializerRegistry& serializers,
     BinaryWriter& writer,
     SceneSerializationContext& context,
     SceneSaveError* error = nullptr);
-[[nodiscard]] bool LoadSceneBinary(BinaryReader& reader, Registry& registry,
+[[nodiscard]] bool LoadSceneBinary(BinaryReader& reader,
+    Registry& registry,
+    const ComponentSerializerRegistry& serializers,
     SceneLoadError* error = nullptr);
 [[nodiscard]] bool LoadSceneBinary(BinaryReader& reader,
     Registry& registry,
+    const ComponentSerializerRegistry& serializers,
     SceneSerializationContext& context,
     SceneLoadError* error = nullptr);
 
-[[nodiscard]] JsonValue SaveSceneJson(const Registry& registry);
 [[nodiscard]] JsonValue SaveSceneJson(const Registry& registry,
+    const ComponentSerializerRegistry& serializers);
+[[nodiscard]] JsonValue SaveSceneJson(const Registry& registry,
+    const ComponentSerializerRegistry& serializers,
     SceneSerializationContext& context);
-[[nodiscard]] bool LoadSceneJson(const JsonValue& root, Registry& registry,
+[[nodiscard]] bool LoadSceneJson(const JsonValue& root,
+    Registry& registry,
+    const ComponentSerializerRegistry& serializers,
     SceneLoadError* error = nullptr);
 [[nodiscard]] bool LoadSceneJson(const JsonValue& root,
     Registry& registry,
+    const ComponentSerializerRegistry& serializers,
     SceneSerializationContext& context,
     SceneLoadError* error = nullptr);

--- a/engine/src/app/Engine.cpp
+++ b/engine/src/app/Engine.cpp
@@ -15,6 +15,7 @@
 #include <world/RuntimeComponentSchema.h>
 #include <world/RuntimeWorld.h>
 #include <world/serialization/ComponentSerializerRegistry.h>
+#include <world/serialization/SceneSerializer.h>
 
 #ifdef SENCHA_ENABLE_VULKAN
 #include <graphics/vulkan/GraphicsServices.h>
@@ -369,8 +370,13 @@ int Engine::Run(Game& game)
     // Serializers and runtime storage share stable component identities but are
     // independent registries. The editor calls only the serializer hook; the
     // runtime additionally composes and seals the complete World vocabulary.
-    ComponentSerializerRegistry& serializers =
-        DefaultComponentSerializerRegistry();
+    //
+    // The engine registers its own manifest before handing the registry to the
+    // game, so a game module adds to a known set instead of being responsible
+    // for seeding it. Clear first: Run may be called again in the same process.
+    ComponentSerializerRegistry& serializers = SceneSerializerRegistry;
+    serializers.Clear();
+    RegisterEngineSceneSerializers(serializers);
     game.OnRegisterComponents(serializers);
 
     RuntimeComponentSchemaState = WorldComponentSchema{};

--- a/engine/src/attributes/AttributeSetSerializer.cpp
+++ b/engine/src/attributes/AttributeSetSerializer.cpp
@@ -13,8 +13,7 @@
 #include <memory>
 #include <span>
 #include <vector>
-
-void RegisterComponentSerializer(std::unique_ptr<IComponentSerializer> serializer);
+#include <world/serialization/ComponentSerializerRegistry.h>
 
 namespace
 {
@@ -131,8 +130,8 @@ public:
 };
 } // namespace
 
-void RegisterAttributeSerializer()
+void RegisterAttributeSerializer(ComponentSerializerRegistry& serializers)
 {
-    RegisterComponentSerializer(
+    (void)serializers.Register(
         std::make_unique<AttributeSetSerializer>());
 }

--- a/engine/src/gameplay_tags/GameplayTagContainerSerializer.cpp
+++ b/engine/src/gameplay_tags/GameplayTagContainerSerializer.cpp
@@ -13,8 +13,7 @@
 #include <memory>
 #include <span>
 #include <vector>
-
-void RegisterComponentSerializer(std::unique_ptr<IComponentSerializer> serializer);
+#include <world/serialization/ComponentSerializerRegistry.h>
 
 namespace
 {
@@ -131,8 +130,8 @@ public:
 };
 } // namespace
 
-void RegisterGameplayTagSerializer()
+void RegisterGameplayTagSerializer(ComponentSerializerRegistry& serializers)
 {
-    RegisterComponentSerializer(
+    (void)serializers.Register(
         std::make_unique<GameplayTagContainerSerializer>());
 }

--- a/engine/src/world/serialization/SceneSerializer.cpp
+++ b/engine/src/world/serialization/SceneSerializer.cpp
@@ -22,11 +22,6 @@
 
 namespace
 {
-    const std::vector<std::unique_ptr<IComponentSerializer>>& SerializerEntries()
-    {
-        return DefaultComponentSerializerRegistry().Entries();
-    }
-
     void SetError(SceneSaveError* error, std::string message)
     {
         if (error)
@@ -39,9 +34,10 @@ namespace
             error->Message = std::move(message);
     }
 
-    IComponentSerializer* FindByChunkMutable(std::uint32_t chunkId)
+    IComponentSerializer* FindByChunkMutable(const ComponentSerializerRegistry& serializers,
+                                             std::uint32_t chunkId)
     {
-        for (const auto& entry : SerializerEntries())
+        for (const auto& entry : serializers.Entries())
         {
             if (entry->BinaryChunkId() == chunkId)
                 return entry.get();
@@ -49,9 +45,10 @@ namespace
         return nullptr;
     }
 
-    IComponentSerializer* FindByJsonKey(std::string_view key)
+    IComponentSerializer* FindByJsonKey(const ComponentSerializerRegistry& serializers,
+                                        std::string_view key)
     {
-        for (const auto& entry : SerializerEntries())
+        for (const auto& entry : serializers.Entries())
         {
             if (key == entry->JsonKey())
                 return entry.get();
@@ -59,9 +56,10 @@ namespace
         return nullptr;
     }
 
-    void RegisterSerializedComponentStorage(Registry& registry)
+    void RegisterSerializedComponentStorage(const ComponentSerializerRegistry& serializers,
+                                            Registry& registry)
     {
-        for (const auto& entry : SerializerEntries())
+        for (const auto& entry : serializers.Entries())
             entry->RegisterStorage(registry);
     }
 
@@ -257,62 +255,39 @@ namespace
         return true;
     }
 
-    void RollbackLoadedEntities(Registry& registry, const std::vector<EntityId>& entities)
+    void RollbackLoadedEntities(const ComponentSerializerRegistry& serializers,
+                                Registry& registry,
+                                const std::vector<EntityId>& entities)
     {
         for (auto it = entities.rbegin(); it != entities.rend(); ++it)
         {
-            for (const auto& serializer : SerializerEntries())
+            for (const auto& serializer : serializers.Entries())
                 serializer->Remove(*it, registry);
             registry.Components.DestroyEntity(*it);
         }
     }
 }
 
-void RegisterComponentSerializer(std::unique_ptr<IComponentSerializer> serializer)
+void RegisterEngineSceneSerializers(ComponentSerializerRegistry& serializers)
 {
-    // Conflict policy lives in ComponentSerializerRegistry; the legacy free
-    // function preserves the historical fail-loud behavior so the death tests
-    // still observe a hard stop on a genuine collision (vs. the loader, which
-    // takes the returned Rejected and refuses the module cleanly).
-    const auto result = DefaultComponentSerializerRegistry().Register(std::move(serializer));
-    assert(result != ComponentSerializerRegistry::RegisterResult::Rejected
-           && "Component serializer collision: ComponentTypeId, chunk ID, or JSON "
-              "key already registered by a different component");
-    (void)result;
-}
-
-void ClearComponentSerializers()
-{
-    DefaultComponentSerializerRegistry().Clear();
-}
-
-ComponentSerializerRegistry& DefaultComponentSerializerRegistry()
-{
-    static ComponentSerializerRegistry instance;
-    return instance;
-}
-
-void InitSceneSerializer()
-{
-    ForEachSceneComponent([](auto tag)
+    ForEachSceneComponent([&](auto tag)
     {
-        RegisterComponent<typename decltype(tag)::Type>();
+        RegisterComponent<typename decltype(tag)::Type>(serializers);
     });
 }
 
-const std::vector<std::unique_ptr<IComponentSerializer>>& GetComponentSerializerEntries()
-{
-    return SerializerEntries();
-}
-
-bool SaveSceneBinary(const Registry& registry, BinaryWriter& writer, SceneSaveError* error)
+bool SaveSceneBinary(const Registry& registry,
+                     const ComponentSerializerRegistry& serializers,
+                     BinaryWriter& writer,
+                     SceneSaveError* error)
 {
     LoggingProvider logging;
     SceneSerializationContext context(logging);
-    return SaveSceneBinary(registry, writer, context, error);
+    return SaveSceneBinary(registry, serializers, writer, context, error);
 }
 
 bool SaveSceneBinary(const Registry& registry,
+                     const ComponentSerializerRegistry& serializers,
                      BinaryWriter& writer,
                      SceneSerializationContext& context,
                      SceneSaveError* error)
@@ -337,7 +312,7 @@ bool SaveSceneBinary(const Registry& registry,
         return false;
     }
 
-    for (const auto& entry : SerializerEntries())
+    for (const auto& entry : serializers.Entries())
     {
         ChunkWriter chunk;
         if (!chunk.Begin(writer, entry->BinaryChunkId(), SceneVersion)
@@ -352,15 +327,19 @@ bool SaveSceneBinary(const Registry& registry,
     return true;
 }
 
-bool LoadSceneBinary(BinaryReader& reader, Registry& registry, SceneLoadError* error)
+bool LoadSceneBinary(BinaryReader& reader,
+                     Registry& registry,
+                     const ComponentSerializerRegistry& serializers,
+                     SceneLoadError* error)
 {
     LoggingProvider logging;
     SceneSerializationContext context(logging);
-    return LoadSceneBinary(reader, registry, context, error);
+    return LoadSceneBinary(reader, registry, serializers, context, error);
 }
 
 bool LoadSceneBinary(BinaryReader& reader,
                      Registry& registry,
+                     const ComponentSerializerRegistry& serializers,
                      SceneSerializationContext& context,
                      SceneLoadError* error)
 {
@@ -376,7 +355,7 @@ bool LoadSceneBinary(BinaryReader& reader,
     std::vector<EntityId> loadedEntities;
     bool loadedRegistry = false;
 
-    RegisterSerializedComponentStorage(registry);
+    RegisterSerializedComponentStorage(serializers, registry);
 
     while (true)
     {
@@ -398,7 +377,7 @@ bool LoadSceneBinary(BinaryReader& reader,
             ok = Deserialize(reader, count)
                 && LoadHierarchyChunk(reader, count, registry, remap);
         }
-        else if (IComponentSerializer* entry = FindByChunkMutable(chunkHeader.Id))
+        else if (IComponentSerializer* entry = FindByChunkMutable(serializers, chunkHeader.Id))
         {
             std::uint32_t count = 0;
             ok = Deserialize(reader, count)
@@ -407,14 +386,14 @@ bool LoadSceneBinary(BinaryReader& reader,
 
         if (!ok)
         {
-            RollbackLoadedEntities(registry, loadedEntities);
+            RollbackLoadedEntities(serializers, registry, loadedEntities);
             SetError(error, "Failed to read scene chunk " + std::to_string(chunkHeader.Id) + ".");
             return false;
         }
 
         if (!chunk.Skip(reader))
         {
-            RollbackLoadedEntities(registry, loadedEntities);
+            RollbackLoadedEntities(serializers, registry, loadedEntities);
             SetError(error, "Failed to skip scene chunk remainder.");
             return false;
         }
@@ -422,7 +401,7 @@ bool LoadSceneBinary(BinaryReader& reader,
 
     if (!loadedRegistry)
     {
-        RollbackLoadedEntities(registry, loadedEntities);
+        RollbackLoadedEntities(serializers, registry, loadedEntities);
         SetError(error, "Scene is missing entity registry chunk.");
         return false;
     }
@@ -430,14 +409,17 @@ bool LoadSceneBinary(BinaryReader& reader,
     return true;
 }
 
-JsonValue SaveSceneJson(const Registry& registry)
+JsonValue SaveSceneJson(const Registry& registry,
+                        const ComponentSerializerRegistry& serializers)
 {
     LoggingProvider logging;
     SceneSerializationContext context(logging);
-    return SaveSceneJson(registry, context);
+    return SaveSceneJson(registry, serializers, context);
 }
 
-JsonValue SaveSceneJson(const Registry& registry, SceneSerializationContext& context)
+JsonValue SaveSceneJson(const Registry& registry,
+                        const ComponentSerializerRegistry& serializers,
+                        SceneSerializationContext& context)
 {
     JsonValue::Array entitiesJson;
     JsonValue::Array hierarchyJson;
@@ -451,7 +433,7 @@ JsonValue SaveSceneJson(const Registry& registry, SceneSerializationContext& con
         entityToJsonIndex[entity.Index] = i;
 
         JsonValue::Object componentsJson;
-        for (const auto& entry : SerializerEntries())
+        for (const auto& entry : serializers.Entries())
         {
             JsonWriteArchive archive;
             if (!entry->Save(archive, entity, registry, context) || !archive.Ok())
@@ -494,15 +476,19 @@ JsonValue SaveSceneJson(const Registry& registry, SceneSerializationContext& con
     });
 }
 
-bool LoadSceneJson(const JsonValue& root, Registry& registry, SceneLoadError* error)
+bool LoadSceneJson(const JsonValue& root,
+                   Registry& registry,
+                   const ComponentSerializerRegistry& serializers,
+                   SceneLoadError* error)
 {
     LoggingProvider logging;
     SceneSerializationContext context(logging);
-    return LoadSceneJson(root, registry, context, error);
+    return LoadSceneJson(root, registry, serializers, context, error);
 }
 
 bool LoadSceneJson(const JsonValue& root,
                    Registry& registry,
+                   const ComponentSerializerRegistry& serializers,
                    SceneSerializationContext& context,
                    SceneLoadError* error)
 {
@@ -525,13 +511,13 @@ bool LoadSceneJson(const JsonValue& root,
     std::vector<EntityId> entities;
     entities.reserve(entitiesValue->AsArray().size());
 
-    RegisterSerializedComponentStorage(registry);
+    RegisterSerializedComponentStorage(serializers, registry);
 
     for (const JsonValue& entityValue : entitiesValue->AsArray())
     {
         if (!entityValue.IsObject())
         {
-            RollbackLoadedEntities(registry, entities);
+            RollbackLoadedEntities(serializers, registry, entities);
             SetError(error, "Scene JSON entity must be an object.");
             return false;
         }
@@ -545,21 +531,21 @@ bool LoadSceneJson(const JsonValue& root,
 
         if (!components->IsObject())
         {
-            RollbackLoadedEntities(registry, entities);
+            RollbackLoadedEntities(serializers, registry, entities);
             SetError(error, "Scene JSON components must be an object.");
             return false;
         }
 
         for (const auto& [key, componentData] : components->AsObject())
         {
-            IComponentSerializer* entry = FindByJsonKey(key);
+            IComponentSerializer* entry = FindByJsonKey(serializers, key);
             if (!entry)
                 continue;
 
             JsonReadArchive archive(componentData);
             if (!entry->Load(archive, entity, registry, context) || !archive.Ok())
             {
-                RollbackLoadedEntities(registry, entities);
+                RollbackLoadedEntities(serializers, registry, entities);
                 SetError(error, "Failed to load JSON component '" + key + "'.");
                 return false;
             }
@@ -569,7 +555,7 @@ bool LoadSceneJson(const JsonValue& root,
     const JsonValue* hierarchyValue = root.Find("hierarchy");
     if (hierarchyValue && !hierarchyValue->IsArray())
     {
-        RollbackLoadedEntities(registry, entities);
+        RollbackLoadedEntities(serializers, registry, entities);
         SetError(error, "Scene JSON hierarchy must be an array.");
         return false;
     }
@@ -580,7 +566,7 @@ bool LoadSceneJson(const JsonValue& root,
         {
             if (!relation.IsObject())
             {
-                RollbackLoadedEntities(registry, entities);
+                RollbackLoadedEntities(serializers, registry, entities);
                 SetError(error, "Scene JSON hierarchy relation must be an object.");
                 return false;
             }
@@ -589,7 +575,7 @@ bool LoadSceneJson(const JsonValue& root,
             const JsonValue* parent = relation.Find("parent");
             if (!child || !parent || !child->IsNumber() || !parent->IsNumber())
             {
-                RollbackLoadedEntities(registry, entities);
+                RollbackLoadedEntities(serializers, registry, entities);
                 SetError(error, "Scene JSON hierarchy relation is invalid.");
                 return false;
             }
@@ -598,7 +584,7 @@ bool LoadSceneJson(const JsonValue& root,
             const auto parentIndex = static_cast<size_t>(parent->AsNumber());
             if (childIndex >= entities.size() || parentIndex >= entities.size())
             {
-                RollbackLoadedEntities(registry, entities);
+                RollbackLoadedEntities(serializers, registry, entities);
                 SetError(error, "Scene JSON hierarchy references an unknown entity.");
                 return false;
             }

--- a/example/CubeDemo/CubeDemoGame.cpp
+++ b/example/CubeDemo/CubeDemoGame.cpp
@@ -207,8 +207,6 @@ void CubeDemoGame::OnStart(GameStartupContext&)
         graphics.Samplers);
     RuntimeAssets& runtimeAssets = RuntimeAssetState();
 
-    InitSceneSerializer();
-
 #ifdef SENCHA_ENABLE_COOK
     {
         PngTextureImporter pngImporter;
@@ -285,7 +283,7 @@ void CubeDemoGame::OnStart(GameStartupContext&)
         engine.Tasks(),
         engine.World(),
         engine.RuntimeComponents(),
-        DefaultComponentSerializerRegistry(),
+        engine.SceneSerializers(),
         *SceneContext,
         engine.Runtime());
     Preloader.emplace(
@@ -322,8 +320,7 @@ void CubeDemoGame::OnStart(GameStartupContext&)
     auto parsed = std::make_shared<DemoSceneParse>();
     auto packageBuilt = std::make_shared<bool>(false);
     auto packageError = std::make_shared<std::string>();
-    const ComponentSerializerRegistry* serializers =
-        &DefaultComponentSerializerRegistry();
+    const ComponentSerializerRegistry* serializers = &engine.SceneSerializers();
     ZoneLoader->BeginLoad(
         kDemoZone,
         [parsed, packageBuilt, packageError, serializers](

--- a/example/SceneViewer/SceneViewerGame.cpp
+++ b/example/SceneViewer/SceneViewerGame.cpp
@@ -199,7 +199,6 @@ struct ScriptedCameraPathSystem
 void SceneViewerGame::OnRegisterComponents(
     ComponentSerializerRegistry&)
 {
-    InitSceneSerializer();
 }
 
 void SceneViewerGame::OnStart(GameStartupContext&)
@@ -268,7 +267,7 @@ void SceneViewerGame::OnStart(GameStartupContext&)
         engine.Tasks(),
         engine.World(),
         engine.RuntimeComponents(),
-        DefaultComponentSerializerRegistry(),
+        engine.SceneSerializers(),
         *SceneContext,
         engine.Runtime());
     Preloader.emplace(
@@ -367,8 +366,7 @@ ConsoleResult SceneViewerGame::LoadMap(
 
     auto buildResult = std::make_shared<SceneBuildResult>();
     auto probes = std::make_shared<ProbeVolumeFile>();
-    const ComponentSerializerRegistry* serializers =
-        &DefaultComponentSerializerRegistry();
+    const ComponentSerializerRegistry* serializers = &engine.SceneSerializers();
     ZoneLoader->BeginLoad(
         kPlayZone,
         [buildResult, probes, serializers, scenePath](

--- a/template/src/TemplateGame.cpp
+++ b/template/src/TemplateGame.cpp
@@ -506,11 +506,12 @@ struct SpinSystem
 } // namespace
 
 void TemplateGame::OnRegisterComponents(
-    ComponentSerializerRegistry&)
+    ComponentSerializerRegistry& serializers)
 {
-    InitSceneSerializer();
-    RegisterComponent<SpinComponent>();
-    RegisterComponent<PlayerStartComponent>();
+    // The engine already registered its own scene manifest into this registry;
+    // a game adds only what it owns.
+    RegisterComponent<SpinComponent>(serializers);
+    RegisterComponent<PlayerStartComponent>(serializers);
 }
 
 void TemplateGame::OnUnregisterComponents(
@@ -571,7 +572,7 @@ void TemplateGame::OnStart(GameStartupContext&)
         engine.Tasks(),
         engine.World(),
         engine.RuntimeComponents(),
-        DefaultComponentSerializerRegistry(),
+        engine.SceneSerializers(),
         *SceneContext,
         engine.Runtime());
     Preloader.emplace(
@@ -754,8 +755,7 @@ ConsoleResult TemplateGame::LoadMap(std::string_view mapName)
     }
 
     auto buildResult = std::make_shared<SceneBuildResult>();
-    const ComponentSerializerRegistry* serializers =
-        &DefaultComponentSerializerRegistry();
+    const ComponentSerializerRegistry* serializers = &engine.SceneSerializers();
     auto probes = std::make_shared<ProbeVolumeFile>();
     ZoneLoader->BeginLoad(
         kPlayZone,
@@ -875,8 +875,7 @@ ConsoleResult TemplateGame::LoadWorld(std::string_view worldName)
     RuntimeAssets& runtimeAssets = RuntimeAssetState();
     AssetSystem* assetSystem = &runtimeAssets.Assets;
     LoggingProvider* loggingPtr = &logging;
-    const ComponentSerializerRegistry* serializers =
-        &DefaultComponentSerializerRegistry();
+    const ComponentSerializerRegistry* serializers = &engine.SceneSerializers();
 
     const EngineRuntimeConfig& runtimeConfig =
         engine.Config().Runtime;
@@ -998,7 +997,7 @@ ConsoleResult TemplateGame::LoadWorld(std::string_view worldName)
             package,
             buildResult,
             scenePath,
-            DefaultComponentSerializerRegistry());
+            engine.SceneSerializers());
         if (!buildResult.Success)
         {
             Partition.reset();
@@ -1013,7 +1012,7 @@ ConsoleResult TemplateGame::LoadWorld(std::string_view worldName)
                 engine.RuntimeComponents(),
                 package,
                 PersistentStoragePartition,
-                DefaultComponentSerializerRegistry(),
+                engine.SceneSerializers(),
                 *SceneContext,
                 &importError))
         {

--- a/test/core/RuntimeComponentSchemaStartupTests.cpp
+++ b/test/core/RuntimeComponentSchemaStartupTests.cpp
@@ -123,10 +123,9 @@ public:
     }
 
     void OnRegisterComponents(
-        ComponentSerializerRegistry&) override
+        ComponentSerializerRegistry& serializers) override
     {
-        InitSceneSerializer();
-        RegisterComponent<StartupGameComponent>();
+        RegisterComponent<StartupGameComponent>(serializers);
     }
 
     void OnUnregisterComponents(
@@ -204,10 +203,9 @@ public:
     }
 
     void OnRegisterComponents(
-        ComponentSerializerRegistry&) override
+        ComponentSerializerRegistry& serializers) override
     {
-        InitSceneSerializer();
-        RegisterComponent<MissingRuntimeComponent>();
+        RegisterComponent<MissingRuntimeComponent>(serializers);
     }
 
     void OnUnregisterComponents(

--- a/test/core/SceneSerializerIdentityTests.cpp
+++ b/test/core/SceneSerializerIdentityTests.cpp
@@ -59,13 +59,12 @@ namespace
 
 TEST(SceneSerializerIdentity, IdenticalRegistrationIsIdempotent)
 {
-    ClearComponentSerializers();
-    RegisterComponentSerializer(Ser<SerP>());
-    const size_t afterFirst = GetComponentSerializerEntries().size();
-    RegisterComponentSerializer(Ser<SerP>()); // full tuple match → no-op
-    const size_t afterSecond = GetComponentSerializerEntries().size();
+    ComponentSerializerRegistry serializers;
+    (void)serializers.Register(Ser<SerP>());
+    const size_t afterFirst = serializers.Entries().size();
+    (void)serializers.Register(Ser<SerP>()); // full tuple match -> no-op
+    const size_t afterSecond = serializers.Entries().size();
     EXPECT_EQ(afterFirst, afterSecond);
-    ClearComponentSerializers();
 }
 
 TEST(SceneSerializerIdentity, FullTupleIsConsistent)
@@ -84,9 +83,9 @@ TEST(SceneSerializerIdentity, SameJsonKeyDifferentTypeIdRejected)
 #else
     EXPECT_DEATH(
         {
-            ClearComponentSerializers();
-            RegisterComponentSerializer(Ser<SerP>());
-            RegisterComponentSerializer(Ser<SerQ>()); // same key, different id
+            ComponentSerializerRegistry serializers;
+            RegisterComponent<SerP>(serializers);
+            RegisterComponent<SerQ>(serializers); // same key, different id
         },
         "collision");
 #endif
@@ -99,9 +98,9 @@ TEST(SceneSerializerIdentity, SameChunkDifferentTypeIdRejected)
 #else
     EXPECT_DEATH(
         {
-            ClearComponentSerializers();
-            RegisterComponentSerializer(Ser<SerR>());
-            RegisterComponentSerializer(Ser<SerS>()); // same chunk, different id
+            ComponentSerializerRegistry serializers;
+            RegisterComponent<SerR>(serializers);
+            RegisterComponent<SerS>(serializers); // same chunk, different id
         },
         "collision");
 #endif

--- a/test/editor/AffordanceBuildCostTests.cpp
+++ b/test/editor/AffordanceBuildCostTests.cpp
@@ -6,6 +6,7 @@
 
 #include <chrono>
 #include <cstdio>
+#include "document/DocumentSerialization.h"
 
 // Viewport affordances are rebuilt several times a frame (each viewport, the
 // overlay, hover, hit-testing), so the cost of one build is multiplied by a
@@ -32,7 +33,7 @@ TEST_F(AffordanceBuildCostTest, WorkScalesWithAdaptersNotRegisteredComponentType
     // component type. Walking the registered types per entity would make the
     // inner loop an order of magnitude wider than the work that can result.
     const std::size_t adapters = Affordances().Registry().Entries().size();
-    const std::size_t serializers = GetComponentSerializerEntries().size();
+    const std::size_t serializers = EditorSceneSerializers().Entries().size();
     EXPECT_GT(serializers, adapters);
     EXPECT_LE(adapters, 4u) << "affordance adapters grew; re-check the per-entity inner loop";
 }

--- a/test/level_cook/RawComponentRemoveCommandTests.cpp
+++ b/test/level_cook/RawComponentRemoveCommandTests.cpp
@@ -25,10 +25,10 @@ namespace
     protected:
         static void SetUpTestSuite() { RegisterDocumentSerializers(); }
 
-        // The serializer for a given JSON key (process-global, stable).
+        // The serializer for a given JSON key, from the editor's registry.
         IComponentSerializer* SerializerFor(std::string_view jsonKey) const
         {
-            for (const auto& entry : GetComponentSerializerEntries())
+            for (const auto& entry : EditorSceneSerializers().Entries())
                 if (entry->JsonKey() == jsonKey)
                     return entry.get();
             return nullptr;

--- a/test/runtime/AudioRuntimeTests.cpp
+++ b/test/runtime/AudioRuntimeTests.cpp
@@ -158,8 +158,8 @@ TEST(AudioClipCodec, LoadResolvesPathString)
 
 TEST(AudioClipCodec, ComponentRoundTripsThroughSceneJson)
 {
-    ClearComponentSerializers();
-    RegisterComponent<AudioSourceComponent>();
+    ComponentSerializerRegistry serializers;
+    RegisterComponent<AudioSourceComponent>(serializers);
 
     LoggingProvider logging;
     AssetRegistry registry(logging);
@@ -191,12 +191,12 @@ TEST(AudioClipCodec, ComponentRoundTripsThroughSceneJson)
         });
 
     SceneSerializationContext saveContext(logging, &assets);
-    const JsonValue json = SaveSceneJson(source, saveContext);
+    const JsonValue json = SaveSceneJson(source, serializers, saveContext);
 
     Registry destination;
     destination.Components.RegisterComponent<AudioSourceComponent>();
     SceneSerializationContext loadContext(logging, &assets);
-    ASSERT_TRUE(LoadSceneJson(json, destination, loadContext));
+    ASSERT_TRUE(LoadSceneJson(json, destination, serializers, loadContext));
 
     int count = 0;
     destination.Components.ForEachComponent<AudioSourceComponent>(
@@ -213,8 +213,6 @@ TEST(AudioClipCodec, ComponentRoundTripsThroughSceneJson)
         EXPECT_FALSE(component.Started);
     });
     EXPECT_EQ(count, 1);
-
-    ClearComponentSerializers();
 }
 
 TEST(AudioSourceLifetime, RemoveStopsVoiceBeforeReleasingSoleClipReference)

--- a/test/runtime/CaptionSystemTests.cpp
+++ b/test/runtime/CaptionSystemTests.cpp
@@ -344,8 +344,8 @@ TEST(CaptionSystemDegrade, NoAudioServiceStillSubtitlesActiveSources)
 
 TEST(CaptionSceneCodec, ComponentRoundTripsWithReadableEnumStrings)
 {
-    ClearComponentSerializers();
-    RegisterComponent<AudioCaptionComponent>();
+    ComponentSerializerRegistry serializers;
+    RegisterComponent<AudioCaptionComponent>(serializers);
 
     LoggingProvider logging;
 
@@ -363,7 +363,7 @@ TEST(CaptionSceneCodec, ComponentRoundTripsWithReadableEnumStrings)
     });
 
     SceneSerializationContext saveCtx(logging);
-    JsonValue json = SaveSceneJson(src, saveCtx);
+    JsonValue json = SaveSceneJson(src, serializers, saveCtx);
 
     // Author-readable strings in the scene file, never raw integers.
     const JsonValue* components =
@@ -376,7 +376,7 @@ TEST(CaptionSceneCodec, ComponentRoundTripsWithReadableEnumStrings)
     Registry dst;
     dst.Components.RegisterComponent<AudioCaptionComponent>();
     SceneSerializationContext loadCtx(logging);
-    ASSERT_TRUE(LoadSceneJson(json, dst, loadCtx));
+    ASSERT_TRUE(LoadSceneJson(json, dst, serializers, loadCtx));
 
     int count = 0;
     dst.Components.ForEachComponent<AudioCaptionComponent>(
@@ -396,8 +396,6 @@ TEST(CaptionSceneCodec, ComponentRoundTripsWithReadableEnumStrings)
         EXPECT_FALSE(caption.CaptionAttempted);
     });
     EXPECT_EQ(count, 1);
-
-    ClearComponentSerializers();
 }
 
 TEST(CaptionSceneCodec, UnknownEnumStringFailsLoad)

--- a/test/runtime/ComponentManifestTests.cpp
+++ b/test/runtime/ComponentManifestTests.cpp
@@ -86,14 +86,14 @@ TEST(ComponentManifest, SceneRegistryRegistersEveryManifestComponent)
     EXPECT_TRUE(registry.Components.IsRegistered<Parent>());
 }
 
-TEST(ComponentManifest, InitSceneSerializerIsIdempotentAndCoversManifest)
+TEST(ComponentManifest, EngineSerializerRegistrationIsIdempotentAndCoversManifest)
 {
-    ClearComponentSerializers();
-    InitSceneSerializer();
-    const std::size_t count = GetComponentSerializerEntries().size();
+    ComponentSerializerRegistry serializers;
+    RegisterEngineSceneSerializers(serializers);
+    const std::size_t count = serializers.Entries().size();
     EXPECT_EQ(count, std::tuple_size_v<EngineSceneComponents>);
 
-    InitSceneSerializer();
-    EXPECT_EQ(GetComponentSerializerEntries().size(), count)
-        << "Re-running InitSceneSerializer must not duplicate entries";
+    RegisterEngineSceneSerializers(serializers);
+    EXPECT_EQ(serializers.Entries().size(), count)
+        << "Re-registering the engine manifest must not duplicate entries";
 }

--- a/test/runtime/GameModuleLoaderTests.cpp
+++ b/test/runtime/GameModuleLoaderTests.cpp
@@ -130,23 +130,23 @@ TEST(GameModuleLoader, RefusesAbiMismatch)
 // call), loaded into a stock registry that links no editor symbols.
 TEST(GameModuleLoader, ModuleComponentRoundTripsThroughSceneJson)
 {
-    // Use the engine's default registry — the one SaveSceneJson/LoadSceneJson read.
-    ClearComponentSerializers();
-    InitSceneSerializer();
+    // A host registry, seeded exactly the way Engine::Run seeds its own.
+    ComponentSerializerRegistry serializers;
+    RegisterEngineSceneSerializers(serializers);
 
     GameModuleLoader loader;
     std::string error;
     LoadedModule m = loader.Load(TEST_GAME_MODULE_PATH, &error);
     ASSERT_TRUE(m.IsValid()) << error;
-    m.Instance->OnRegisterComponents(DefaultComponentSerializerRegistry());
+    m.Instance->OnRegisterComponents(serializers);
 
-    IComponentSerializer* gs = DefaultComponentSerializerRegistry().FindByJsonKey("spike.grapple_hook");
+    IComponentSerializer* gs = serializers.FindByJsonKey("spike.grapple_hook");
     ASSERT_NE(gs, nullptr);
 
     // Author an entity carrying the game component (type-erased, via its Load).
     Registry source;
-    for (const auto& s : GetComponentSerializerEntries())
-        s->RegisterStorage(source);
+    for (const auto& entry : serializers.Entries())
+        entry->RegisterStorage(source);
 
     LoggingProvider logging;
     SceneSerializationContext sctx{ logging };
@@ -157,10 +157,10 @@ TEST(GameModuleLoader, ModuleComponentRoundTripsThroughSceneJson)
     ASSERT_TRUE(gs->Load(in, e, source, sctx));
 
     // Save the whole scene, then load into a fresh registry (the runtime/editor path).
-    const JsonValue scene = SaveSceneJson(source);
+    const JsonValue scene = SaveSceneJson(source, serializers);
     Registry loaded;
     SceneLoadError loadError;
-    ASSERT_TRUE(LoadSceneJson(scene, loaded, &loadError)) << loadError.Message;
+    ASSERT_TRUE(LoadSceneJson(scene, loaded, serializers, &loadError)) << loadError.Message;
 
     // The game component came back, by its module-stable identity.
     const ComponentId id = loaded.Components.GetComponentIdByType(gs->TypeId());
@@ -181,7 +181,7 @@ TEST(GameModuleLoader, ModuleComponentRoundTripsThroughSceneJson)
     }
     EXPECT_TRUE(found);
 
-    m.Instance->OnUnregisterComponents(DefaultComponentSerializerRegistry());
+    // Entries the module allocated must go before the module is unmapped.
+    m.Instance->OnUnregisterComponents(serializers);
     loader.Unload(m);
-    ClearComponentSerializers();
 }

--- a/test/runtime/SceneFieldCodecTests.cpp
+++ b/test/runtime/SceneFieldCodecTests.cpp
@@ -80,8 +80,8 @@ namespace
 
 TEST(SceneFieldCodec, GenericComponentSerializerWritesTypedMaterialHandleAsPathString)
 {
-    ClearComponentSerializers();
-    RegisterComponent<SceneCodecMaterialComponent>();
+    ComponentSerializerRegistry serializers;
+    RegisterComponent<SceneCodecMaterialComponent>(serializers);
 
     LoggingProvider logging;
     AssetRegistry assetRegistry(logging);
@@ -97,7 +97,7 @@ TEST(SceneFieldCodec, GenericComponentSerializerWritesTypedMaterialHandleAsPathS
     registry.Components.AddComponent(entity, SceneCodecMaterialComponent{ .Material = material });
 
     SceneSerializationContext context(logging, &assets);
-    JsonValue json = SaveSceneJson(registry, context);
+    JsonValue json = SaveSceneJson(registry, serializers, context);
 
     const JsonValue* entities = json.Find("entities");
     ASSERT_NE(entities, nullptr);

--- a/test/runtime/SceneSerializationGoldenTests.cpp
+++ b/test/runtime/SceneSerializationGoldenTests.cpp
@@ -1,0 +1,96 @@
+// Byte-level golden for scene serialization.
+//
+// Round-trip tests prove a scene reads back as what it was; they do not prove
+// the bytes on disk are unchanged. This one pins the exact JSON text and binary
+// payload a fixed scene produces, so a change to serializer ownership,
+// registration order, or field emission that would silently rewrite every
+// cooked scene fails here first.
+//
+// A deliberate format change updates these constants; anything else that moves
+// them is a defect. The scene below carries several component families on
+// purpose, including a parented entity, so chunk ordering is covered.
+
+#include <gtest/gtest.h>
+
+#include <core/hash/ContentHash.h>
+#include <core/json/JsonStringify.h>
+#include <core/serialization/BinaryWriter.h>
+#include <math/geometry/3d/Transform3d.h>
+#include <render/Camera.h>
+#include <render/PointLightComponent.h>
+#include <render/StaticMeshComponent.h>
+#include <world/ComponentManifest.h>
+#include <world/registry/Registry.h>
+#include <world/serialization/SceneSerializer.h>
+#include <world/transform/TransformComponents.h>
+
+#include <cstddef>
+#include <span>
+#include <sstream>
+#include <string>
+
+namespace
+{
+    Registry MakeGoldenScene()
+    {
+        Registry registry;
+        ForEachSceneComponent([&]<typename T>(ComponentTag<T>)
+        {
+            registry.Components.RegisterComponent<T>();
+        });
+        registry.Components.RegisterComponent<WorldTransform>();
+        registry.Components.RegisterComponent<Parent>();
+
+        const EntityId root = registry.Components.CreateEntity();
+        registry.Components.AddComponent(root, LocalTransform{
+            Transform3f(Vec3d(1.0f, 2.0f, 3.0f), Quatf::Identity(), Vec3d::One()) });
+        registry.Components.AddComponent(root, PointLightComponent{});
+
+        const EntityId child = registry.Components.CreateEntity();
+        registry.Components.AddComponent(child, LocalTransform{
+            Transform3f(Vec3d(-4.0f, 0.5f, 7.25f), Quatf::Identity(),
+                        Vec3d(2.0f, 2.0f, 2.0f)) });
+        registry.Components.AddComponent(child, Parent{ root });
+        registry.Components.AddComponent(child, CameraComponent{});
+
+        return registry;
+    }
+
+    uint64_t HashOfString(const std::string& text)
+    {
+        return HashBytes64(std::string_view{ text });
+    }
+
+    ComponentSerializerRegistry EngineSerializers()
+    {
+        ComponentSerializerRegistry serializers;
+        RegisterEngineSceneSerializers(serializers);
+        return serializers;
+    }
+} // namespace
+
+TEST(SceneSerializationGolden, JsonTextIsUnchanged)
+{
+    const ComponentSerializerRegistry serializers = EngineSerializers();
+    Registry registry = MakeGoldenScene();
+    const std::string json =
+        JsonStringify(SaveSceneJson(registry, serializers), /*pretty*/ true);
+
+    EXPECT_EQ(HashOfString(json), 0xf0f7a73e5baf9829ULL)
+        << "scene JSON changed; if that was intended, update the constant.\n" << json;
+}
+
+TEST(SceneSerializationGolden, BinaryPayloadIsUnchanged)
+{
+    const ComponentSerializerRegistry serializers = EngineSerializers();
+    Registry registry = MakeGoldenScene();
+    std::stringstream stream(std::ios::in | std::ios::out | std::ios::binary);
+    BinaryWriter writer(stream);
+    SceneSaveError error;
+    ASSERT_TRUE(SaveSceneBinary(registry, serializers, writer, &error)) << error.Message;
+
+    const std::string bytes = stream.str();
+    EXPECT_EQ(HashOfString(bytes), 0xbd2afea637eb27adULL)
+        << "scene binary changed; if that was intended, update the constant."
+        << " size=" << bytes.size();
+}

--- a/test/runtime/SceneSerializerFailureTests.cpp
+++ b/test/runtime/SceneSerializerFailureTests.cpp
@@ -34,16 +34,17 @@ namespace
         return registry;
     }
 
-    void ResetSceneSerializers()
+    ComponentSerializerRegistry MakeSerializers()
     {
-        ClearComponentSerializers();
-        InitSceneSerializer();
+        ComponentSerializerRegistry serializers;
+        RegisterEngineSceneSerializers(serializers);
+        return serializers;
     }
 }
 
 TEST(SceneSerializerFailure, JsonLoadRollsBackEntitiesAndComponents)
 {
-    ResetSceneSerializers();
+    const ComponentSerializerRegistry serializers = MakeSerializers();
     auto parsed = JsonParse(R"({
         "version": 1,
         "entities": [
@@ -67,7 +68,7 @@ TEST(SceneSerializerFailure, JsonLoadRollsBackEntitiesAndComponents)
 
     Registry loaded = MakeFailureRegistry();
     SceneLoadError error;
-    EXPECT_FALSE(LoadSceneJson(*parsed, loaded, &error));
+    EXPECT_FALSE(LoadSceneJson(*parsed, loaded, serializers, &error));
 
     EXPECT_EQ(loaded.Components.EntityCount(), 0u);
     EXPECT_EQ(loaded.Components.CountComponents<LocalTransform>(), 0u);
@@ -75,7 +76,7 @@ TEST(SceneSerializerFailure, JsonLoadRollsBackEntitiesAndComponents)
 
 TEST(SceneSerializerFailure, BinaryLoadRollsBackCreatedEntities)
 {
-    ResetSceneSerializers();
+    const ComponentSerializerRegistry serializers = MakeSerializers();
     auto stream = MakeBinaryStream();
     BinaryWriter writer(stream);
 
@@ -102,7 +103,7 @@ TEST(SceneSerializerFailure, BinaryLoadRollsBackCreatedEntities)
     BinaryReader reader(stream);
     Registry loaded = MakeFailureRegistry();
     SceneLoadError error;
-    EXPECT_FALSE(LoadSceneBinary(reader, loaded, &error));
+    EXPECT_FALSE(LoadSceneBinary(reader, loaded, serializers, &error));
 
     EXPECT_EQ(loaded.Components.EntityCount(), 0u);
     EXPECT_EQ(loaded.Components.CountComponents<CameraComponent>(), 0u);
@@ -110,7 +111,7 @@ TEST(SceneSerializerFailure, BinaryLoadRollsBackCreatedEntities)
 
 TEST(SceneSerializerFailure, BinarySkipsUnknownChunks)
 {
-    ResetSceneSerializers();
+    const ComponentSerializerRegistry serializers = MakeSerializers();
     auto stream = MakeBinaryStream();
     BinaryWriter writer(stream);
 
@@ -144,7 +145,7 @@ TEST(SceneSerializerFailure, BinarySkipsUnknownChunks)
     stream.seekg(0);
     BinaryReader reader(stream);
     Registry loaded;
-    ASSERT_TRUE(LoadSceneBinary(reader, loaded));
+    ASSERT_TRUE(LoadSceneBinary(reader, loaded, serializers));
 
     EXPECT_EQ(loaded.Components.EntityCount(), 1u);
     EXPECT_EQ(loaded.Components.CountComponents<CameraComponent>(), 1u);
@@ -152,20 +153,20 @@ TEST(SceneSerializerFailure, BinarySkipsUnknownChunks)
 
 TEST(SceneSerializerFailure, HandlesEmptyRegistry)
 {
-    ResetSceneSerializers();
+    const ComponentSerializerRegistry serializers = MakeSerializers();
     Registry source;
     auto stream = MakeBinaryStream();
     BinaryWriter writer(stream);
-    ASSERT_TRUE(SaveSceneBinary(source, writer));
+    ASSERT_TRUE(SaveSceneBinary(source, serializers, writer));
 
     stream.seekg(0);
     BinaryReader reader(stream);
     Registry loaded;
-    ASSERT_TRUE(LoadSceneBinary(reader, loaded));
+    ASSERT_TRUE(LoadSceneBinary(reader, loaded, serializers));
     EXPECT_EQ(loaded.Components.EntityCount(), 0u);
 
-    JsonValue json = SaveSceneJson(source);
+    JsonValue json = SaveSceneJson(source, serializers);
     Registry jsonLoaded;
-    ASSERT_TRUE(LoadSceneJson(json, jsonLoaded));
+    ASSERT_TRUE(LoadSceneJson(json, jsonLoaded, serializers));
     EXPECT_EQ(jsonLoaded.Components.EntityCount(), 0u);
 }

--- a/test/runtime/SceneSerializerTests.cpp
+++ b/test/runtime/SceneSerializerTests.cpp
@@ -46,10 +46,11 @@ namespace
         return registry;
     }
 
-    void ResetSceneSerializers()
+    ComponentSerializerRegistry MakeSerializers()
     {
-        ClearComponentSerializers();
-        InitSceneSerializer();
+        ComponentSerializerRegistry serializers;
+        RegisterEngineSceneSerializers(serializers);
+        return serializers;
     }
 
     Transform3f MakeTransform(float x, float y, float z)
@@ -73,7 +74,7 @@ namespace
 }
 TEST(SceneSerializer, BinaryRoundTripsCleanRegistry)
 {
-    ResetSceneSerializers();
+    const ComponentSerializerRegistry serializers = MakeSerializers();
     Registry source = MakeSceneRegistry();
 
     EntityId parent = source.Components.CreateEntity();
@@ -94,13 +95,13 @@ TEST(SceneSerializer, BinaryRoundTripsCleanRegistry)
 
     auto stream = MakeBinaryStream();
     BinaryWriter writer(stream);
-    ASSERT_TRUE(SaveSceneBinary(source, writer));
+    ASSERT_TRUE(SaveSceneBinary(source, serializers, writer));
 
     stream.seekg(0);
     BinaryReader reader(stream);
     Registry loaded;
     SceneLoadError error;
-    ASSERT_TRUE(LoadSceneBinary(reader, loaded, &error)) << error.Message;
+    ASSERT_TRUE(LoadSceneBinary(reader, loaded, serializers, &error)) << error.Message;
 
     EXPECT_EQ(loaded.Components.EntityCount(), 2u);
 
@@ -129,14 +130,14 @@ TEST(SceneSerializer, BinaryRoundTripsCleanRegistry)
 
 TEST(SceneSerializer, BinaryLoadIsAdditiveAndRemapsEntityIndices)
 {
-    ResetSceneSerializers();
+    const ComponentSerializerRegistry serializers = MakeSerializers();
     Registry source = MakeSceneRegistry();
     EntityId sourceEntity = source.Components.CreateEntity();
     AddTransform(source, sourceEntity, MakeTransform(8.0f, 0.0f, 0.0f));
 
     auto stream = MakeBinaryStream();
     BinaryWriter writer(stream);
-    ASSERT_TRUE(SaveSceneBinary(source, writer));
+    ASSERT_TRUE(SaveSceneBinary(source, serializers, writer));
 
     Registry loaded = MakeSceneRegistry();
     EntityId preexisting = loaded.Components.CreateEntity();
@@ -144,7 +145,7 @@ TEST(SceneSerializer, BinaryLoadIsAdditiveAndRemapsEntityIndices)
 
     stream.seekg(0);
     BinaryReader reader(stream);
-    ASSERT_TRUE(LoadSceneBinary(reader, loaded));
+    ASSERT_TRUE(LoadSceneBinary(reader, loaded, serializers));
 
     EXPECT_EQ(loaded.Components.EntityCount(), 2u);
     ASSERT_EQ(loaded.Components.CountComponents<LocalTransform>(), 2u);
@@ -164,19 +165,19 @@ TEST(SceneSerializer, BinaryLoadIsAdditiveAndRemapsEntityIndices)
 
 TEST(SceneSerializer, JsonRoundTripsThroughStringifyAndParser)
 {
-    ResetSceneSerializers();
+    const ComponentSerializerRegistry serializers = MakeSerializers();
     Registry source = MakeSceneRegistry();
     EntityId entity = source.Components.CreateEntity();
     AddTransform(source, entity, MakeTransform(2.0f, 3.0f, 4.0f));
     source.Components.AddComponent(entity, CameraComponent{});
 
-    JsonValue json = SaveSceneJson(source);
+    JsonValue json = SaveSceneJson(source, serializers);
     std::string text = JsonStringify(json, true);
     auto parsed = JsonParse(text);
     ASSERT_TRUE(parsed.has_value());
 
     Registry loaded;
-    ASSERT_TRUE(LoadSceneJson(*parsed, loaded));
+    ASSERT_TRUE(LoadSceneJson(*parsed, loaded, serializers));
 
     ASSERT_EQ(loaded.Components.EntityCount(), 1u);
     ASSERT_EQ(loaded.Components.CountComponents<LocalTransform>(), 1u);
@@ -192,7 +193,7 @@ TEST(SceneSerializer, JsonRoundTripsThroughStringifyAndParser)
 
 TEST(SceneSerializer, PointLightRoundTripsThroughJson)
 {
-    ResetSceneSerializers();
+    const ComponentSerializerRegistry serializers = MakeSerializers();
     Registry source = MakeSceneRegistry();
     EntityId entity = source.Components.CreateEntity();
     AddTransform(source, entity, MakeTransform(0.0f, 0.0f, 0.0f));
@@ -204,12 +205,12 @@ TEST(SceneSerializer, PointLightRoundTripsThroughJson)
     light.Enabled = false;
     source.Components.AddComponent(entity, light);
 
-    JsonValue json = SaveSceneJson(source);
+    JsonValue json = SaveSceneJson(source, serializers);
     auto parsed = JsonParse(JsonStringify(json, true));
     ASSERT_TRUE(parsed.has_value());
 
     Registry loaded;
-    ASSERT_TRUE(LoadSceneJson(*parsed, loaded));
+    ASSERT_TRUE(LoadSceneJson(*parsed, loaded, serializers));
 
     ASSERT_EQ(loaded.Components.CountComponents<PointLightComponent>(), 1u);
     const PointLightComponent* out = nullptr;
@@ -228,7 +229,7 @@ TEST(SceneSerializer, PointLightRoundTripsThroughJson)
 
 TEST(SceneSerializer, LoadsHandAuthoredJson)
 {
-    ResetSceneSerializers();
+    const ComponentSerializerRegistry serializers = MakeSerializers();
     auto parsed = JsonParse(R"({
         "version": 1,
         "entities": [
@@ -269,7 +270,7 @@ TEST(SceneSerializer, LoadsHandAuthoredJson)
     ASSERT_TRUE(parsed.has_value());
 
     Registry loaded;
-    ASSERT_TRUE(LoadSceneJson(*parsed, loaded));
+    ASSERT_TRUE(LoadSceneJson(*parsed, loaded, serializers));
 
     EXPECT_EQ(loaded.Components.EntityCount(), 2u);
     EXPECT_EQ(loaded.Components.CountComponents<LocalTransform>(), 2u);
@@ -282,7 +283,7 @@ TEST(SceneSerializer, LoadsLightRecordsCookedBeforeShadowFieldsExisted)
     // Scenes cooked before the shadow and bake fields existed carry only the
     // original light keys; the schema defaults must fill the rest instead of
     // rejecting the component.
-    ResetSceneSerializers();
+    const ComponentSerializerRegistry serializers = MakeSerializers();
     auto parsed = JsonParse(R"({
         "version": 1,
         "entities": [
@@ -327,7 +328,7 @@ TEST(SceneSerializer, LoadsLightRecordsCookedBeforeShadowFieldsExisted)
     ASSERT_TRUE(parsed.has_value());
 
     Registry loaded;
-    ASSERT_TRUE(LoadSceneJson(*parsed, loaded));
+    ASSERT_TRUE(LoadSceneJson(*parsed, loaded, serializers));
 
     ASSERT_EQ(loaded.Components.CountComponents<PointLightComponent>(), 1u);
     ASSERT_EQ(loaded.Components.CountComponents<SpotLightComponent>(), 1u);
@@ -353,10 +354,10 @@ TEST(SceneSerializer, LoadsLightRecordsCookedBeforeShadowFieldsExisted)
 
 TEST(SceneSerializer, RegistersStaticMeshThroughGenericSerializer)
 {
-    ResetSceneSerializers();
+    const ComponentSerializerRegistry serializers = MakeSerializers();
 
     bool found = false;
-    for (const auto& entry : GetComponentSerializerEntries())
+    for (const auto& entry : serializers.Entries())
         found = found || entry->JsonKey() == "StaticMesh";
 
     EXPECT_TRUE(found);


### PR DESCRIPTION
Which components a scene can carry is a property of the host, not of the process. The runtime's set is the engine manifest plus whatever the loaded game module registers; the editor's adds authoring-only components that never reach a cooked scene; a test wants only what it declared. All three shared one process-global registry, so those vocabularies could not be held apart and a test could be perturbed by whatever ran before it.

Engine now owns a ComponentSerializerRegistry and seeds it with the engine manifest before calling Game::OnRegisterComponents, so a game adds to a known set instead of being responsible for seeding it -- CubeDemo, SceneViewer, and the template each called InitSceneSerializer themselves to do that. Zone loading, scene save/load, and the examples read engine.SceneSerializers(). The scene functions take the registry as a parameter, which is what makes the ownership visible at the call site.

DefaultComponentSerializerRegistry, RegisterComponentSerializer, ClearComponentSerializers, InitSceneSerializer, and GetComponentSerializerEntries are gone. RegisterComponent<T> now takes the registry and keeps the fail-loud assert on a genuine identity collision, which is what the collision death tests exercise.

The zone layer needed no change: ZonePackageSceneLoader, ZonePackageImporter, and AsyncZoneLoader already took an explicit registry, and the zone tests already built local ones. Only their callers were reaching for the global.

RegisterGameplayTagSerializer and RegisterAttributeSerializer took the registry too. Both are unwired today -- nothing calls them -- but they are anchored to gameplay-tag and attribute persistence, so they keep their capability rather than being deleted here.

Kyusu owns its registry through EditorSceneSerializers(). That is still an accessor rather than a reference threaded into each consumer: the inspector, hierarchy panel, visual renderer, and entity recipe read it without holding a document, so giving them explicit references is a change to their construction and is not in this pass. The engine-level global is gone either way.

Scene bytes are unchanged. SceneSerializationGoldenTests pins the exact JSON text and binary payload of a fixed scene; the constants were captured before this change and still pass after it.

SENCHA_GAME_ABI_VERSION goes to 7: a module that reached for the default registry no longer links. Game::OnRegisterComponents itself is unchanged, so the module ABI tier 2 work (POD descriptors over a C ABI) does not have to rewrite these call sites when it lands.