### PR TITLE
Framerate independent simulation

### DIFF
--- a/docs/action-adventure-core-runtime.md
+++ b/docs/action-adventure-core-runtime.md
@@ -277,7 +277,10 @@ Candidate transition kinds:
 
 Each transition can declare:
 
-- interpolation history reset policy
+- interpolation history reset policy (the reset half exists: a temporal
+  discontinuity snaps every `WorldTransformHistory`, and
+  `RequestTransformHistorySnap` snaps one entity; what a transition would add
+  is declaring which of the two it wants)
 - camera history reset or blend policy
 - async drain tolerance for this frame range
 - required pinned zones

--- a/docs/core-systems-map.md
+++ b/docs/core-systems-map.md
@@ -118,17 +118,46 @@ compile time, not by runtime type lookup.
 | `ResolveLifecycle` | Apply window resize/minimize/restore to `RuntimeFrameLoop`. |
 | `RebuildGraphics` | Recreate swapchain/frame/render resources when needed. |
 | `DrainAsyncTasks` | Run ready async commits on the owner thread, within `AsyncCommitBudgetMs`. Zone attaches and asset publishes happen here. |
-| `ScheduleTicks` | Build `FrameZoneView` from zone participation and decide whether fixed simulation runs this frame. |
+| `ScheduleTicks` | Build `FrameZoneView` from zone participation and convert elapsed wall time into this frame's fixed-tick budget. |
 | `Simulate` | Run fixed-phase systems, physics systems, transform propagation, then post-fixed systems. |
 | `Update` | Run presentation-rate systems and then audio systems. |
 | `ExtractRenderPacket` | Propagate visible transforms, extract camera and render queue data. |
 | `Render` | Submit the current packet through `Renderer`. |
 | `EndFrame` | Run cleanup/end systems, record lifecycle timing, end runtime frame, flip packet buffers, pace. |
 
-Current simulation scheduling is conservative: lifecycle-only frames run zero
-fixed ticks, normal frames currently schedule one fixed tick. Fixed systems
-consume `FixedSimTime`; `FrameUpdateContext::WallDeltaSeconds` is for
-presentation-rate behavior only, such as camera look smoothing or UI.
+Simulation runs on a fixed timestep decoupled from presentation.
+`RuntimeFrameLoop` accumulates each frame's elapsed wall time (scaled by
+`SetSimulationTimescale`) through `FixedStepScheduler` and emits however many
+whole ticks that time now covers: zero on a short frame, several on a long one.
+Simulated time therefore tracks wall time at any frame rate, and every tick is
+still exactly `FixedSimTime::DeltaSeconds` long, so per-tick behavior stays
+deterministic. The sub-tick remainder carries to the next frame and is
+published as `PresentationTime::Alpha`.
+
+Two bounds keep a stall from cascading. `MaxFrameWallDeltaSeconds` caps the
+elapsed time one frame may contribute, and `MaxFixedTicksPerFrame` caps the
+ticks it may run; whole ticks past the cap are dropped rather than deferred, so
+simulated time falls behind wall time instead of the next frame inheriting an
+even larger debt. Dropped ticks appear as `RuntimeFrameSnapshot::TicksDropped`
+and in the timing history. Lifecycle-only frames accumulate nothing, and a
+temporal discontinuity clears the residual so the new state does not replay
+time that belonged to the old one.
+
+Fixed systems consume `FixedSimTime`; `FrameUpdateContext::WallDeltaSeconds` is
+for presentation-rate behavior only, such as camera look smoothing or UI. A
+frame runs its fixed ticks before presentation-rate systems, so a
+presentation-rate system must not write simulation state: with a variable tick
+count its writes land outside the simulation's own cadence.
+
+Input edges follow from the same rule. They are drained after the first fixed
+tick of a frame, so ticks after the first see held state only, and a frame that
+runs no tick keeps them for the next one rather than dropping the press.
+Anything that reads an edge outside that drain — an engine-level window or
+pause key in `PumpPlatform` — must consume it with `InputFrame::ConsumeKeyPressed`,
+or it will act on the same press again on the next zero-tick frame.
+Per-frame accumulated values such as `InputFrame::MouseDeltaX` are
+presentation-rate inputs: consuming one per fixed tick would apply it several
+times on a catch-up frame and not at all on a short one.
 
 Lifecycle-only frames are real frames. They still pump platform, drain async
 tasks, and run end-frame bookkeeping, but skip extraction/render when the

--- a/docs/core-systems-map.md
+++ b/docs/core-systems-map.md
@@ -149,6 +149,16 @@ frame runs its fixed ticks before presentation-rate systems, so a
 presentation-rate system must not write simulation state: with a variable tick
 count its writes land outside the simulation's own cadence.
 
+Because a frame renders between ticks, an entity that opts into
+`WorldTransformHistory` keeps its last two simulated poses and renders the
+blend at `PresentationTime::Alpha`. Mesh and shadow-caster extraction and the
+follow camera all read that blended pose, so they agree about where a thing is;
+entities without the component render their live `WorldTransform` unchanged.
+The history snaps rather than blends where there is no meaningful earlier pose:
+a spawn, a streamed-in entity, a teleport (`RequestTransformHistorySnap`, which
+`CharacterMoverPool::SetPosition` calls), or a frame-wide temporal
+discontinuity.
+
 Input edges follow from the same rule. They are drained after the first fixed
 tick of a frame, so ticks after the first see held state only, and a frame that
 runs no tick keeps them for the next one rather than dropping the press.

--- a/docs/renderer/frame.md
+++ b/docs/renderer/frame.md
@@ -2,15 +2,15 @@
 
 ## Phase placement
 
-The renderer occupies two of the ten `FramePhase` slots
+The renderer occupies two of the eleven `FramePhase` slots
 (`engine/include/runtime/FrameDriver.h`). Registration for both lives in
 `engine/src/app/EngineFramePhases.cpp`.
 
 | Phase | Renderer work |
 |---|---|
 | `RebuildGraphics` (2) | `VulkanSwapchainService::Recreate`, `VulkanFrameService::ResetAfterSwapchainRecreate`, `Renderer::NotifySwapchainRecreated` |
-| `ExtractRenderPacket` (7) | latch the profile mode, propagate visible transforms, run every registered extract system (`DefaultRenderPipeline::ExtractRender`) |
-| `Render` (8) | `Renderer::DrawFrameScheduled`, then push the timing sample and the stats frame |
+| `ExtractRenderPacket` (8) | latch the profile mode, propagate visible transforms, run every registered extract system (`DefaultRenderPipeline::ExtractRender`) |
+| `Render` (9) | `Renderer::DrawFrameScheduled`, then push the timing sample and the stats frame |
 
 Lifecycle-only frames (resize, minimize, swapchain rebuild) skip extract and
 render but still pump platform events and stamp telemetry.

--- a/engine/include/app/GameContexts.h
+++ b/engine/include/app/GameContexts.h
@@ -131,6 +131,10 @@ struct AudioContext
     EngineConfig& Config;
     RuntimeFrameLoop& Runtime;
     InputFrame& Input;
+    // Audio runs once per rendered frame, so anything here that ages with the
+    // player's experience rather than with simulation -- subtitle dwell time,
+    // for instance -- uses this rather than the tick delta.
+    double WallDeltaSeconds = 0.0;
     PresentationTime Presentation;
     World& Entities;
     const StoragePartitionSet& Partitions;

--- a/engine/include/core/config/RuntimeConfig.h
+++ b/engine/include/core/config/RuntimeConfig.h
@@ -11,6 +11,16 @@ struct EngineRuntimeConfig
     double TargetFps = 0.0;
     double ResizeSettleSeconds = 0.10;
 
+    // Catch-up bounds for the fixed-tick accumulator. A frame that spans a long
+    // stall (breakpoint, window drag, disk hitch) would otherwise owe more
+    // simulation than it can afford, and running it all makes the next frame
+    // later still. MaxFixedTicksPerFrame caps the ticks one frame may run and
+    // MaxFrameWallDeltaSeconds caps the elapsed time it may claim; the excess
+    // is dropped, so simulated time falls behind wall time instead of
+    // spiralling. Dropped ticks are reported per frame.
+    int MaxFixedTicksPerFrame = 4;
+    double MaxFrameWallDeltaSeconds = 0.25;
+
     // Wall-time budget for async-task commits per frame (the
     // FramePhase::DrainAsyncTasks drain). 0.0 = unbudgeted, matching the
     // TargetFps convention. The first ready commit always runs regardless,

--- a/engine/include/input/InputFrame.h
+++ b/engine/include/input/InputFrame.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -69,6 +70,19 @@ struct InputFrame
         KeysReleased.clear();
         MouseButtonsPressed.clear();
         MouseButtonsReleased.clear();
+    }
+
+    // Take a key press edge. Bindings that run outside the fixed-tick drain,
+    // such as engine-level window and pause keys in PumpPlatform, must consume
+    // the edge they act on: edges survive frames that run no fixed tick, so a
+    // handler that only tests for the press would fire again next frame.
+    bool ConsumeKeyPressed(uint32_t scancode)
+    {
+        const auto first = std::remove(KeysPressed.begin(), KeysPressed.end(), scancode);
+        if (first == KeysPressed.end())
+            return false;
+        KeysPressed.erase(first, KeysPressed.end());
+        return true;
     }
 
     [[nodiscard]] bool IsKeyDown(uint32_t scancode) const

--- a/engine/include/math/Quat.h
+++ b/engine/include/math/Quat.h
@@ -279,6 +279,46 @@ struct Quat
 		}
 		return q.Normalized();
 	}
+
+	// Shortest-path spherical interpolation. q and -q are the same orientation,
+	// so a negative dot is flipped first; otherwise the blend would travel the
+	// long way around. Near-parallel inputs fall back to a normalized linear
+	// blend, where the slerp coefficients lose precision and the two agree.
+	static Quat Slerp(const Quat& from, const Quat& to, T t) requires std::floating_point<T>
+	{
+		Quat target = to;
+		T cosTheta = from.Dot(to);
+		if (cosTheta < T{0})
+		{
+			target = to * T{-1};
+			cosTheta = -cosTheta;
+		}
+
+		constexpr T kParallelThreshold = T{0.9995};
+		if (cosTheta > kParallelThreshold)
+		{
+			const Quat blended{
+				from.X + (target.X - from.X) * t,
+				from.Y + (target.Y - from.Y) * t,
+				from.Z + (target.Z - from.Z) * t,
+				from.W + (target.W - from.W) * t,
+			};
+			return blended.Normalized();
+		}
+
+		if (cosTheta > T{1}) cosTheta = T{1};
+		const T theta = std::acos(cosTheta);
+		const T sinTheta = std::sin(theta);
+		const T fromScale = std::sin((T{1} - t) * theta) / sinTheta;
+		const T toScale = std::sin(t * theta) / sinTheta;
+
+		return Quat{
+			from.X * fromScale + target.X * toScale,
+			from.Y * fromScale + target.Y * toScale,
+			from.Z * fromScale + target.Z * toScale,
+			from.W * fromScale + target.W * toScale,
+		}.Normalized();
+	}
 };
 
 // -- Free function: scalar * quat -------------------------------------------

--- a/engine/include/math/geometry/3d/Transform3d.h
+++ b/engine/include/math/geometry/3d/Transform3d.h
@@ -147,6 +147,19 @@ struct Transform3d
 		return Transform3d{};
 	}
 
+	// Component-wise blend: linear for position and scale, shortest-path
+	// spherical for rotation. Interpolating the TRS components rather than the
+	// matrices is what keeps the result a well-formed transform.
+	static Transform3d Interpolate(const Transform3d& from, const Transform3d& to, T t)
+		requires std::floating_point<T>
+	{
+		return Transform3d{
+			Vec<3, T>::Lerp(from.Position, to.Position, t),
+			Quat<T>::Slerp(from.Rotation, to.Rotation, t),
+			Vec<3, T>::Lerp(from.Scale, to.Scale, t),
+		};
+	}
+
 private:
 	static constexpr Vec<3, T> ComponentScale(const Vec<3, T>& a, const Vec<3, T>& b)
 	{

--- a/engine/include/render/RenderExtractionSystem.h
+++ b/engine/include/render/RenderExtractionSystem.h
@@ -11,6 +11,7 @@
 #include <render/TextureHandle.h>
 #include <render/static_mesh/StaticMeshCache.h>
 #include <world/transform/TransformComponents.h>
+#include <world/transform/TransformHistory.h>
 
 #include <cstdint>
 #include <optional>
@@ -77,6 +78,10 @@ public:
     // `textures` resolves each resident zone's ZoneLightmapComponent to the
     // bindless atlas index stamped on that zone's items; null leaves items
     // without a lightmap.
+    // `interpolationAlpha` is how far this frame sits past the last completed
+    // simulation tick (PresentationTime::Alpha). Entities carrying
+    // WorldTransformHistory render the blend at that point; everything else
+    // renders its live WorldTransform.
     void Extract(
         const World& world,
         const StoragePartitionSet& partitions,
@@ -85,11 +90,16 @@ public:
         const MaterialSetCache& materialSets,
         const CameraRenderData& camera,
         RenderQueue& queue,
-        const TextureCache* textures = nullptr);
+        const TextureCache* textures = nullptr,
+        double interpolationAlpha = 1.0);
 
 private:
     const World* LastWorld = nullptr;
-    std::optional<Query<Read<WorldTransform>, Read<StaticMeshComponent>>> CachedQuery;
+    std::optional<Query<Read<WorldTransform>,
+                        Read<StaticMeshComponent>,
+                        Without<WorldTransformHistory>>> CachedQuery;
+    std::optional<Query<Read<WorldTransformHistory>,
+                        Read<StaticMeshComponent>>> CachedInterpolatedQuery;
     // Retained across frames so a steady-state extract allocates nothing; both
     // are rebuilt from scratch each call.
     std::vector<ZoneLightmapBinding> LightmapBindings;

--- a/engine/include/render/ShadowCasterExtractionSystem.h
+++ b/engine/include/render/ShadowCasterExtractionSystem.h
@@ -11,6 +11,7 @@
 #include <render/StaticMeshComponent.h>
 #include <render/static_mesh/StaticMeshCache.h>
 #include <world/transform/TransformComponents.h>
+#include <world/transform/TransformHistory.h>
 
 #include <cstdint>
 #include <optional>
@@ -68,9 +69,14 @@ public:
                  const MaterialCache& materials,
                  const MaterialSetCache& materialSets,
                  ShadowCasterSet& casters,
-                 bool emitRecords = true);
+                 bool emitRecords = true,
+                 double interpolationAlpha = 1.0);
 
 private:
     const World* LastWorld = nullptr;
-    std::optional<Query<Read<WorldTransform>, Read<StaticMeshComponent>>> CachedQuery;
+    std::optional<Query<Read<WorldTransform>,
+                        Read<StaticMeshComponent>,
+                        Without<WorldTransformHistory>>> CachedQuery;
+    std::optional<Query<Read<WorldTransformHistory>,
+                        Read<StaticMeshComponent>>> CachedInterpolatedQuery;
 };

--- a/engine/include/runtime/FrameDriver.h
+++ b/engine/include/runtime/FrameDriver.h
@@ -72,8 +72,9 @@ public:
 private:
     void InvokePhase(FramePhase phase, PhaseContext& ctx);
 
-    // Input edges are consumed by the first fixed tick of a frame, or dropped
-    // at the end of a frame that ran none, so a press is never seen twice.
+    // Input edges are consumed by the first fixed tick of a frame. A frame that
+    // runs no tick leaves them intact so the press reaches the next tick
+    // instead of being lost; ticks after the first see held state only.
     void DrainInputEdgesForFirstTick();
 
     RuntimeFrameLoop& Runtime;

--- a/engine/include/runtime/RuntimeFrameLoop.h
+++ b/engine/include/runtime/RuntimeFrameLoop.h
@@ -2,6 +2,7 @@
 
 #include <platform/WindowTypes.h>
 #include <runtime/FrameDiscontinuityBus.h>
+#include <time/FixedStepScheduler.h>
 #include <time/FrameClock.h>
 #include <time/SimClock.h>
 #include <time/TimeService.h>
@@ -71,6 +72,10 @@ struct RuntimeFrameSnapshot
     TickBudget Budget;
     double TickDtSeconds = FixedSimulationLoop::DefaultFixedDt;
     uint32_t FixedTicks = 0;
+
+    // Whole ticks this frame's elapsed time covered but the per-frame cap
+    // refused to run. Non-zero means simulated time fell behind wall time.
+    uint32_t TicksDropped = 0;
     RuntimeFrameState State = RuntimeFrameState::Running;
     TemporalDiscontinuityReason DiscontinuityReason = TemporalDiscontinuityReason::None;
     RuntimeFrameEventFlags Events = RuntimeFrameEventFlags::None;
@@ -111,10 +116,18 @@ public:
     [[nodiscard]] FrameDiscontinuityBus& GetDiscontinuityBus() { return DiscontinuityBus; }
     [[nodiscard]] const FrameDiscontinuityBus& GetDiscontinuityBus() const { return DiscontinuityBus; }
 
-    // 0.0 pauses simulation tick emission; positive values emit the configured
-    // locked tick budget. FixedSimTime::DeltaSeconds never changes.
+    // Scales wall time on its way into the tick accumulator, so it changes how
+    // often ticks are emitted and never how long a tick is:
+    // FixedSimTime::DeltaSeconds stays constant and per-tick behavior stays
+    // deterministic. 0.0 accumulates nothing, which is what pauses simulation.
     void SetSimulationTimescale(float scale) { SimulationTimescale = scale < 0.0f ? 0.0f : scale; }
     [[nodiscard]] float GetSimulationTimescale() const { return SimulationTimescale; }
+
+    // Bounds on catch-up after a stall. Ticks beyond the cap are dropped, not
+    // deferred; see FixedStepScheduler.
+    void SetMaxFixedTicksPerFrame(uint32_t ticks) { Scheduler.SetMaxTicksPerFrame(ticks); }
+    void SetMaxFrameWallDeltaSeconds(double seconds) { Scheduler.SetMaxFrameInputSeconds(seconds); }
+    [[nodiscard]] const FixedStepScheduler& GetFixedStepScheduler() const { return Scheduler; }
 
     // Resize events can arrive sparsely while the OS is in a live-resize drag.
     // Hold lifecycle mode for a short real-time quiet window so swapchain
@@ -141,6 +154,9 @@ private:
 
     TimeService WallClock;
     FixedSimulationLoop SimulationClock;
+    // Persistent across frames on purpose: the sub-tick residual is the state
+    // that makes tick emission track wall time. Current is cleared every frame.
+    FixedStepScheduler Scheduler;
     FrameDiscontinuityBus DiscontinuityBus;
     RuntimeFrameSnapshot Current;
     RuntimeFrameState State = RuntimeFrameState::Running;

--- a/engine/include/time/FixedStepScheduler.h
+++ b/engine/include/time/FixedStepScheduler.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+//=============================================================================
+// FixedStepScheduler
+//
+// Converts elapsed wall time into whole fixed ticks. This is what keeps
+// simulation speed independent of how fast frames are presented: a frame
+// contributes its wall delta to a residual, and the scheduler emits however
+// many whole ticks that residual now covers. Sub-tick remainder carries to the
+// next frame, so no time is invented or lost across frames.
+//
+// The type is deliberately free of clocks, windows, and lifecycle state so the
+// conservation invariant (emitted ticks plus residual equals accumulated input)
+// is testable on its own. RuntimeFrameLoop owns when it is consulted.
+//
+// Two bounds keep a stalled or debugger-paused process from trying to catch up
+// forever. A single frame's input is clamped, and the ticks emitted from one
+// frame are capped; whole ticks beyond the cap are dropped rather than
+// deferred, so simulation falls behind wall time instead of spiralling. That
+// loss is real and is reported through FixedStepPlan so callers can surface it.
+//=============================================================================
+
+struct FixedStepPlan
+{
+    uint32_t TicksToRun = 0;
+
+    // Residual as a fraction of one fixed tick, in [0, 1). This is how far
+    // presentation sits past the last completed tick.
+    double Alpha = 0.0;
+
+    // Whole ticks discarded by the per-frame cap. Non-zero means simulated
+    // time fell behind wall time this frame.
+    uint32_t TicksDropped = 0;
+
+    // Input seconds discarded by the per-frame input clamp.
+    double ClampedInputSeconds = 0.0;
+};
+
+class FixedStepScheduler
+{
+public:
+    // Accumulate one frame of elapsed simulated time and take the whole ticks
+    // it covers. Residual is always left below fixedDt.
+    [[nodiscard]] FixedStepPlan Advance(double inputSeconds, double fixedDtSeconds)
+    {
+        FixedStepPlan plan;
+        if (!(fixedDtSeconds > 0.0) || !std::isfinite(fixedDtSeconds))
+            return plan;
+
+        double input = std::isfinite(inputSeconds) && inputSeconds > 0.0 ? inputSeconds : 0.0;
+        if (input > MaxFrameInputSeconds)
+        {
+            plan.ClampedInputSeconds = input - MaxFrameInputSeconds;
+            input = MaxFrameInputSeconds;
+        }
+
+        const double accumulated = ResidualSeconds + input;
+        const double wholeTicks = std::floor(accumulated / fixedDtSeconds);
+
+        // The residual drops every whole tick the accumulation covered, including
+        // the ones the cap refuses to run. Keeping them would only guarantee the
+        // next frame is over budget too.
+        ResidualSeconds = accumulated - wholeTicks * fixedDtSeconds;
+        if (ResidualSeconds < 0.0)
+            ResidualSeconds = 0.0;
+
+        const double cappedTicks = wholeTicks > static_cast<double>(MaxTicksPerFrame)
+            ? static_cast<double>(MaxTicksPerFrame)
+            : wholeTicks;
+
+        plan.TicksToRun = static_cast<uint32_t>(cappedTicks);
+        plan.TicksDropped = static_cast<uint32_t>(wholeTicks - cappedTicks);
+        plan.Alpha = GetAlpha(fixedDtSeconds);
+        return plan;
+    }
+
+    // Drop the residual. Used when simulated time is cut, such as a teleport or
+    // a return from a long lifecycle stall, where catching up would replay time
+    // that no longer belongs to the new state.
+    void Reset() { ResidualSeconds = 0.0; }
+
+    void SetMaxTicksPerFrame(uint32_t ticks) { MaxTicksPerFrame = ticks < 1u ? 1u : ticks; }
+    void SetMaxFrameInputSeconds(double seconds)
+    {
+        if (seconds > 0.0 && std::isfinite(seconds))
+            MaxFrameInputSeconds = seconds;
+    }
+
+    [[nodiscard]] uint32_t GetMaxTicksPerFrame() const { return MaxTicksPerFrame; }
+    [[nodiscard]] double GetMaxFrameInputSeconds() const { return MaxFrameInputSeconds; }
+    [[nodiscard]] double GetResidualSeconds() const { return ResidualSeconds; }
+
+    [[nodiscard]] double GetAlpha(double fixedDtSeconds) const
+    {
+        if (!(fixedDtSeconds > 0.0) || !std::isfinite(fixedDtSeconds))
+            return 0.0;
+        const double alpha = ResidualSeconds / fixedDtSeconds;
+        if (alpha < 0.0) return 0.0;
+        if (alpha > 1.0) return 1.0;
+        return alpha;
+    }
+
+private:
+    double ResidualSeconds = 0.0;
+    uint32_t MaxTicksPerFrame = 4;
+    double MaxFrameInputSeconds = 0.25;
+};

--- a/engine/include/time/FrameClock.h
+++ b/engine/include/time/FrameClock.h
@@ -5,9 +5,11 @@
 //=============================================================================
 // FrameClock
 //
-// Per-frame wall-clock snapshot produced by TimeService::Advance(). This is a
-// diagnostic platform clock sample only. RuntimeFrameLoop owns tick scheduling,
-// and simulation never consumes any field from this struct.
+// Per-frame wall-clock snapshot produced by TimeService::Advance().
+// RuntimeFrameLoop converts Dt into whole fixed ticks, and presentation-rate
+// systems read it as FrameUpdateContext::WallDeltaSeconds. No simulation system
+// consumes it directly: gameplay that advanced on this clock would run at
+// whatever rate frames happen to be presented.
 //
 // Dt / UnscaledDt        - raw wall delta from the platform clock. They are
 //                          equal while this compatibility snapshot exists.
@@ -28,6 +30,9 @@ struct FrameClock
     uint64_t FrameIndex       = 0;
 };
 
+// The defaults here mirror FixedSimulationLoop::DefaultFixedDt so a
+// default-constructed context carries a sane delta; the scheduling path always
+// overwrites them from the configured tick rate.
 struct FixedSimTime
 {
     double   DeltaSeconds = 1.0 / 60.0;
@@ -36,8 +41,9 @@ struct FixedSimTime
 
 struct PresentationTime
 {
-    // Fixed presentation tick delta plus render interpolation alpha. Authoritative
-    // gameplay must consume FixedSimTime instead.
+    // Fixed tick delta plus how far this frame sits past the last completed
+    // tick, in [0, 1). Renderers that keep per-tick history blend with Alpha;
+    // authoritative gameplay must consume FixedSimTime instead.
     double DeltaSeconds = 1.0 / 60.0;
     double Alpha = 0.0;
     uint64_t FrameIndex = 0;

--- a/engine/include/time/SimClock.h
+++ b/engine/include/time/SimClock.h
@@ -8,14 +8,19 @@
 // FixedSimulationLoop
 //
 // Fixed-step simulation clock. RuntimeFrameLoop decides how many fixed ticks a
-// frame should run; this type only owns the fixed delta and monotonic tick index.
+// frame should run (see FixedStepScheduler); this type only owns the fixed
+// delta and monotonic tick index.
 //
 // The main loop drives it:
 //
-//   TickBudget budget = scheduler.ConsumeTicks(runtimeState);
+//   TickBudget budget = runtime.ScheduleFixedTicks();
 //   for (uint32_t i = 0; i < budget.TicksToRunThisFrame; ++i)
-//       schedule.RunFixedLogic(sim.BeginFixedTickContext());
-//   systemHost.RunRender(presentation.Alpha);
+//       schedule.RunFixedLogic(sim.BeginFixedTick());
+//   render(runtime.BuildPresentationFrame().Alpha);
+//
+// The delta never varies with frame rate: a slow frame runs more ticks, not
+// longer ones. Simulation that integrates ctx.Time.DeltaSeconds is therefore
+// framerate-independent and reproducible for a given tick sequence.
 //=============================================================================
 struct TickBudget
 {

--- a/engine/include/time/TimeService.h
+++ b/engine/include/time/TimeService.h
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <functional>
 
 //=============================================================================
 // TimeService
@@ -13,19 +14,31 @@
 // returns dt = 0 by contract.
 //
 // This service does not clamp, scale, reset, or accumulate gameplay time.
+// Tick scheduling reads these samples (RuntimeFrameLoop), but no simulation
+// system consumes them.
 //=============================================================================
 class TimeService
 {
 public:
+    using Clock = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+    using NowSource = std::function<TimePoint()>;
+
     TimeService();
 
     // Advance the platform clock by one frame. Call exactly once per frame.
     FrameClock Advance();
 
-private:
-    using Clock = std::chrono::steady_clock;
-    using TimePoint = Clock::time_point;
+    // Replace the platform clock. Tick scheduling is a function of elapsed wall
+    // time, so testing it deterministically means scripting that time rather
+    // than sleeping; an empty source restores steady_clock. Set it before the
+    // first Advance() so the baseline comes from the same source.
+    void SetNowSource(NowSource source);
 
+private:
+    [[nodiscard]] TimePoint Now() const;
+
+    NowSource Source;
     TimePoint LastTime;
     float    ElapsedTime = 0.0f;
     uint64_t FrameIndex = 0;

--- a/engine/include/time/TimingHistory.h
+++ b/engine/include/time/TimingHistory.h
@@ -20,6 +20,9 @@ struct TimingFrameSample
     double PresentSeconds = 0.0;
     double TotalFrameSeconds = 0.0;
     uint32_t FixedTicks = 0;
+    // Ticks this frame owed but the catch-up cap refused. Sustained non-zero
+    // values mean simulation cannot keep up with wall time.
+    uint32_t TicksDropped = 0;
     int LifecycleState = 0;
     int TemporalDiscontinuityReason = 0;
     uint32_t RuntimeEvents = 0;

--- a/engine/include/world/transform/TransformHistory.h
+++ b/engine/include/world/transform/TransformHistory.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <ecs/ComponentTypeId.h>
+#include <ecs/EntityId.h>
+#include <math/geometry/3d/Transform3d.h>
+
+class StoragePartitionSet;
+class World;
+
+//=============================================================================
+// WorldTransformHistory
+//
+// The two most recent simulated poses of an entity, so rendering can show
+// where it is between ticks instead of snapping to the last completed one.
+// Simulation runs at a fixed rate that has nothing to do with the display's,
+// and a frame usually lands part way through a tick; that fraction arrives as
+// PresentationTime::Alpha.
+//
+// Opt-in per entity. Entities without it extract their live WorldTransform
+// exactly as before, which is what keeps this off the cost of static geometry
+// and out of editor worlds entirely (it is runtime-only and never serialized).
+//
+// Snap means "there is no previous pose to blend from": a freshly spawned or
+// streamed-in entity, or one that was teleported. Blending across a teleport
+// would draw the entity streaking through the space between.
+//
+// Mesh and shadow-caster extraction consume this; they have to agree or a
+// shadow separates from the object casting it. Light extraction does not, so a
+// light on a history-carrying entity still steps at the tick rate. Nothing
+// attaches one today; wire it there when something does, rather than carrying
+// an untested path.
+//=============================================================================
+struct WorldTransformHistory
+{
+    Transform3f Previous;
+    Transform3f Current;
+    bool Snap = true;
+};
+SENCHA_DECLARE_COMPONENT_TYPE(WorldTransformHistory, "sencha.world_transform_history");
+
+// Roll Current into Previous and sample the entity's world pose. Call once per
+// fixed tick, after simulation-domain propagation has produced this tick's
+// WorldTransform. snapAll collapses every history, for a frame-wide
+// discontinuity where no entity's previous pose is meaningful any more.
+void CaptureWorldTransformHistory(World& world,
+                                  const StoragePartitionSet& partitions,
+                                  bool snapAll);
+
+// Collapse one entity's history, for a teleport that the rest of the frame
+// should not blend through. Safe to call on an entity without history.
+void RequestTransformHistorySnap(World& world, EntityId entity);
+
+// The pose to render: the blend between the last two ticks, or the current
+// pose when there is nothing meaningful to blend from.
+[[nodiscard]] Transform3f ResolvePresentationPose(const WorldTransformHistory& history,
+                                                  double alpha);

--- a/engine/src/app/DefaultRenderPipeline.cpp
+++ b/engine/src/app/DefaultRenderPipeline.cpp
@@ -228,7 +228,7 @@ void DefaultRenderPipeline::ExtractRender(RenderExtractContext& ctx)
         CpuScopeTimer timer(scopes, CpuScope::Extraction);
         RenderExtractor.Extract(
             world, ctx.Partitions, *Meshes, *Materials, *MaterialSets, Camera,
-            Queue, Textures);
+            Queue, Textures, ctx.Presentation.Alpha);
         Queue.SortOpaque();
     }
 
@@ -247,7 +247,7 @@ void DefaultRenderPipeline::ExtractRender(RenderExtractContext& ctx)
         const bool wantsCasterEvents = Residency.HasOnChangeSlots();
         ShadowCasterExtractor.Extract(
             world, ctx.Partitions, *Meshes, *Materials, *MaterialSets,
-            ShadowCasters, wantsCasterEvents);
+            ShadowCasters, wantsCasterEvents, ctx.Presentation.Alpha);
 
         CasterEvents.clear();
         if (wantsCasterEvents)

--- a/engine/src/app/Engine.cpp
+++ b/engine/src/app/Engine.cpp
@@ -102,6 +102,9 @@ bool Engine::Initialize()
 
     RuntimeLoop.SetResizeSettleSeconds(Configuration.Runtime.ResizeSettleSeconds);
     RuntimeLoop.GetSimulationClock().SetFixedTickRate(Configuration.Runtime.FixedTickRate);
+    RuntimeLoop.SetMaxFixedTicksPerFrame(
+        static_cast<uint32_t>(Configuration.Runtime.MaxFixedTicksPerFrame));
+    RuntimeLoop.SetMaxFrameWallDeltaSeconds(Configuration.Runtime.MaxFrameWallDeltaSeconds);
 
     TaskQueueInstance = std::make_unique<AsyncTaskQueue>(
         static_cast<uint32_t>(Configuration.Runtime.AsyncTaskThreadCount));

--- a/engine/src/app/EngineConsoleBuiltins.cpp
+++ b/engine/src/app/EngineConsoleBuiltins.cpp
@@ -180,7 +180,9 @@ namespace EngineConsoleBuiltins
             .DefaultValue = 1.0,
             .CurrentValue = static_cast<double>(runtimeLoop.GetSimulationTimescale()),
             .Flags = CVarFlags::Transient,
-            .Help = "Simulation timescale. 0 pauses fixed-tick simulation.",
+            .Help = "Scales wall time entering the tick accumulator: 0.5 is "
+                    "half speed, 2 is double, 0 pauses. Tick delta is "
+                    "unchanged, so per-tick behavior stays deterministic.",
             .Source = { "runtime loop" },
             .Min = 0.0,
             .OnChange = [&runtimeLoop](const CVarChangeContext& ctx) {
@@ -202,6 +204,43 @@ namespace EngineConsoleBuiltins
             .OnChange = [&runtimeLoop, &runtimeConfig](const CVarChangeContext& ctx) {
                 runtimeConfig.FixedTickRate = std::get<double>(ctx.NewValue);
                 runtimeLoop.GetSimulationClock().SetFixedTickRate(runtimeConfig.FixedTickRate);
+            },
+        });
+
+        registry.RegisterCVar({
+            .Name = "time.max_ticks_per_frame",
+            .Owner = "engine",
+            .Type = CVarType::Int,
+            .DefaultValue = static_cast<std::int64_t>(runtimeConfig.MaxFixedTicksPerFrame),
+            .CurrentValue = static_cast<std::int64_t>(runtimeConfig.MaxFixedTicksPerFrame),
+            .Flags = CVarFlags::Archive,
+            .Help = "Most fixed ticks one frame may run while catching up. "
+                    "Ticks beyond it are dropped, so simulation falls behind "
+                    "wall time rather than spiralling after a stall.",
+            .Source = { "engine config" },
+            .Min = 1.0,
+            .OnChange = [&runtimeLoop, &runtimeConfig](const CVarChangeContext& ctx) {
+                runtimeConfig.MaxFixedTicksPerFrame =
+                    static_cast<int>(std::get<std::int64_t>(ctx.NewValue));
+                runtimeLoop.SetMaxFixedTicksPerFrame(
+                    static_cast<uint32_t>(runtimeConfig.MaxFixedTicksPerFrame));
+            },
+        });
+
+        registry.RegisterCVar({
+            .Name = "time.max_frame_delta",
+            .Owner = "engine",
+            .Type = CVarType::Double,
+            .DefaultValue = runtimeConfig.MaxFrameWallDeltaSeconds,
+            .CurrentValue = runtimeConfig.MaxFrameWallDeltaSeconds,
+            .Flags = CVarFlags::Archive,
+            .Help = "Most elapsed wall time one frame may contribute to the "
+                    "tick accumulator, in seconds.",
+            .Source = { "engine config" },
+            .Min = 0.001,
+            .OnChange = [&runtimeLoop, &runtimeConfig](const CVarChangeContext& ctx) {
+                runtimeConfig.MaxFrameWallDeltaSeconds = std::get<double>(ctx.NewValue);
+                runtimeLoop.SetMaxFrameWallDeltaSeconds(runtimeConfig.MaxFrameWallDeltaSeconds);
             },
         });
 

--- a/engine/src/app/EngineConsoleBuiltins.cpp
+++ b/engine/src/app/EngineConsoleBuiltins.cpp
@@ -296,7 +296,8 @@ namespace EngineConsoleBuiltins
             .DefaultValue = std::int64_t{ 0 },
             .CurrentValue = std::int64_t{ 0 },
             .Flags = CVarFlags::Transient,
-            .Help = "Request exit once this many frames have been driven. 0 runs "
+            .Help = "Request exit once this many rendered frames have been "
+                    "driven -- not fixed ticks, which vary per frame. 0 runs "
                     "until a quit request. For bounded, unattended runs.",
             .Source = { "engine defaults" },
             .Min = 0.0,

--- a/engine/src/app/EngineFramePhases.cpp
+++ b/engine/src/app/EngineFramePhases.cpp
@@ -215,6 +215,7 @@ void Engine::RegisterFramePhases(Game& game)
             .Config = config,
             .Runtime = *ctx.Runtime,
             .Input = *ctx.Input,
+            .WallDeltaSeconds = static_cast<double>(rf.WallTime.Dt),
             .Presentation = rf.Presentation,
             .Entities = entities,
             .Partitions = zones.Audio,

--- a/engine/src/app/EngineFramePhases.cpp
+++ b/engine/src/app/EngineFramePhases.cpp
@@ -79,17 +79,11 @@ void Engine::RegisterFramePhases(Game& game)
         if (config.Runtime.ExitOnEscape && ctx.Input->IsKeyDown(SDL_SCANCODE_ESCAPE))
             ctx.Input->QuitRequested = true;
 
-        if (config.Runtime.TogglePauseOnF1)
+        if (config.Runtime.TogglePauseOnF1
+            && ctx.Input->ConsumeKeyPressed(SDL_SCANCODE_F1))
         {
             const bool wasPaused = ctx.Runtime->GetSimulationTimescale() == 0.0f;
-            for (uint32_t sc : ctx.Input->KeysPressed)
-            {
-                if (sc == SDL_SCANCODE_F1)
-                {
-                    ctx.Runtime->SetSimulationTimescale(wasPaused ? 1.0f : 0.0f);
-                    break;
-                }
-            }
+            ctx.Runtime->SetSimulationTimescale(wasPaused ? 1.0f : 0.0f);
         }
     });
 

--- a/engine/src/app/EngineFramePhases.cpp
+++ b/engine/src/app/EngineFramePhases.cpp
@@ -4,6 +4,7 @@
 #include <jobs/AsyncTaskQueue.h>
 #include <runtime/FrameDriver.h>
 #include <world/RuntimeWorld.h>
+#include <world/transform/TransformHistory.h>
 #include <world/transform/TransformPropagation.h>
 
 #ifdef SENCHA_ENABLE_DEBUG_UI
@@ -183,6 +184,15 @@ void Engine::RegisterFramePhases(Game& game)
             .Partitions = zones.Logic,
         };
         engine.Schedule().RunPostFixed(postFixed);
+
+        // Last thing in the tick, so the captured pose is the one this tick
+        // finished with. A frame-wide discontinuity has no meaningful previous
+        // pose to blend from, so it collapses every history instead.
+        CaptureWorldTransformHistory(
+            entities,
+            zones.Logic,
+            HasRuntimeFrameEvent(ctx.Runtime->GetCurrentFrame().Events,
+                                 RuntimeFrameEventFlags::TemporalDiscontinuity));
     });
 
     driver.Register(FramePhase::Update, [&engine, &config](PhaseContext& ctx) {

--- a/engine/src/audio/AudioSystem.cpp
+++ b/engine/src/audio/AudioSystem.cpp
@@ -23,6 +23,10 @@ void AudioSystem::Update(
     if (audio == nullptr || !audio->IsValid())
         return;
 
+    // Drains and re-queues backend buffers. Deliberately per rendered frame
+    // rather than per simulation tick: it is idempotent and only needs to run
+    // often enough to keep the mixer fed, so pacing it off a second
+    // accumulator would buy nothing.
     audio->Tick();
 
     std::unordered_set<std::uint16_t> active;

--- a/engine/src/audio/CaptionSystem.cpp
+++ b/engine/src/audio/CaptionSystem.cpp
@@ -47,6 +47,10 @@ float ClipDurationSeconds(
 
 void CaptionSystem::Audio(AudioContext& ctx)
 {
+    // Captions are read by a person, so they age on the wall clock. This phase
+    // runs once per rendered frame; charging it a fixed tick's worth each time
+    // made subtitles expire faster the higher the frame rate, and kept them
+    // ageing on frames that simulated nothing.
     Update(
         Captions,
         (AudioBackend != nullptr && AudioBackend->IsValid())
@@ -54,7 +58,7 @@ void CaptionSystem::Audio(AudioContext& ctx)
             : nullptr,
         ctx.Entities,
         ctx.Partitions,
-        static_cast<float>(ctx.Presentation.DeltaSeconds));
+        static_cast<float>(ctx.WallDeltaSeconds));
 }
 
 void CaptionSystem::Update(

--- a/engine/src/camera/CameraFollowSystem.cpp
+++ b/engine/src/camera/CameraFollowSystem.cpp
@@ -6,6 +6,7 @@
 #include <camera/CameraRig.h>
 #include <components/ActiveCameraService.h>
 #include <world/transform/TransformComponents.h>
+#include <world/transform/TransformHistory.h>
 
 void CameraFollowSystem::FrameUpdate(FrameUpdateContext& ctx)
 {
@@ -35,9 +36,20 @@ void CameraFollowSystem::FrameUpdate(FrameUpdateContext& ctx)
     rig->Pitch -= ctx.Input.MouseDeltaY * rig->Sensitivity;
     rig->Pitch = std::clamp(rig->Pitch, rig->MinPitch, rig->MaxPitch);
 
+    // Follow the pose the target is being drawn at, not the one the last tick
+    // left it in: chasing the tick pose would reintroduce the step this frame's
+    // interpolation exists to remove.
     Vec3d targetPosition = Vec3d::Zero();
-    if (const WorldTransform* target = world.TryGet<WorldTransform>(rig->Target))
+    if (const WorldTransformHistory* history =
+            world.TryGet<WorldTransformHistory>(rig->Target))
+    {
+        targetPosition =
+            ResolvePresentationPose(*history, ctx.Presentation.Alpha).Position;
+    }
+    else if (const WorldTransform* target = world.TryGet<WorldTransform>(rig->Target))
+    {
         targetPosition = target->Value.Position;
+    }
 
     const CameraPose pose = ComputeCameraPose(*rig, targetPosition);
     if (!pose.Override)

--- a/engine/src/core/config/RuntimeConfig.cpp
+++ b/engine/src/core/config/RuntimeConfig.cpp
@@ -91,6 +91,10 @@ std::optional<EngineRuntimeConfig> DeserializeRuntimeConfig(
             config.TargetFps, sectionError)
         || !ReadDoubleEither(root, "resizeSettleSeconds", "resize_settle_seconds",
             config.ResizeSettleSeconds, sectionError)
+        || !ReadIntEither(root, "maxFixedTicksPerFrame", "max_fixed_ticks_per_frame",
+            config.MaxFixedTicksPerFrame, sectionError)
+        || !ReadDoubleEither(root, "maxFrameWallDeltaSeconds", "max_frame_wall_delta_seconds",
+            config.MaxFrameWallDeltaSeconds, sectionError)
         || !ReadDoubleEither(root, "asyncCommitBudgetMs", "async_commit_budget_ms",
             config.AsyncCommitBudgetMs, sectionError)
         || !ReadIntEither(root, "jobWorkerCount", "job_worker_count",
@@ -121,6 +125,18 @@ std::optional<EngineRuntimeConfig> DeserializeRuntimeConfig(
     if (!std::isfinite(config.FixedTickRate) || config.FixedTickRate <= 0.0)
     {
         if (error) error->Message = "runtime config: 'fixedTickRate' must be greater than zero";
+        return std::nullopt;
+    }
+
+    if (config.MaxFixedTicksPerFrame < 1)
+    {
+        if (error) error->Message = "runtime config: 'maxFixedTicksPerFrame' must be at least one";
+        return std::nullopt;
+    }
+
+    if (!std::isfinite(config.MaxFrameWallDeltaSeconds) || config.MaxFrameWallDeltaSeconds <= 0.0)
+    {
+        if (error) error->Message = "runtime config: 'maxFrameWallDeltaSeconds' must be greater than zero";
         return std::nullopt;
     }
 

--- a/engine/src/graphics/vulkan/TimingSampler.cpp
+++ b/engine/src/graphics/vulkan/TimingSampler.cpp
@@ -14,6 +14,7 @@ namespace
             .PresentationDtSeconds = frame.Presentation.DeltaSeconds,
             .InterpolationAlpha = frame.Presentation.Alpha,
             .FixedTicks = frame.FixedTicks,
+            .TicksDropped = frame.TicksDropped,
             .LifecycleState = static_cast<int>(frame.State),
             .TemporalDiscontinuityReason = static_cast<int>(frame.DiscontinuityReason),
             .RuntimeEvents = static_cast<uint32_t>(frame.Events),

--- a/engine/src/physics/CharacterMoverPool.cpp
+++ b/engine/src/physics/CharacterMoverPool.cpp
@@ -12,6 +12,7 @@
 #include <physics/components/CharacterController.h>
 #include <physics/components/CharacterMoverLink.h>
 #include <world/transform/TransformComponents.h>
+#include <world/transform/TransformHistory.h>
 
 namespace
 {
@@ -276,5 +277,8 @@ bool CharacterMoverPool::SetPosition(World& world, EntityId entity,
         return false;
     slot.Mover->SetPosition(position);
     transform->Value.Position = position;
+    // This is a teleport, not motion. Rendering must not blend the character
+    // across the gap it just skipped.
+    RequestTransformHistorySnap(world, entity);
     return true;
 }

--- a/engine/src/render/RenderExtractionSystem.cpp
+++ b/engine/src/render/RenderExtractionSystem.cpp
@@ -1,5 +1,7 @@
 #include <render/RenderExtractionSystem.h>
 
+#include <world/transform/TransformHistory.h>
+
 #include <graphics/vulkan/TextureCache.h>
 #include <render/ZoneLightmapComponent.h>
 
@@ -85,7 +87,8 @@ void RenderExtractionSystem::Extract(
     const MaterialSetCache& materialSets,
     const CameraRenderData& camera,
     RenderQueue& queue,
-    const TextureCache* textures)
+    const TextureCache* textures,
+    double interpolationAlpha)
 {
     if (!world.IsRegistered<WorldTransform>()
         || !world.IsRegistered<StaticMeshComponent>())
@@ -122,12 +125,14 @@ void RenderExtractionSystem::Extract(
     if (LastWorld != &world || !CachedQuery.has_value())
     {
         CachedQuery.emplace(world);
+        CachedInterpolatedQuery.emplace(world);
         LastWorld = &world;
     }
 
-    CachedQuery->ForEachChunkIn(partitions, [&](auto& view)
+    // Whether an entity carries pose history is an archetype property, so the
+    // two paths are separate chunk walks rather than a per-entity branch.
+    const auto emitChunk = [&](auto& view, auto&& poseAt)
     {
-        const auto transforms = view.template Read<WorldTransform>();
         const auto renderers = view.template Read<StaticMeshComponent>();
         const ZoneLightmapIndices lightmap =
             LookupZoneLightmap(LightmapTable, view.Partition());
@@ -147,7 +152,7 @@ void RenderExtractionSystem::Extract(
                 continue;
             }
 
-            const Mat4 worldMatrix = transforms[i].Value.ToMat4();
+            const Mat4 worldMatrix = poseAt(i).ToMat4();
             const Aabb3d worldBounds =
                 TransformBounds(mesh->LocalBounds, worldMatrix);
             if (!camera.ViewFrustum.IntersectsAabb(worldBounds))
@@ -192,5 +197,19 @@ void RenderExtractionSystem::Extract(
                 queue.AddOpaque(item);
             }
         }
+    };
+
+    CachedQuery->ForEachChunkIn(partitions, [&](auto& view)
+    {
+        const auto transforms = view.template Read<WorldTransform>();
+        emitChunk(view, [&](uint32_t i) -> const Transform3f& { return transforms[i].Value; });
+    });
+
+    CachedInterpolatedQuery->ForEachChunkIn(partitions, [&](auto& view)
+    {
+        const auto histories = view.template Read<WorldTransformHistory>();
+        emitChunk(view, [&](uint32_t i) {
+            return ResolvePresentationPose(histories[i], interpolationAlpha);
+        });
     });
 }

--- a/engine/src/render/ShadowCasterExtractionSystem.cpp
+++ b/engine/src/render/ShadowCasterExtractionSystem.cpp
@@ -1,5 +1,7 @@
 #include <render/ShadowCasterExtractionSystem.h>
 
+#include <world/transform/TransformHistory.h>
+
 #include <render/RenderEntityKey.h>
 
 namespace
@@ -108,7 +110,8 @@ void ShadowCasterExtractionSystem::Extract(
     const MaterialCache& materials,
     const MaterialSetCache& materialSets,
     ShadowCasterSet& casters,
-    bool emitRecords)
+    bool emitRecords,
+    double interpolationAlpha)
 {
     casters.Reset();
 
@@ -121,12 +124,14 @@ void ShadowCasterExtractionSystem::Extract(
     if (LastWorld != &world || !CachedQuery.has_value())
     {
         CachedQuery.emplace(world);
+        CachedInterpolatedQuery.emplace(world);
         LastWorld = &world;
     }
 
-    CachedQuery->ForEachChunkIn(partitions, [&](auto& view)
+    // Casters must use the same pose their mesh renders at, or a shadow
+    // separates from the object dropping it.
+    const auto emitChunk = [&](auto& view, auto&& poseAt)
     {
-        const auto transforms = view.template Read<WorldTransform>();
         const auto renderers = view.template Read<StaticMeshComponent>();
 
         for (uint32_t i = 0; i < view.Count(); ++i)
@@ -143,7 +148,7 @@ void ShadowCasterExtractionSystem::Extract(
 
             const ShadowCasterGatherResult gathered = AppendShadowCasters(
                 renderer, *mesh, *sectionMaterials, materials,
-                transforms[i].Value.ToMat4(), casters);
+                poseAt(i).ToMat4(), casters);
             if (gathered.EffectiveSectionMask == 0 || !emitRecords)
                 continue;
 
@@ -158,5 +163,19 @@ void ShadowCasterExtractionSystem::Extract(
                 },
             });
         }
+    };
+
+    CachedQuery->ForEachChunkIn(partitions, [&](auto& view)
+    {
+        const auto transforms = view.template Read<WorldTransform>();
+        emitChunk(view, [&](uint32_t i) -> const Transform3f& { return transforms[i].Value; });
+    });
+
+    CachedInterpolatedQuery->ForEachChunkIn(partitions, [&](auto& view)
+    {
+        const auto histories = view.template Read<WorldTransformHistory>();
+        emitChunk(view, [&](uint32_t i) {
+            return ResolvePresentationPose(histories[i], interpolationAlpha);
+        });
     });
 }

--- a/engine/src/runtime/FrameDriver.cpp
+++ b/engine/src/runtime/FrameDriver.cpp
@@ -94,11 +94,15 @@ void FrameDriver::StepOnce()
         const bool shouldDrainEdgesAfterTick = !EdgesDrainedThisFrame;
         ctx.CurrentTick = Runtime.BeginFixedTick();
         ctx.IsFixedTick = true;
+        // Per tick rather than per frame: a frame may run several ticks while
+        // catching up, and the burst is the thing worth seeing in a trace.
+        if (Trace) Trace->BeginPhase("FixedTick");
         const int simIdx = static_cast<int>(FramePhase::Simulate);
         for (auto& cb : Phases[simIdx])
         {
             if (cb) cb(ctx);
         }
+        if (Trace) Trace->EndPhase("FixedTick");
         if (shouldDrainEdgesAfterTick)
             DrainInputEdgesForFirstTick();
         Runtime.EndFixedTick();

--- a/engine/src/runtime/RuntimeFrameLoop.cpp
+++ b/engine/src/runtime/RuntimeFrameLoop.cpp
@@ -125,11 +125,30 @@ void RuntimeFrameLoop::FailSwapchainRebuild()
 
 TickBudget RuntimeFrameLoop::ScheduleFixedTicks()
 {
+    // Reset before this frame's time is accumulated: a discontinuity means the
+    // elapsed wall time does not correspond to simulated time the new state
+    // should replay.
     if (DiscontinuityPending)
+    {
         ApplyDiscontinuity();
+        Scheduler.Reset();
+    }
 
-    Current.Budget.TicksToRunThisFrame =
-        (!Current.LifecycleOnly && SimulationTimescale > 0.0f) ? 1u : 0u;
+    // Lifecycle-only frames render nothing and simulate nothing, and the wall
+    // time they span belongs to the stall rather than to gameplay. They also
+    // end in a discontinuity, which clears the residual anyway.
+    if (Current.LifecycleOnly)
+    {
+        Current.Budget.TicksToRunThisFrame = 0u;
+        return Current.Budget;
+    }
+
+    const double elapsed =
+        static_cast<double>(Current.WallTime.Dt) * static_cast<double>(SimulationTimescale);
+    const FixedStepPlan plan = Scheduler.Advance(elapsed, SimulationClock.GetFixedDt());
+
+    Current.Budget.TicksToRunThisFrame = plan.TicksToRun;
+    Current.TicksDropped = plan.TicksDropped;
     return Current.Budget;
 }
 
@@ -151,10 +170,11 @@ void RuntimeFrameLoop::EndFixedTick()
 
 PresentationTime RuntimeFrameLoop::BuildPresentationFrame()
 {
-    // Locked scheduling renders the latest completed simulation state. A future
-    // paced scheduler can provide a fractional phase here without changing
-    // FixedSimTime.
-    Current.Presentation = SimulationClock.BuildPresentationTime(1.0);
+    // How far presentation sits past the last completed tick. Renderers that
+    // keep per-tick history blend with it; everything else renders the latest
+    // completed state and ignores it.
+    Current.Presentation =
+        SimulationClock.BuildPresentationTime(Scheduler.GetAlpha(SimulationClock.GetFixedDt()));
     Current.Presentation.FrameIndex = Current.WallTime.FrameIndex;
     return Current.Presentation;
 }

--- a/engine/src/time/TimeService.cpp
+++ b/engine/src/time/TimeService.cpp
@@ -1,13 +1,28 @@
 #include <time/TimeService.h>
 
+#include <utility>
+
 TimeService::TimeService()
     : LastTime(Clock::now())
 {
 }
 
+void TimeService::SetNowSource(NowSource source)
+{
+    Source = std::move(source);
+    // Rebase so the first sample after the swap measures from the new source
+    // rather than across the two clocks.
+    LastTime = Now();
+}
+
+TimeService::TimePoint TimeService::Now() const
+{
+    return Source ? Source() : Clock::now();
+}
+
 FrameClock TimeService::Advance()
 {
-    TimePoint now = Clock::now();
+    TimePoint now = Now();
 
     float delta = 0.0f;
     if (!FirstFrame)

--- a/engine/src/world/RuntimeComponentSchema.cpp
+++ b/engine/src/world/RuntimeComponentSchema.cpp
@@ -19,6 +19,7 @@
 #include <world/ComponentManifest.h>
 #include <world/serialization/ComponentSerializerRegistry.h>
 #include <world/transform/TransformComponents.h>
+#include <world/transform/TransformHistory.h>
 
 void RegisterEngineRuntimeComponents(WorldComponentSchema& schema)
 {
@@ -59,6 +60,10 @@ void RegisterEngineRuntimeComponents(WorldComponentSchema& schema)
 
     // Camera runtime data beyond the serializable CameraComponent.
     schema.Add<CameraRig>();
+
+    // Per-tick pose history for entities that opt into render interpolation.
+    // Derived and runtime-only, like WorldTransform: never serialized.
+    schema.Add<WorldTransformHistory>();
 }
 
 bool RuntimeComponentSchemaCoversSerializers(

--- a/engine/src/world/transform/TransformHistory.cpp
+++ b/engine/src/world/transform/TransformHistory.cpp
@@ -1,0 +1,57 @@
+#include <world/transform/TransformHistory.h>
+
+#include <ecs/Query.h>
+#include <ecs/StoragePartitionSet.h>
+#include <world/transform/TransformComponents.h>
+
+#include <cstdint>
+#include <utility>
+
+void CaptureWorldTransformHistory(World& world,
+                                  const StoragePartitionSet& partitions,
+                                  bool snapAll)
+{
+    if (!world.IsRegistered<WorldTransformHistory>() || !world.IsRegistered<WorldTransform>())
+        return;
+
+    Query<Write<WorldTransformHistory>, Read<WorldTransform>> query(world);
+    query.ForEachChunkIn(partitions, [snapAll](auto& view)
+    {
+        auto histories = view.template Write<WorldTransformHistory>();
+        const auto worlds = view.template Read<WorldTransform>();
+
+        for (uint32_t row = 0; row < view.Count(); ++row)
+        {
+            WorldTransformHistory& history = histories[row];
+            const Transform3f& pose = worlds[row].Value;
+
+            // A snapped entity has no earlier pose worth blending from, so both
+            // ends of the blend are this tick and rendering shows it exactly
+            // where the simulation put it.
+            if (snapAll || history.Snap)
+            {
+                history.Previous = pose;
+                history.Current = pose;
+                history.Snap = false;
+                continue;
+            }
+
+            history.Previous = history.Current;
+            history.Current = pose;
+        }
+    });
+}
+
+void RequestTransformHistorySnap(World& world, EntityId entity)
+{
+    if (!world.IsRegistered<WorldTransformHistory>())
+        return;
+    if (WorldTransformHistory* history = world.TryGet<WorldTransformHistory>(entity))
+        history->Snap = true;
+}
+
+Transform3f ResolvePresentationPose(const WorldTransformHistory& history, double alpha)
+{
+    const float t = alpha <= 0.0 ? 0.0f : (alpha >= 1.0 ? 1.0f : static_cast<float>(alpha));
+    return Transform3f::Interpolate(history.Previous, history.Current, t);
+}

--- a/example/SceneViewer/SceneViewerGame.cpp
+++ b/example/SceneViewer/SceneViewerGame.cpp
@@ -156,6 +156,13 @@ struct FreeCameraMovementSystem
 // same view sequence. Runs in FrameUpdate (after the fixed-tick free-cam),
 // so it wins for the presented frame whenever armed. Off by default; free
 // fly-cam is untouched unless sceneviewer.camera.scripted is set.
+//
+// Keying the orbit to rendered frames rather than simulated time is
+// deliberate and is the exception to the rule that presentation-rate systems
+// leave simulation alone. Renderer A/B captures compare frame N of one build
+// against frame N of another, which only means anything if frame N is the
+// same view in both; a time-based orbit would move with whatever frame rate
+// each build happened to achieve. It is a capture tool, not gameplay.
 struct ScriptedCameraPathSystem
 {
     ScriptedCameraPathSystem(FreeCamera& freeCamera, const bool& enabled)

--- a/template/src/TemplateGame.cpp
+++ b/template/src/TemplateGame.cpp
@@ -48,6 +48,7 @@
 #include <world/serialization/ComponentSerializerRegistry.h>
 #include <world/serialization/SceneSerializer.h>
 #include <world/transform/TransformComponents.h>
+#include <world/transform/TransformHistory.h>
 #include <zone/WorldPartitionIds.h>
 #include <zone/ZoneLoadPackage.h>
 #include <zone/ZonePackageImporter.h>
@@ -360,31 +361,50 @@ struct WorldPartitionUpdateSystem
             Runtime);
 
         // A crossing the destination is not ready for leaves the pawn where the
-        // sweep last had it fully inside the source zone; without this the next
-        // physics tick would restore the position that entered the unloaded zone.
+        // sweep last had it fully inside the source zone. Streaming decides
+        // that here, on the wall clock, but moving the pawn is simulation, so
+        // the position is recorded and applied on the next fixed tick.
         if (Pawn.IsValid()
             && Partition->LastTraversal().Status
                 == DockTraversalStatus::BlockedDestinationNotReady)
         {
-            const Vec3d safe = Partition->LastTraversal().SafeSourcePosition;
-            bool moved = false;
-            if (world.HasResource<CharacterMoverPool>())
-            {
-                moved = world.GetResource<CharacterMoverPool>().SetPosition(
-                    world, Pawn, safe);
-            }
-            if (!moved)
-                if (LocalTransform* transform = world.TryGet<LocalTransform>(Pawn))
-                    transform->Value.Position = safe;
-            if (WorldTransform* transform = world.TryGet<WorldTransform>(Pawn))
-                transform->Value.Position = safe;
+            PendingSafePosition = Partition->LastTraversal().SafeSourcePosition;
         }
+    }
+
+    // Applied at the head of the tick, before movement runs, so the pawn never
+    // enters physics at the position that reached into the unloaded zone.
+    void FixedLogic(FixedLogicContext& ctx)
+    {
+        if (!PendingSafePosition.has_value() || !Pawn.IsValid())
+            return;
+
+        World& world = ctx.Entities;
+        const Vec3d safe = *PendingSafePosition;
+        PendingSafePosition.reset();
+
+        bool moved = false;
+        if (world.HasResource<CharacterMoverPool>())
+        {
+            moved = world.GetResource<CharacterMoverPool>().SetPosition(
+                world, Pawn, safe);
+        }
+        if (!moved)
+        {
+            if (LocalTransform* transform = world.TryGet<LocalTransform>(Pawn))
+                transform->Value.Position = safe;
+            RequestTransformHistorySnap(world, Pawn);
+        }
+        if (WorldTransform* transform = world.TryGet<WorldTransform>(Pawn))
+            transform->Value.Position = safe;
     }
 
     std::optional<WorldPartitionRuntime>& Partition;
     std::optional<AsyncZoneLoader>& Loader;
     RuntimeWorld& Runtime;
     EntityId& Pawn;
+    // Set by streaming on the wall clock, consumed by the next fixed tick.
+    std::optional<Vec3d> PendingSafePosition;
 };
 
 struct CharacterInputSystem

--- a/template/src/TemplateGame.cpp
+++ b/template/src/TemplateGame.cpp
@@ -231,6 +231,9 @@ EntityId SpawnPlayerAvatar(
     world.AddComponent<MovementIntent>(
         pawn,
         MovementIntent{});
+    // The pawn moves every tick and is what the camera watches, so it renders
+    // interpolated between ticks rather than stepping at the tick rate.
+    world.AddComponent<WorldTransformHistory>(pawn, WorldTransformHistory{});
     world.AddComponent<OnGround>(pawn, OnGround{});
     world.AddComponent<LocomotionModeRequest>(
         pawn,

--- a/test/core/FixedStepSchedulerTests.cpp
+++ b/test/core/FixedStepSchedulerTests.cpp
@@ -1,0 +1,185 @@
+#include <time/FixedStepScheduler.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+#include <random>
+#include <vector>
+
+namespace
+{
+    constexpr double kFixedDt = 1.0 / 60.0;
+
+    // Total ticks emitted over a scripted sequence of frame deltas, which is
+    // what "simulation speed" means once frames stop being ticks.
+    uint64_t RunFrames(FixedStepScheduler& scheduler,
+                       const std::vector<double>& frameDeltas,
+                       double fixedDt = kFixedDt)
+    {
+        uint64_t ticks = 0;
+        for (double delta : frameDeltas)
+            ticks += scheduler.Advance(delta, fixedDt).TicksToRun;
+        return ticks;
+    }
+}
+
+TEST(FixedStepScheduler, EmitsWholeTicksAsResidualCrossesFixedDt)
+{
+    FixedStepScheduler scheduler;
+
+    // Half-tick frames: every second one completes a tick. Halving and
+    // re-adding is exact in binary floating point, so the cadence is too.
+    const double halfTick = kFixedDt * 0.5;
+    for (int pair = 0; pair < 4; ++pair)
+    {
+        EXPECT_EQ(scheduler.Advance(halfTick, kFixedDt).TicksToRun, 0u) << "pair " << pair;
+        EXPECT_EQ(scheduler.Advance(halfTick, kFixedDt).TicksToRun, 1u) << "pair " << pair;
+    }
+}
+
+TEST(FixedStepScheduler, LowRefreshFrameRunsSeveralTicks)
+{
+    FixedStepScheduler scheduler;
+
+    // A 30 Hz frame owes two 60 Hz ticks. This is the half-speed case.
+    const FixedStepPlan plan = scheduler.Advance(1.0 / 30.0, kFixedDt);
+    EXPECT_EQ(plan.TicksToRun, 2u);
+    EXPECT_EQ(plan.TicksDropped, 0u);
+}
+
+TEST(FixedStepScheduler, TickTotalsTrackWallTimeAtAnyRefreshRate)
+{
+    // The invariant the bug violated: a second of frames is a second of
+    // simulation, whatever the frame cadence is. Simulated time may trail wall
+    // time by up to the tick that has not completed yet, and by no more.
+    const double refreshRates[] = { 144.0, 120.0, 60.0, 59.94, 30.0 };
+    for (double refresh : refreshRates)
+    {
+        FixedStepScheduler scheduler;
+        const auto frameCount = static_cast<std::size_t>(refresh);
+        const std::vector<double> frames(frameCount, 1.0 / refresh);
+
+        const uint64_t ticks = RunFrames(scheduler, frames);
+
+        double wallSeconds = 0.0;
+        for (double frame : frames)
+            wallSeconds += frame;
+
+        const double simulatedSeconds = static_cast<double>(ticks) * kFixedDt;
+        const double lag = wallSeconds - simulatedSeconds;
+
+        // Summing the frames and multiplying out the ticks round differently,
+        // so an exactly-caught-up sequence can land either side of zero.
+        constexpr double kSummationEpsilon = 1e-12;
+        EXPECT_GE(lag, -kSummationEpsilon) << "refresh " << refresh;
+        EXPECT_LT(lag, kFixedDt) << "refresh " << refresh;
+        EXPECT_NEAR(simulatedSeconds + scheduler.GetResidualSeconds(), wallSeconds, 1e-9)
+            << "refresh " << refresh;
+    }
+}
+
+TEST(FixedStepScheduler, ConservesInputAcrossIrregularFrames)
+{
+    FixedStepScheduler scheduler;
+    std::mt19937 rng(1337u);
+    std::uniform_real_distribution<double> jitter(0.001, 0.05);
+
+    double totalInput = 0.0;
+    uint64_t ticks = 0;
+    for (int frame = 0; frame < 500; ++frame)
+    {
+        const double delta = jitter(rng);
+        totalInput += delta;
+        const FixedStepPlan plan = scheduler.Advance(delta, kFixedDt);
+        ticks += plan.TicksToRun;
+        ASSERT_EQ(plan.TicksDropped, 0u) << "frame " << frame;
+        ASSERT_LT(scheduler.GetResidualSeconds(), kFixedDt);
+    }
+
+    // Emitted time plus what is still owed equals what went in.
+    const double emitted = static_cast<double>(ticks) * kFixedDt;
+    EXPECT_NEAR(emitted + scheduler.GetResidualSeconds(), totalInput, 1e-9);
+}
+
+TEST(FixedStepScheduler, CapDropsBacklogAndKeepsResidualBelowOneTick)
+{
+    FixedStepScheduler scheduler;
+    scheduler.SetMaxTicksPerFrame(4);
+    scheduler.SetMaxFrameInputSeconds(2.0); // isolate the tick cap from the input clamp
+
+    const FixedStepPlan plan = scheduler.Advance(1.0, kFixedDt);
+
+    EXPECT_EQ(plan.TicksToRun, 4u);
+    EXPECT_EQ(plan.TicksDropped, 56u);
+    EXPECT_LT(scheduler.GetResidualSeconds(), kFixedDt);
+
+    // The dropped backlog does not come back as a second overrun next frame.
+    const FixedStepPlan next = scheduler.Advance(kFixedDt, kFixedDt);
+    EXPECT_LE(next.TicksToRun, 2u);
+    EXPECT_EQ(next.TicksDropped, 0u);
+}
+
+TEST(FixedStepScheduler, InputClampBoundsASingleFrame)
+{
+    FixedStepScheduler scheduler;
+    scheduler.SetMaxFrameInputSeconds(0.25);
+    scheduler.SetMaxTicksPerFrame(1000);
+
+    const FixedStepPlan plan = scheduler.Advance(30.0, kFixedDt);
+
+    EXPECT_NEAR(plan.ClampedInputSeconds, 29.75, 1e-9);
+    EXPECT_EQ(plan.TicksToRun, 15u); // 0.25 s of 1/60 s ticks
+}
+
+TEST(FixedStepScheduler, ResetDropsResidual)
+{
+    FixedStepScheduler scheduler;
+    (void)scheduler.Advance(kFixedDt * 0.9, kFixedDt);
+    ASSERT_GT(scheduler.GetResidualSeconds(), 0.0);
+
+    scheduler.Reset();
+
+    EXPECT_EQ(scheduler.GetResidualSeconds(), 0.0);
+    // Without the reset this frame would have completed the pending tick.
+    EXPECT_EQ(scheduler.Advance(kFixedDt * 0.9, kFixedDt).TicksToRun, 0u);
+}
+
+TEST(FixedStepScheduler, AlphaReportsResidualAsFractionOfTick)
+{
+    FixedStepScheduler scheduler;
+
+    (void)scheduler.Advance(kFixedDt * 0.25, kFixedDt);
+    EXPECT_NEAR(scheduler.GetAlpha(kFixedDt), 0.25, 1e-6);
+
+    const FixedStepPlan plan = scheduler.Advance(kFixedDt * 0.5, kFixedDt);
+    EXPECT_NEAR(plan.Alpha, 0.75, 1e-6);
+
+    // Completing a tick leaves the leftover behind it, not a full tick.
+    const FixedStepPlan crossing = scheduler.Advance(kFixedDt * 0.5, kFixedDt);
+    EXPECT_EQ(crossing.TicksToRun, 1u);
+    EXPECT_NEAR(crossing.Alpha, 0.25, 1e-6);
+}
+
+TEST(FixedStepScheduler, IgnoresNonPositiveAndNonFiniteInput)
+{
+    FixedStepScheduler scheduler;
+
+    EXPECT_EQ(scheduler.Advance(0.0, kFixedDt).TicksToRun, 0u);
+    EXPECT_EQ(scheduler.Advance(-1.0, kFixedDt).TicksToRun, 0u);
+    EXPECT_EQ(scheduler.Advance(
+        std::numeric_limits<double>::quiet_NaN(), kFixedDt).TicksToRun, 0u);
+    EXPECT_EQ(scheduler.GetResidualSeconds(), 0.0);
+
+    // A zero or nonsense tick length cannot divide time; emit nothing.
+    EXPECT_EQ(scheduler.Advance(1.0, 0.0).TicksToRun, 0u);
+}
+
+TEST(FixedStepScheduler, HonoursConfiguredTickRate)
+{
+    FixedStepScheduler scheduler;
+    const double fixedDt = 1.0 / 120.0;
+
+    // One 60 Hz frame owes two 120 Hz ticks.
+    EXPECT_EQ(scheduler.Advance(1.0 / 60.0, fixedDt).TicksToRun, 2u);
+}

--- a/test/core/RuntimeComponentSchemaStartupTests.cpp
+++ b/test/core/RuntimeComponentSchemaStartupTests.cpp
@@ -249,7 +249,7 @@ TEST(RuntimeComponentSchema, EngineSchemaUsesCanonicalComponentIds)
     RegisterEngineRuntimeComponents(schema);
     schema.Seal();
 
-    EXPECT_EQ(schema.Size(), 30u);
+    EXPECT_EQ(schema.Size(), 31u);
 
     World world;
     schema.Apply(world);
@@ -304,9 +304,9 @@ TEST(RuntimeComponentSchema, EngineOwnsUnifiedWorldBeforeGameStart)
     EXPECT_TRUE(game.AppliedGameComponent);
     EXPECT_TRUE(game.SawEngineOwnedWorld);
     EXPECT_TRUE(game.EngineOwnedEntityWasPersistent);
-    EXPECT_EQ(game.SchemaSize, 31u);
-    EXPECT_EQ(game.AppliedGameComponentId, 30u);
-    EXPECT_EQ(game.EngineOwnedGameComponentId, 30u);
+    EXPECT_EQ(game.SchemaSize, 32u);
+    EXPECT_EQ(game.AppliedGameComponentId, 31u);
+    EXPECT_EQ(game.EngineOwnedGameComponentId, 31u);
     EXPECT_EQ(StartupGameRemoveCalls, 1);
 }
 

--- a/test/core/RuntimeConfigTests.cpp
+++ b/test/core/RuntimeConfigTests.cpp
@@ -29,10 +29,42 @@ TEST(RuntimeConfig, EmptyObjectYieldsDefaults)
     EXPECT_DOUBLE_EQ(config->TargetFps, 0.0);
     EXPECT_DOUBLE_EQ(config->ResizeSettleSeconds, 0.10);
     EXPECT_DOUBLE_EQ(config->AsyncCommitBudgetMs, 2.0);
+    EXPECT_EQ(config->MaxFixedTicksPerFrame, 4);
+    EXPECT_DOUBLE_EQ(config->MaxFrameWallDeltaSeconds, 0.25);
     EXPECT_EQ(config->JobWorkerCount, -1);
     EXPECT_EQ(config->AsyncTaskThreadCount, 1);
     EXPECT_FALSE(config->ExitOnEscape);
     EXPECT_FALSE(config->TogglePauseOnF1);
+}
+
+TEST(RuntimeConfig, ReadsCatchUpBoundsInEitherSpelling)
+{
+    auto camel = Parse(R"({
+        "maxFixedTicksPerFrame": 8,
+        "maxFrameWallDeltaSeconds": 0.5
+    })");
+    ASSERT_TRUE(camel.has_value());
+    EXPECT_EQ(camel->MaxFixedTicksPerFrame, 8);
+    EXPECT_DOUBLE_EQ(camel->MaxFrameWallDeltaSeconds, 0.5);
+
+    auto snake = Parse(R"({
+        "max_fixed_ticks_per_frame": 2,
+        "max_frame_wall_delta_seconds": 0.1
+    })");
+    ASSERT_TRUE(snake.has_value());
+    EXPECT_EQ(snake->MaxFixedTicksPerFrame, 2);
+    EXPECT_DOUBLE_EQ(snake->MaxFrameWallDeltaSeconds, 0.1);
+}
+
+TEST(RuntimeConfig, RejectsCatchUpBoundsThatWouldStallSimulation)
+{
+    RuntimeConfigError error;
+    // Zero ticks per frame would emit no simulation at all.
+    EXPECT_FALSE(Parse(R"({"maxFixedTicksPerFrame": 0})", &error).has_value());
+    EXPECT_NE(error.Message.find("maxFixedTicksPerFrame"), std::string::npos);
+
+    EXPECT_FALSE(Parse(R"({"maxFrameWallDeltaSeconds": 0.0})", &error).has_value());
+    EXPECT_NE(error.Message.find("maxFrameWallDeltaSeconds"), std::string::npos);
 }
 
 TEST(RuntimeConfig, ReadsCamelCaseFields)

--- a/test/core/TimeServiceTests.cpp
+++ b/test/core/TimeServiceTests.cpp
@@ -5,7 +5,9 @@
 #include <time/TimingHistory.h>
 
 #include <chrono>
+#include <cstdint>
 #include <thread>
+#include <vector>
 
 // =============================================================================
 // FrameClock layout
@@ -187,17 +189,200 @@ TEST(TimingHistory, MaintainsBoundedChronologicalSamples)
 // Runtime frame loop
 // =============================================================================
 
-TEST(RuntimeFrameLoop, DiscontinuityProducesHistoryResetWithoutChangingTickTime)
+namespace
+{
+    // Scripts the platform clock so tick scheduling can be tested as a function
+    // of elapsed time instead of by sleeping.
+    class ScriptedClock
+    {
+    public:
+        explicit ScriptedClock(RuntimeFrameLoop& runtime)
+        {
+            runtime.GetWallClock().SetNowSource([this] { return Now; });
+        }
+
+        void Advance(double seconds)
+        {
+            Now += std::chrono::duration_cast<TimeService::Clock::duration>(
+                std::chrono::duration<double>(seconds));
+        }
+
+    private:
+        TimeService::TimePoint Now{};
+    };
+
+    // One frame of the scheduling path: advance the clock, begin the frame,
+    // resolve lifecycle, and take the tick budget.
+    uint32_t StepFrame(RuntimeFrameLoop& runtime, ScriptedClock& clock, double seconds)
+    {
+        clock.Advance(seconds);
+        runtime.BeginFrame();
+        runtime.ResolveLifecycleTransitions();
+        const uint32_t ticks = runtime.ScheduleFixedTicks().TicksToRunThisFrame;
+        for (uint32_t tick = 0; tick < ticks; ++tick)
+        {
+            (void)runtime.BeginFixedTick();
+            runtime.EndFixedTick();
+        }
+        runtime.BuildPresentationFrame();
+        runtime.EndFrame();
+        return ticks;
+    }
+}
+
+TEST(RuntimeFrameLoop, DiscontinuityResetsResidualWithoutChangingTickTime)
 {
     RuntimeFrameLoop runtime;
+    ScriptedClock clock(runtime);
+    const double fixedDt = runtime.GetSimulationClock().GetFixedDt();
+
+    // Bank most of a tick, then cut simulated time.
+    EXPECT_EQ(StepFrame(runtime, clock, 0.0), 0u); // first Advance() yields dt = 0
+    EXPECT_EQ(StepFrame(runtime, clock, fixedDt * 0.9), 0u);
+
+    clock.Advance(fixedDt * 0.9);
     runtime.BeginFrame();
     runtime.MarkTemporalDiscontinuity(TemporalDiscontinuityReason::SwapchainRecreated);
-    TickBudget budget = runtime.ScheduleFixedTicks();
+    runtime.ResolveLifecycleTransitions();
+    const TickBudget budget = runtime.ScheduleFixedTicks();
 
-    EXPECT_EQ(budget.TicksToRunThisFrame, 1u);
-    EXPECT_DOUBLE_EQ(runtime.GetCurrentFrame().TickDtSeconds, runtime.GetSimulationClock().GetFixedDt());
+    // Without the reset the two nine-tenths frames would have completed a tick.
+    EXPECT_EQ(budget.TicksToRunThisFrame, 0u);
+    EXPECT_DOUBLE_EQ(runtime.GetCurrentFrame().TickDtSeconds, fixedDt);
     EXPECT_TRUE(HasRuntimeFrameEvent(runtime.GetCurrentFrame().Events,
                                      RuntimeFrameEventFlags::TemporalDiscontinuity));
+}
+
+TEST(RuntimeFrameLoop, TickBudgetTracksScriptedWallClock)
+{
+    // The framerate-independence invariant at the layer that owns scheduling:
+    // the same elapsed wall time yields the same simulated time, whether it
+    // arrives as many short frames or few long ones. Simulated time may trail
+    // by the tick still in progress, and by no more.
+    const double frameDeltas[] = { 1.0 / 144.0, 1.0 / 60.0, 1.0 / 30.0 };
+    for (double delta : frameDeltas)
+    {
+        RuntimeFrameLoop runtime;
+        ScriptedClock clock(runtime);
+        const double fixedDt = runtime.GetSimulationClock().GetFixedDt();
+
+        // The platform clock reports zero for its first sample by contract, so
+        // prime it before measuring elapsed time against emitted ticks.
+        StepFrame(runtime, clock, 0.0);
+
+        uint64_t ticks = 0;
+        double wallSeconds = 0.0;
+        const int frames = static_cast<int>(1.0 / delta);
+        for (int frame = 0; frame < frames; ++frame)
+        {
+            ticks += StepFrame(runtime, clock, delta);
+            wallSeconds += delta;
+        }
+
+        // Wall deltas reach scheduling as float, so a delta that is an exact
+        // multiple of the tick can land a hair under it and defer that tick to
+        // the next frame. Lag therefore reaches one whole tick, and the
+        // epsilon covers comparing that against this test's own double sum.
+        constexpr double kRoundingEpsilon = 1e-9;
+        const double simulated = static_cast<double>(ticks) * fixedDt;
+        const double lag = wallSeconds - simulated;
+        EXPECT_GE(lag, -kRoundingEpsilon) << "frame delta " << delta;
+        EXPECT_LE(lag, fixedDt + kRoundingEpsilon) << "frame delta " << delta;
+    }
+}
+
+TEST(RuntimeFrameLoop, SpikeFrameClampsTickBurst)
+{
+    RuntimeFrameLoop runtime;
+    ScriptedClock clock(runtime);
+    runtime.SetMaxFixedTicksPerFrame(4);
+
+    EXPECT_EQ(StepFrame(runtime, clock, 0.0), 0u);
+    const uint32_t ticks = StepFrame(runtime, clock, 1.0);
+
+    EXPECT_EQ(ticks, 4u);
+    EXPECT_GT(runtime.GetCurrentFrame().TicksDropped, 0u);
+}
+
+TEST(RuntimeFrameLoop, TimescaleScalesTickAccrualNotTickDelta)
+{
+    // Half timescale over the same wall time is half the simulated time, and
+    // every tick is still the same length.
+    const auto ticksAtTimescale = [](float timescale) {
+        RuntimeFrameLoop runtime;
+        ScriptedClock clock(runtime);
+        runtime.SetSimulationTimescale(timescale);
+        StepFrame(runtime, clock, 0.0);
+
+        uint64_t ticks = 0;
+        for (int frame = 0; frame < 120; ++frame)
+        {
+            ticks += StepFrame(runtime, clock, 1.0 / 120.0);
+            EXPECT_DOUBLE_EQ(runtime.GetCurrentFrame().TickDtSeconds,
+                             runtime.GetSimulationClock().GetFixedDt());
+        }
+        return ticks;
+    };
+
+    const uint64_t fullSpeed = ticksAtTimescale(1.0f);
+    const uint64_t halfSpeed = ticksAtTimescale(0.5f);
+
+    EXPECT_NEAR(static_cast<double>(fullSpeed), 60.0, 1.0);
+    EXPECT_NEAR(static_cast<double>(halfSpeed), 30.0, 1.0);
+}
+
+TEST(RuntimeFrameLoop, PausedTimescaleAccruesNothing)
+{
+    RuntimeFrameLoop runtime;
+    ScriptedClock clock(runtime);
+    const double fixedDt = runtime.GetSimulationClock().GetFixedDt();
+    runtime.SetSimulationTimescale(0.0f);
+
+    EXPECT_EQ(StepFrame(runtime, clock, 0.0), 0u);
+    EXPECT_EQ(StepFrame(runtime, clock, 1.0), 0u);
+
+    // Unpausing does not replay the wall time that passed while paused.
+    runtime.SetSimulationTimescale(1.0f);
+    EXPECT_EQ(StepFrame(runtime, clock, fixedDt * 1.5), 1u);
+}
+
+TEST(RuntimeFrameLoop, PresentationAlphaReportsResidual)
+{
+    RuntimeFrameLoop runtime;
+    ScriptedClock clock(runtime);
+    const double fixedDt = runtime.GetSimulationClock().GetFixedDt();
+
+    EXPECT_EQ(StepFrame(runtime, clock, 0.0), 0u);
+    EXPECT_EQ(StepFrame(runtime, clock, fixedDt * 0.25), 0u);
+
+    EXPECT_NEAR(runtime.GetCurrentFrame().Presentation.Alpha, 0.25, 1e-5);
+}
+
+TEST(RuntimeFrameLoop, IdenticalScriptedClocksProduceIdenticalTickStreams)
+{
+    // Tick scheduling is owner-thread work with no parallel path, so the serial
+    // reference is the whole contract: identical elapsed time in, identical
+    // tick stream out.
+    const auto run = [](std::vector<uint32_t>& perFrameTicks, uint64_t& finalTickIndex) {
+        RuntimeFrameLoop runtime;
+        ScriptedClock clock(runtime);
+        const double deltas[] = { 0.004, 0.021, 0.007, 0.033, 0.012, 0.0166, 0.05 };
+        for (int repeat = 0; repeat < 10; ++repeat)
+            for (double delta : deltas)
+                perFrameTicks.push_back(StepFrame(runtime, clock, delta));
+        finalTickIndex = runtime.GetSimulationClock().GetTickIndex();
+    };
+
+    std::vector<uint32_t> first;
+    std::vector<uint32_t> second;
+    uint64_t firstIndex = 0;
+    uint64_t secondIndex = 0;
+    run(first, firstIndex);
+    run(second, secondIndex);
+
+    EXPECT_EQ(first, second);
+    EXPECT_EQ(firstIndex, secondIndex);
+    EXPECT_GT(firstIndex, 0u);
 }
 
 TEST(RuntimeFrameLoop, ResizeSettlesBeforeSwapchainRebuild)

--- a/test/math_geometry/QuatSlerpTests.cpp
+++ b/test/math_geometry/QuatSlerpTests.cpp
@@ -1,0 +1,115 @@
+#include <math/Quat.h>
+#include <math/Vec.h>
+#include <math/geometry/3d/Transform3d.h>
+
+#include <gtest/gtest.h>
+
+#include <numbers>
+
+namespace
+{
+    constexpr float kPi = std::numbers::pi_v<float>;
+
+    void ExpectQuatNear(const Quatf& actual, const Quatf& expected, float tolerance = 1e-5f)
+    {
+        // q and -q are the same orientation, so compare on the closer sign.
+        const float sign = actual.Dot(expected) < 0.0f ? -1.0f : 1.0f;
+        EXPECT_NEAR(actual.X * sign, expected.X, tolerance);
+        EXPECT_NEAR(actual.Y * sign, expected.Y, tolerance);
+        EXPECT_NEAR(actual.Z * sign, expected.Z, tolerance);
+        EXPECT_NEAR(actual.W * sign, expected.W, tolerance);
+    }
+}
+
+TEST(QuatSlerp, ReturnsEndpoints)
+{
+    const Quatf from = Quatf::FromAxisAngle(Vec3d::Up(), 0.0f);
+    const Quatf to = Quatf::FromAxisAngle(Vec3d::Up(), kPi * 0.5f);
+
+    ExpectQuatNear(Quatf::Slerp(from, to, 0.0f), from);
+    ExpectQuatNear(Quatf::Slerp(from, to, 1.0f), to);
+}
+
+TEST(QuatSlerp, HalfwayIsHalfTheRotation)
+{
+    const Quatf from = Quatf::FromAxisAngle(Vec3d::Up(), 0.0f);
+    const Quatf to = Quatf::FromAxisAngle(Vec3d::Up(), kPi * 0.5f);
+
+    const Quatf mid = Quatf::Slerp(from, to, 0.5f);
+
+    ExpectQuatNear(mid, Quatf::FromAxisAngle(Vec3d::Up(), kPi * 0.25f));
+    EXPECT_NEAR(mid.Length(), 1.0f, 1e-5f);
+}
+
+TEST(QuatSlerp, TakesShortestPathAcrossNegatedInput)
+{
+    const Quatf from = Quatf::FromAxisAngle(Vec3d::Up(), 0.0f);
+    // Same orientation as a small positive rotation, expressed with the
+    // opposite sign. Without the shortest-path flip this blends the long way.
+    const Quatf small = Quatf::FromAxisAngle(Vec3d::Up(), kPi * 0.25f);
+    const Quatf negated = small * -1.0f;
+
+    const Quatf mid = Quatf::Slerp(from, negated, 0.5f);
+
+    ExpectQuatNear(mid, Quatf::FromAxisAngle(Vec3d::Up(), kPi * 0.125f));
+}
+
+TEST(QuatSlerp, NearParallelInputsStayNormalized)
+{
+    const Quatf from = Quatf::FromAxisAngle(Vec3d::Up(), 0.0f);
+    const Quatf to = Quatf::FromAxisAngle(Vec3d::Up(), 1e-4f);
+
+    const Quatf mid = Quatf::Slerp(from, to, 0.5f);
+
+    EXPECT_NEAR(mid.Length(), 1.0f, 1e-5f);
+    ExpectQuatNear(mid, Quatf::FromAxisAngle(Vec3d::Up(), 5e-5f), 1e-4f);
+}
+
+TEST(QuatSlerp, RotatesVectorsProgressively)
+{
+    const Quatf from = Quatf::FromAxisAngle(Vec3d::Up(), 0.0f);
+    const Quatf to = Quatf::FromAxisAngle(Vec3d::Up(), kPi);
+
+    const Vec3d start = Quatf::Slerp(from, to, 0.0f).RotateVector(Vec3d::Forward());
+    const Vec3d quarter = Quatf::Slerp(from, to, 0.25f).RotateVector(Vec3d::Forward());
+    const Vec3d half = Quatf::Slerp(from, to, 0.5f).RotateVector(Vec3d::Forward());
+
+    // A quarter of a half-turn is 45 degrees off the start, half is 90.
+    EXPECT_NEAR(start.Dot(quarter), std::cos(kPi * 0.25f), 1e-4f);
+    EXPECT_NEAR(start.Dot(half), std::cos(kPi * 0.5f), 1e-4f);
+}
+
+TEST(Transform3dInterpolate, BlendsTranslationRotationAndScale)
+{
+    Transform3f from;
+    from.Position = Vec3d(0.0f, 0.0f, 0.0f);
+    from.Rotation = Quatf::FromAxisAngle(Vec3d::Up(), 0.0f);
+    from.Scale = Vec3d(1.0f, 1.0f, 1.0f);
+
+    Transform3f to;
+    to.Position = Vec3d(10.0f, 4.0f, -2.0f);
+    to.Rotation = Quatf::FromAxisAngle(Vec3d::Up(), kPi * 0.5f);
+    to.Scale = Vec3d(3.0f, 3.0f, 3.0f);
+
+    const Transform3f mid = Transform3f::Interpolate(from, to, 0.5f);
+
+    EXPECT_NEAR(mid.Position.X, 5.0f, 1e-5f);
+    EXPECT_NEAR(mid.Position.Y, 2.0f, 1e-5f);
+    EXPECT_NEAR(mid.Position.Z, -1.0f, 1e-5f);
+    EXPECT_NEAR(mid.Scale.X, 2.0f, 1e-5f);
+    ExpectQuatNear(mid.Rotation, Quatf::FromAxisAngle(Vec3d::Up(), kPi * 0.25f));
+}
+
+TEST(Transform3dInterpolate, ReturnsEndpointsExactly)
+{
+    Transform3f from;
+    from.Position = Vec3d(1.0f, 2.0f, 3.0f);
+    Transform3f to;
+    to.Position = Vec3d(9.0f, 8.0f, 7.0f);
+
+    const Transform3f atZero = Transform3f::Interpolate(from, to, 0.0f);
+    const Transform3f atOne = Transform3f::Interpolate(from, to, 1.0f);
+
+    EXPECT_NEAR(atZero.Position.X, 1.0f, 1e-6f);
+    EXPECT_NEAR(atOne.Position.X, 9.0f, 1e-6f);
+}

--- a/test/runtime/CaptionClockTests.cpp
+++ b/test/runtime/CaptionClockTests.cpp
@@ -1,0 +1,100 @@
+#include <gtest/gtest.h>
+
+#include <app/GameContexts.h>
+#include <audio/CaptionRuntime.h>
+#include <audio/CaptionSystem.h>
+#include <core/config/CaptionConfig.h>
+#include <core/config/EngineConfig.h>
+#include <core/logging/LoggingProvider.h>
+#include <ecs/StoragePartitionSet.h>
+#include <ecs/World.h>
+#include <input/InputFrame.h>
+#include <runtime/RuntimeFrameLoop.h>
+
+// Captions are read by a person, so they age on the wall clock. The audio phase
+// runs once per rendered frame, so charging it a fixed tick's worth each time
+// tied subtitle dwell to frame rate.
+
+namespace
+{
+    EngineCaptionConfig OneChannel()
+    {
+        EngineCaptionConfig config;
+        config.Channels.push_back({ .Name = "World", .MaxVisibleLines = 2 });
+        return config;
+    }
+
+    CaptionPayload Line()
+    {
+        CaptionPayload payload;
+        payload.Kind = CaptionKind::Subtitle;
+        payload.Channel = "World";
+        payload.Priority = CaptionPriority::Gameplay;
+        payload.Text = "line.timed";
+        return payload;
+    }
+
+    // Runs CaptionSystem through the real phase context, which is where the
+    // clock choice lives; calling Update directly would bypass it.
+    void RunAudioPhase(CaptionSystem& system,
+                       World& world,
+                       double wallDeltaSeconds,
+                       double presentationDeltaSeconds)
+    {
+        EngineConfig config;
+        RuntimeFrameLoop runtime;
+        InputFrame input;
+        StoragePartitionSet partitions;
+        partitions.Add(StoragePartitionId::Default());
+
+        AudioContext ctx{
+            .Config = config,
+            .Runtime = runtime,
+            .Input = input,
+            .WallDeltaSeconds = wallDeltaSeconds,
+            .Presentation = PresentationTime{ .DeltaSeconds = presentationDeltaSeconds },
+            .Entities = world,
+            .Partitions = partitions,
+        };
+        system.Audio(ctx);
+    }
+}
+
+TEST(CaptionClock, AgesByWallTimeNotByTickDelta)
+{
+    LoggingProvider logging;
+    CaptionRuntime captions(logging, OneChannel());
+    World world;
+
+    CaptionSystem system(&captions);
+
+    const CaptionId id = captions.BeginTimedCaption(Line(), 1.0f);
+    ASSERT_TRUE(captions.IsActive(id));
+
+    // One long frame. Presentation delta still reports a 60 Hz tick, so a
+    // caption that consumed that instead would barely age at all.
+    RunAudioPhase(system, world, 0.6, 1.0 / 60.0);
+    EXPECT_TRUE(captions.IsActive(id));
+
+    RunAudioPhase(system, world, 0.6, 1.0 / 60.0);
+    EXPECT_FALSE(captions.IsActive(id));
+}
+
+TEST(CaptionClock, DoesNotAgeOnAFrameThatPassedNoWallTime)
+{
+    LoggingProvider logging;
+    CaptionRuntime captions(logging, OneChannel());
+    World world;
+
+    CaptionSystem system(&captions);
+
+    const CaptionId id = captions.BeginTimedCaption(Line(), 0.1f);
+    ASSERT_TRUE(captions.IsActive(id));
+
+    // Frames that advance no wall time must not retire a caption, however many
+    // of them the renderer produces.
+    for (int frame = 0; frame < 100; ++frame)
+        RunAudioPhase(system, world, 0.0, 1.0 / 60.0);
+
+    EXPECT_TRUE(captions.IsActive(id));
+}

--- a/test/runtime/FrameLoopScenarioTests.cpp
+++ b/test/runtime/FrameLoopScenarioTests.cpp
@@ -17,6 +17,30 @@
 // number so the suite does not depend on SDL headers. 26 is SDL_SCANCODE_W.
 static constexpr uint32_t kTestScancode = 26;
 
+namespace
+{
+    // Scripts the platform clock so a scenario controls how much simulated time
+    // each frame is worth. Tick emission is a function of elapsed wall time, so
+    // scheduling behavior is only testable deterministically by scripting it.
+    class ScriptedFrameClock
+    {
+    public:
+        explicit ScriptedFrameClock(RuntimeFrameLoop& runtime)
+        {
+            runtime.GetWallClock().SetNowSource([this] { return Now; });
+        }
+
+        void Advance(double seconds)
+        {
+            Now += std::chrono::duration_cast<TimeService::Clock::duration>(
+                std::chrono::duration<double>(seconds));
+        }
+
+    private:
+        TimeService::TimePoint Now{};
+    };
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -238,20 +262,28 @@ TEST(RuntimeFrameLoopScenario, TimescaleZeroPausesSimulationTicks)
 TEST(RuntimeFrameLoopScenario, TimescaleRealtimeProducesTicks)
 {
     RuntimeFrameLoop runtime;
+    ScriptedFrameClock clock(runtime);
+    const double fixedDt = runtime.GetSimulationClock().GetFixedDt();
 
-    uint32_t ticksAt1x = 0;
-    runtime.BeginFrame();
-    runtime.ResolveLifecycleTransitions();
-    runtime.ScheduleFixedTicks();
-    while (runtime.CanRunFixedTickThisFrame())
-    {
-        (void)runtime.BeginFixedTick();
-        runtime.EndFixedTick();
-        ++ticksAt1x;
-    }
-    runtime.BuildPresentationFrame();
-    runtime.EndFrame();
-    EXPECT_EQ(ticksAt1x, 1u);
+    const auto stepFrame = [&](double seconds) {
+        clock.Advance(seconds);
+        runtime.BeginFrame();
+        runtime.ResolveLifecycleTransitions();
+        runtime.ScheduleFixedTicks();
+        uint32_t ticks = 0;
+        while (runtime.CanRunFixedTickThisFrame())
+        {
+            (void)runtime.BeginFixedTick();
+            runtime.EndFixedTick();
+            ++ticks;
+        }
+        runtime.BuildPresentationFrame();
+        runtime.EndFrame();
+        return ticks;
+    };
+
+    stepFrame(0.0);
+    EXPECT_EQ(stepFrame(fixedDt * 1.5), 1u);
 }
 
 // ---------------------------------------------------------------------------
@@ -308,15 +340,36 @@ TEST(InputFrame, HeldStateSurvivesEdgeClear)
     EXPECT_TRUE(frame.IsKeyDown(kTestScancode));
 }
 
-TEST(FrameDriver, LockedTickSeesInputEdges)
+TEST(InputFrame, ConsumeKeyPressedRemovesAllMatchingEdges)
+{
+    InputFrame frame;
+    frame.KeysPressed.push_back(kTestScancode);
+    frame.KeysPressed.push_back(99);
+    frame.KeysPressed.push_back(kTestScancode);
+
+    EXPECT_TRUE(frame.ConsumeKeyPressed(kTestScancode));
+    EXPECT_EQ(frame.KeysPressed.size(), 1u);
+    EXPECT_EQ(frame.KeysPressed.front(), 99u);
+
+    // A second consume finds nothing, which is what stops a handler outside the
+    // fixed-tick drain from acting on the same press twice.
+    EXPECT_FALSE(frame.ConsumeKeyPressed(kTestScancode));
+}
+
+TEST(FrameDriver, FirstTickSeesInputEdges)
 {
     RuntimeFrameLoop runtime;
+    ScriptedFrameClock clock(runtime);
     FrameDriver driver(runtime);
+    const double fixedDt = runtime.GetSimulationClock().GetFixedDt();
 
     int tickCount = 0;
     std::size_t firstTickPressed = 0;
+    bool pressThisFrame = true;
 
     driver.Register(FramePhase::PumpPlatform, [&](PhaseContext& ctx) {
+        if (!pressThisFrame)
+            return;
         ctx.Input->SetKeyHeld(kTestScancode, true);
         ctx.Input->KeysPressed.push_back(kTestScancode);
     });
@@ -329,11 +382,87 @@ TEST(FrameDriver, LockedTickSeesInputEdges)
         ++tickCount;
     });
 
+    // The platform clock reports zero for its first sample, so the opening
+    // frame accrues no simulated time and runs no tick.
+    clock.Advance(0.0);
+    driver.StepOnce();
+    pressThisFrame = false;
+
+    clock.Advance(fixedDt * 1.5);
     driver.StepOnce();
 
     EXPECT_EQ(tickCount, 1);
     EXPECT_EQ(firstTickPressed, 1u);
     EXPECT_TRUE(driver.GetInputFrame().IsKeyDown(kTestScancode));
+}
+
+TEST(FrameDriver, EdgesPersistAcrossZeroTickFramesUntilFirstTick)
+{
+    RuntimeFrameLoop runtime;
+    ScriptedFrameClock clock(runtime);
+    FrameDriver driver(runtime);
+    const double fixedDt = runtime.GetSimulationClock().GetFixedDt();
+
+    int ticksSeen = 0;
+    int ticksThatSawTheEdge = 0;
+    bool pressThisFrame = false;
+
+    driver.Register(FramePhase::PumpPlatform, [&](PhaseContext& ctx) {
+        if (pressThisFrame)
+            ctx.Input->KeysPressed.push_back(kTestScancode);
+    });
+    driver.Register(FramePhase::ScheduleTicks, [&](PhaseContext& ctx) {
+        ctx.Runtime->ScheduleFixedTicks();
+    });
+    driver.Register(FramePhase::Simulate, [&](PhaseContext& ctx) {
+        ++ticksSeen;
+        for (uint32_t scancode : ctx.Input->KeysPressed)
+            if (scancode == kTestScancode)
+                ++ticksThatSawTheEdge;
+    });
+
+    // Press during a frame too short to complete a tick.
+    clock.Advance(0.0);
+    driver.StepOnce();
+    pressThisFrame = true;
+    clock.Advance(fixedDt * 0.4);
+    driver.StepOnce();
+    pressThisFrame = false;
+    ASSERT_EQ(ticksSeen, 0);
+
+    // The press waits for the tick rather than being lost with the frame.
+    clock.Advance(fixedDt * 0.4);
+    driver.StepOnce();
+    clock.Advance(fixedDt * 0.4);
+    driver.StepOnce();
+
+    EXPECT_GE(ticksSeen, 1);
+    EXPECT_EQ(ticksThatSawTheEdge, 1);
+}
+
+TEST(FrameDriver, SpikeFrameRunsCappedTickBurst)
+{
+    RuntimeFrameLoop runtime;
+    ScriptedFrameClock clock(runtime);
+    runtime.SetMaxFixedTicksPerFrame(4);
+    FrameDriver driver(runtime);
+
+    int ticksSeen = 0;
+    driver.Register(FramePhase::ScheduleTicks, [](PhaseContext& ctx) {
+        ctx.Runtime->ScheduleFixedTicks();
+    });
+    driver.Register(FramePhase::Simulate, [&](PhaseContext&) { ++ticksSeen; });
+
+    clock.Advance(0.0);
+    driver.StepOnce();
+
+    // A stalled frame catches up to the cap and drops the rest, so the frame
+    // after a hitch is not itself late.
+    clock.Advance(1.0);
+    driver.StepOnce();
+
+    EXPECT_EQ(ticksSeen, 4);
+    EXPECT_GT(runtime.GetCurrentFrame().TicksDropped, 0u);
 }
 
 TEST(SwapchainRebuildWorker, RunningRequestQueuesFollowUpAndReportsCompletedExtents)

--- a/test/runtime/TransformHistoryTests.cpp
+++ b/test/runtime/TransformHistoryTests.cpp
@@ -1,0 +1,154 @@
+#include <ecs/StoragePartitionSet.h>
+#include <ecs/World.h>
+#include <world/transform/TransformComponents.h>
+#include <world/transform/TransformHistory.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+    struct HistoryWorld
+    {
+        World Entities;
+        StoragePartitionSet Partitions;
+
+        HistoryWorld()
+        {
+            Entities.RegisterComponent<LocalTransform>();
+            Entities.RegisterComponent<WorldTransform>();
+            Entities.RegisterComponent<WorldTransformHistory>();
+            Partitions.Add(StoragePartitionId::Default());
+        }
+
+        EntityId SpawnAt(float x)
+        {
+            const EntityId entity = Entities.CreateEntity();
+            Transform3f pose;
+            pose.Position = Vec3d(x, 0.0f, 0.0f);
+            Entities.AddComponent<LocalTransform>(entity, LocalTransform{ pose });
+            Entities.AddComponent<WorldTransform>(entity, WorldTransform{ pose });
+            Entities.AddComponent<WorldTransformHistory>(entity, WorldTransformHistory{});
+            return entity;
+        }
+
+        void MoveTo(EntityId entity, float x)
+        {
+            Transform3f pose;
+            pose.Position = Vec3d(x, 0.0f, 0.0f);
+            Entities.TryGet<WorldTransform>(entity)->Value = pose;
+        }
+
+        const WorldTransformHistory& HistoryOf(EntityId entity)
+        {
+            return *Entities.TryGet<WorldTransformHistory>(entity);
+        }
+
+        void Capture(bool snapAll = false)
+        {
+            CaptureWorldTransformHistory(Entities, Partitions, snapAll);
+        }
+    };
+}
+
+TEST(TransformHistory, FirstCaptureHasNothingToBlendFrom)
+{
+    HistoryWorld world;
+    const EntityId entity = world.SpawnAt(5.0f);
+
+    world.Capture();
+
+    // A spawn must render where it was placed, not blend in from the origin.
+    const WorldTransformHistory& history = world.HistoryOf(entity);
+    EXPECT_FLOAT_EQ(history.Previous.Position.X, 5.0f);
+    EXPECT_FLOAT_EQ(history.Current.Position.X, 5.0f);
+    EXPECT_FALSE(history.Snap);
+    EXPECT_FLOAT_EQ(ResolvePresentationPose(history, 0.0).Position.X, 5.0f);
+}
+
+TEST(TransformHistory, CaptureShiftsCurrentIntoPrevious)
+{
+    HistoryWorld world;
+    const EntityId entity = world.SpawnAt(0.0f);
+    world.Capture();
+
+    world.MoveTo(entity, 1.0f);
+    world.Capture();
+
+    const WorldTransformHistory& history = world.HistoryOf(entity);
+    EXPECT_FLOAT_EQ(history.Previous.Position.X, 0.0f);
+    EXPECT_FLOAT_EQ(history.Current.Position.X, 1.0f);
+}
+
+TEST(TransformHistory, ResolveBlendsBetweenTheLastTwoTicks)
+{
+    HistoryWorld world;
+    const EntityId entity = world.SpawnAt(0.0f);
+    world.Capture();
+    world.MoveTo(entity, 10.0f);
+    world.Capture();
+
+    const WorldTransformHistory& history = world.HistoryOf(entity);
+    EXPECT_FLOAT_EQ(ResolvePresentationPose(history, 0.0).Position.X, 0.0f);
+    EXPECT_FLOAT_EQ(ResolvePresentationPose(history, 0.5).Position.X, 5.0f);
+    EXPECT_FLOAT_EQ(ResolvePresentationPose(history, 1.0).Position.X, 10.0f);
+}
+
+TEST(TransformHistory, ResolveClampsAlphaOutsideTheTick)
+{
+    HistoryWorld world;
+    const EntityId entity = world.SpawnAt(0.0f);
+    world.Capture();
+    world.MoveTo(entity, 10.0f);
+    world.Capture();
+
+    const WorldTransformHistory& history = world.HistoryOf(entity);
+    EXPECT_FLOAT_EQ(ResolvePresentationPose(history, -1.0).Position.X, 0.0f);
+    EXPECT_FLOAT_EQ(ResolvePresentationPose(history, 2.0).Position.X, 10.0f);
+}
+
+TEST(TransformHistory, SnapAllCollapsesEveryHistory)
+{
+    HistoryWorld world;
+    const EntityId first = world.SpawnAt(0.0f);
+    const EntityId second = world.SpawnAt(100.0f);
+    world.Capture();
+
+    world.MoveTo(first, 1.0f);
+    world.MoveTo(second, 200.0f);
+    world.Capture(/*snapAll*/ true);
+
+    // A frame-wide discontinuity has no previous pose worth blending from, so
+    // nothing streaks across the gap.
+    EXPECT_FLOAT_EQ(world.HistoryOf(first).Previous.Position.X, 1.0f);
+    EXPECT_FLOAT_EQ(world.HistoryOf(second).Previous.Position.X, 200.0f);
+    EXPECT_FLOAT_EQ(ResolvePresentationPose(world.HistoryOf(second), 0.0).Position.X, 200.0f);
+}
+
+TEST(TransformHistory, RequestSnapAffectsOnlyThatEntity)
+{
+    HistoryWorld world;
+    const EntityId teleported = world.SpawnAt(0.0f);
+    const EntityId walking = world.SpawnAt(0.0f);
+    world.Capture();
+
+    RequestTransformHistorySnap(world.Entities, teleported);
+    world.MoveTo(teleported, 500.0f);
+    world.MoveTo(walking, 1.0f);
+    world.Capture();
+
+    // The teleported entity appears at its destination; its neighbour still
+    // blends normally.
+    EXPECT_FLOAT_EQ(ResolvePresentationPose(world.HistoryOf(teleported), 0.0).Position.X, 500.0f);
+    EXPECT_FLOAT_EQ(ResolvePresentationPose(world.HistoryOf(walking), 0.0).Position.X, 0.0f);
+    EXPECT_FLOAT_EQ(ResolvePresentationPose(world.HistoryOf(walking), 1.0).Position.X, 1.0f);
+}
+
+TEST(TransformHistory, SnapRequestOnEntityWithoutHistoryIsHarmless)
+{
+    HistoryWorld world;
+    const EntityId bare = world.Entities.CreateEntity();
+
+    RequestTransformHistorySnap(world.Entities, bare);
+
+    EXPECT_FALSE(world.Entities.HasComponent<WorldTransformHistory>(bare));
+}


### PR DESCRIPTION
Decouples physics timestep from the framerate. Really should have done this way earlier. Starting rearing its ugly head when I worked on refactoring my movement, though.